### PR TITLE
fixed typo in deployment serviceaccount

### DIFF
--- a/chart/nodecore/Chart.yaml
+++ b/chart/nodecore/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nodecore
 description: a helm chart for nodecore
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0

--- a/chart/nodecore/templates/deployment.yaml
+++ b/chart/nodecore/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Release.name }}
+      serviceAccountName: {{ .Release.Name }}
       {{- else }}
       serviceAccountName: default
       {{- end }}


### PR DESCRIPTION
My previous PR had a typo in .Release.Name. I had .Release.name instead of .Release.Name