### PR TITLE
Add "upgrade to paid tier" to errors.yaml

### DIFF
--- a/pkg/errors_config/errors.yaml
+++ b/pkg/errors_config/errors.yaml
@@ -78,6 +78,7 @@ retryable-errors:
   - str: <html>
   - str: www.allnodes.com
   - str: upgrade your plan
+  - str: upgrade to paid tier
   - str: Block not available for slot
   - str: L2 finalized block height not
   - str: decoding block from


### PR DESCRIPTION
**Description**

Recently, `celo` and `mantle` on public drpc is failing with the message `method is not available on freetier, please upgrade to paid tier` - this makes nodecore not switch to our other providers.

This PR adds `upgrade to paid tier` to `retryable-errors`.

```bash
curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' https://mantle.drpc.org

{"id":1,"jsonrpc":"2.0","error":{"message":"method is not available on freetier, please upgrade to paid tier","code":35}}
```

```bash
curl -s -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' https://celo.drpc.org

{"id":1,"jsonrpc":"2.0","error":{"message":"method is not available on freetier, please upgrade to paid tier","code":35}}
```