### PR TITLE
Update Chart documentation & validation for "image"

### DIFF
--- a/chart/nodecore/README.md
+++ b/chart/nodecore/README.md
@@ -57,8 +57,7 @@ Create your own `values.yaml`:
 
 ```yaml
 image:
-  repository: drpcorg/nodecore
-  tag: "latest"
+  name: drpcorg/nodecore:latest
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -99,8 +98,7 @@ This removes all Kubernetes resources created by the chart.
 | Key                | Type   | Description                      |
 | ------------------ | ------ | -------------------------------- |
 | `replicaCount`     | int    | Number of replicas               |
-| `image.repository` | string | Container image repository       |
-| `image.tag`        | string | Image tag                        |
+| `image.name`       | string | Container image (repository:tag) |
 | `image.pullPolicy` | string | Image pull policy                |
 | `service.type`     | string | Kubernetes Service type          |
 | `service.port`     | int    | Service port                     |

--- a/chart/nodecore/values.schema.json
+++ b/chart/nodecore/values.schema.json
@@ -5,6 +5,7 @@
   "properties": {
     "image": {
       "type": "object",
+      "additionalProperties": false,
       "description": "Container image configuration",
       "properties": {
         "name": {


### PR DESCRIPTION
**Description**

The chart ([deployment.yaml](https://github.com/drpcorg/nodecore/blob/main/chart/nodecore/templates/deployment.yaml#L47), [values.schema.json](https://github.com/drpcorg/nodecore/blob/main/chart/nodecore/values.schema.json#L6)) uses `image.name` instead of `image.tag` & `image.repository` (which are documented in the README). I learnt it the hard way during a rollout restart :smiling_face_with_tear: 

I've also added `"additionalProperties": false` to the nested json schema to avoid such misconfiguration in the future (my `image.tag` config passed validation but was dropped silently), but let me know if this is not something you want. It'd be nice if this was added to other nested schemas too.