### PR TITLE
Add comprehensive health, chain, and lower bound validators for Aztec

### DIFF
--- a/internal/config/stats_config.go
+++ b/internal/config/stats_config.go
@@ -18,7 +18,7 @@ func (s *StatsConfig) validate() error {
 		return fmt.Errorf("stats type validation error - %s", err.Error())
 	}
 	if s.Enabled && s.FlushInterval.Minutes() < 3 {
-		return errors.New("stats flush-interval must be greater than 3 minutes")
+		return errors.New("stats flush-interval must be at least 3 minutes")
 	}
 	return nil
 }

--- a/internal/config/stats_config.go
+++ b/internal/config/stats_config.go
@@ -17,7 +17,7 @@ func (s *StatsConfig) validate() error {
 	if err := s.Type.validate(); err != nil {
 		return fmt.Errorf("stats type validation error - %s", err.Error())
 	}
-	if s.FlushInterval.Minutes() < 3 {
+	if s.Enabled && s.FlushInterval.Minutes() < 3 {
 		return errors.New("stats flush-interval must be greater than 3 minutes")
 	}
 	return nil

--- a/internal/config/stats_config.go
+++ b/internal/config/stats_config.go
@@ -18,7 +18,7 @@ func (s *StatsConfig) validate() error {
 		return fmt.Errorf("stats type validation error - %s", err.Error())
 	}
 	if s.Enabled && s.FlushInterval.Minutes() < 3 {
-		return errors.New("stats flush-interval must be at least 3 minutes")
+		return errors.New("stats flush-interval must be greater than 3 minutes")
 	}
 	return nil
 }

--- a/internal/config/stats_config_test.go
+++ b/internal/config/stats_config_test.go
@@ -46,5 +46,5 @@ func TestStatsConfigInvalidType(t *testing.T) {
 func TestStatsConfigInvalidFlushInterval(t *testing.T) {
 	t.Setenv(config.ConfigPathVar, "configs/stats/stats-config-invalid-flush-interval.yaml")
 	_, err := config.NewAppConfig()
-	assert.ErrorContains(t, err, `stats flush-interval must be greater than 3 minutes`)
+	assert.ErrorContains(t, err, `stats flush-interval must be at least 3 minutes`)
 }

--- a/internal/config/stats_config_test.go
+++ b/internal/config/stats_config_test.go
@@ -46,5 +46,5 @@ func TestStatsConfigInvalidType(t *testing.T) {
 func TestStatsConfigInvalidFlushInterval(t *testing.T) {
 	t.Setenv(config.ConfigPathVar, "configs/stats/stats-config-invalid-flush-interval.yaml")
 	_, err := config.NewAppConfig()
-	assert.ErrorContains(t, err, `stats flush-interval must be at least 3 minutes`)
+	assert.ErrorContains(t, err, `stats flush-interval must be greater than 3 minutes`)
 }

--- a/internal/upstreams/chains_specific/algorand_chain_specific.go
+++ b/internal/upstreams/chains_specific/algorand_chain_specific.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -19,6 +20,7 @@ type AlgorandChainSpecificObject struct {
 	ctx             context.Context
 	upstreamId      string
 	connector       connectors.ApiConnector
+	options         *config.UpstreamOptions
 	internalTimeout time.Duration
 	labelsDelay     time.Duration
 	configuredChain *chains.ConfiguredChain
@@ -29,14 +31,15 @@ func NewAlgorandChainSpecificObject(
 	configuredChain *chains.ConfiguredChain,
 	upstreamId string,
 	connector connectors.ApiConnector,
-	internalTimeout, labelsDelay time.Duration,
+	options *config.UpstreamOptions,
 ) *AlgorandChainSpecificObject {
 	return &AlgorandChainSpecificObject{
 		ctx:             ctx,
 		upstreamId:      upstreamId,
 		connector:       connector,
-		internalTimeout: internalTimeout,
-		labelsDelay:     labelsDelay,
+		options:         options,
+		internalTimeout: options.InternalTimeout,
+		labelsDelay:     options.ValidationInterval * 5,
 		configuredChain: configuredChain,
 	}
 }
@@ -71,6 +74,9 @@ func (a *AlgorandChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBo
 }
 
 func (a *AlgorandChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	if a.options != nil && *a.options.DisableHealthValidation {
+		return []validations.Validator[protocol.AvailabilityStatus]{}
+	}
 	return []validations.Validator[protocol.AvailabilityStatus]{
 		validations.NewAlgorandHealthValidator(
 			a.upstreamId, a.connector, a.configuredChain.Chain, a.internalTimeout,
@@ -81,6 +87,9 @@ func (a *AlgorandChainSpecificObject) HealthValidators() []validations.Validator
 func (a *AlgorandChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
 	if a.configuredChain == nil || a.configuredChain.ChainId == "" {
 		return nil
+	}
+	if a.options != nil && *a.options.DisableChainValidation {
+		return []validations.Validator[validations.ValidationSettingResult]{}
 	}
 	return []validations.Validator[validations.ValidationSettingResult]{
 		validations.NewAlgorandChainValidator(a.upstreamId, a.connector, a.configuredChain, a.internalTimeout),

--- a/internal/upstreams/chains_specific/algorand_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/algorand_chain_specific_test.go
@@ -1,0 +1,115 @@
+package specific_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAlgorandSubscribeHeadRequest(t *testing.T) {
+	req, err := test_utils.NewAlgorandChainSpecific(context.Background(), nil).SubscribeHeadRequest()
+	assert.Nil(t, req)
+	assert.EqualError(t, err, "algorand does not support websocket subscriptions")
+}
+
+func TestAlgorandParseSubscriptionBlock(t *testing.T) {
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), nil).ParseSubscriptionBlock([]byte(`{}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.EqualError(t, err, "algorand does not support websocket subscriptions")
+}
+
+func TestAlgorandParseBlock(t *testing.T) {
+	body := []byte(`{
+		"last-round": 12345,
+		"catchup-time": 0,
+		"stopped-at-unsupported-round": false
+	}`)
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), nil).ParseBlock(body)
+	assert.Nil(t, err)
+
+	expected := protocol.NewBlock(12345, 0, blockchain.EmptyHash, blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAlgorandParseBlockInvalidJSON(t *testing.T) {
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), nil).ParseBlock([]byte(`not json`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the algorand status")
+}
+
+func TestAlgorandParseBlockZeroLastRound(t *testing.T) {
+	body := []byte(`{"last-round": 0}`)
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), nil).ParseBlock(body)
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the algorand status")
+}
+
+func TestAlgorandGetLatestBlock(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"last-round": 99999,
+		"catchup-time": 0,
+		"stopped-at-unsupported-round": false
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.Rest)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	assert.Nil(t, err)
+
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(99999, 0, blockchain.EmptyHash, blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAlgorandGetLatestBlockWithError(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "block error", nil))
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+
+	var upErr *protocol.ResponseError
+	assert.True(t, errors.As(err, &upErr))
+	assert.Equal(t, 1, upErr.Code)
+	assert.Equal(t, "block error", upErr.Message)
+}
+
+func TestAlgorandGetFinalizedBlockDelegatesToLatest(t *testing.T) {
+	// GetFinalizedBlock delegates to GetLatestBlock for Algorand.
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"last-round": 77777,
+		"catchup-time": 0,
+		"stopped-at-unsupported-round": false
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.Rest)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+	assert.Nil(t, err)
+
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(77777, 0, blockchain.EmptyHash, blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -24,103 +24,6 @@ type AztecChainSpecificObject struct {
 	configuredChain *chains.ConfiguredChain
 }
 
-func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
-	labelsDetectors := []labels.LabelsDetector{
-		labels.NewClientLabelDetectorHandler(a.upstreamId, a.connector, labels.NewAztecClientLabelsDetector(), a.internalTimeout),
-	}
-	return labels.NewBaseLabelsProcessor(a.ctx, a.upstreamId, labelsDetectors, a.labelsDelay)
-}
-
-func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
-	detectors := []lower_bounds.LowerBoundDetector{
-		lower_bounds.NewAztecLowerBoundDetector(a.upstreamId, a.internalTimeout, a.connector),
-	}
-	return lower_bounds.NewBaseLowerBoundProcessor(a.ctx, a.upstreamId, a.configuredChain.AverageRemoveSpeed(), detectors)
-}
-
-func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
-	return []validations.Validator[protocol.AvailabilityStatus]{
-		validations.NewAztecHealthValidator(a.upstreamId, a.connector, a.internalTimeout),
-	}
-}
-
-func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
-	if a.configuredChain == nil || a.configuredChain.ChainId == "" {
-		return nil
-	}
-	return []validations.Validator[validations.ValidationSettingResult]{
-		validations.NewAztecChainValidator(a.upstreamId, a.connector, a.configuredChain, a.internalTimeout),
-	}
-}
-
-func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", []interface{}{}, chains.AZTEC_MAINNET)
-	if err != nil {
-		return protocol.ZeroBlock{}, err
-	}
-
-	response := a.connector.SendRequest(ctx, request)
-	if response.HasError() {
-		return protocol.ZeroBlock{}, response.GetError()
-	}
-
-	return a.ParseBlock(response.ResponseResult())
-}
-
-func (a *AztecChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", []interface{}{}, chains.AZTEC_MAINNET)
-	if err != nil {
-		return protocol.ZeroBlock{}, err
-	}
-
-	response := a.connector.SendRequest(ctx, request)
-	if response.HasError() {
-		return protocol.ZeroBlock{}, response.GetError()
-	}
-
-	tips := AztecL2Tips{}
-	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
-		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse aztec L2 tips, reason - %s", err.Error())
-	}
-	if tips.Proven.Number == 0 {
-		return protocol.ZeroBlock{}, nil
-	}
-	return protocol.NewBlock(
-		tips.Proven.Number,
-		0,
-		blockchain.NewHashIdFromString(tips.Proven.Hash),
-		blockchain.EmptyHash,
-	), nil
-}
-
-func (a *AztecChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
-	tips := AztecL2Tips{}
-	err := sonic.Unmarshal(blockBytes, &tips)
-	if err != nil {
-		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec L2 tips, reason - %s", err.Error())
-	}
-
-	height := tips.Proposed.Number
-	if height == 0 {
-		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec L2 tips, got '%s'", string(blockBytes))
-	}
-
-	return protocol.NewBlock(
-		height,
-		0,
-		blockchain.NewHashIdFromString(tips.Proposed.Hash),
-		blockchain.EmptyHash,
-	), nil
-}
-
-func (a *AztecChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
-	return protocol.ZeroBlock{}, fmt.Errorf("aztec does not support websocket subscriptions")
-}
-
-func (a *AztecChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolder, error) {
-	return nil, fmt.Errorf("aztec does not support websocket subscriptions")
-}
-
 func NewAztecChainSpecificObject(
 	ctx context.Context,
 	configuredChain *chains.ConfiguredChain,
@@ -138,46 +41,141 @@ func NewAztecChainSpecificObject(
 	}
 }
 
+func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
+	labelsDetectors := []labels.LabelsDetector{
+		labels.NewClientLabelDetectorHandler(
+			a.upstreamId,
+			a.connector,
+			labels.NewAztecClientLabelsDetector(),
+			a.internalTimeout,
+		),
+	}
+	return labels.NewBaseLabelsProcessor(a.ctx, a.upstreamId, labelsDetectors, a.labelsDelay)
+}
+
+func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
+	detectors := []lower_bounds.LowerBoundDetector{
+		lower_bounds.NewAztecLowerBoundDetector(
+			a.upstreamId, a.internalTimeout, a.connector,
+		),
+	}
+	return lower_bounds.NewBaseLowerBoundProcessor(
+		a.ctx,
+		a.upstreamId,
+		a.configuredChain.AverageRemoveSpeed(),
+		detectors,
+	)
+}
+
+func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	return []validations.Validator[protocol.AvailabilityStatus]{
+		validations.NewAztecHealthValidator(
+			a.upstreamId, a.connector, a.configuredChain.Chain, a.internalTimeout,
+		),
+	}
+}
+
+func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
+	if a.configuredChain == nil || a.configuredChain.ChainId == "" {
+		return nil
+	}
+	return []validations.Validator[validations.ValidationSettingResult]{
+		validations.NewAztecChainValidator(a.upstreamId, a.connector, a.configuredChain, a.internalTimeout),
+	}
+}
+
+func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"node_getL2Tips",
+		[]interface{}{},
+		a.configuredChain.Chain,
+	)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return protocol.ZeroBlock{}, response.GetError()
+	}
+
+	return a.ParseBlock(response.ResponseResult())
+}
+
 // AztecL2Tips models the response from node_getL2Tips. Aztec reshaped the payload
 // between v3 and v4: in v3 every tip was flat ({number, hash}); in v4 proven,
 // finalized and checkpointed each became {block: {number, hash}, checkpoint: {...}}
 // while proposed stayed flat. AztecVersionedTip handles both shapes transparently
 // so a node on either version is parsed correctly.
 type AztecL2Tips struct {
-	Proposed     AztecTip          `json:"proposed"`
-	Proven       AztecVersionedTip `json:"proven"`
-	Finalized    AztecVersionedTip `json:"finalized"`
-	Checkpointed AztecVersionedTip `json:"checkpointed"`
+	Proposed     validations.AztecTip          `json:"proposed"`
+	Proven       validations.AztecVersionedTip `json:"proven"`
+	Finalized    validations.AztecVersionedTip `json:"finalized"`
+	Checkpointed validations.AztecVersionedTip `json:"checkpointed"`
 }
 
-type AztecTip struct {
-	Number uint64 `json:"number"`
-	Hash   string `json:"hash"`
+func (a *AztecChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"node_getL2Tips",
+		[]interface{}{},
+		a.configuredChain.Chain,
+	)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return protocol.ZeroBlock{}, response.GetError()
+	}
+
+	tips := AztecL2Tips{}
+	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf(
+			"couldn't parse aztec L2 tips, reason - %s", err.Error(),
+		)
+	}
+	if tips.Proven.Number == 0 {
+		return protocol.ZeroBlock{}, nil
+	}
+	return protocol.NewBlock(
+		tips.Proven.Number,
+		0,
+		blockchain.NewHashIdFromString(tips.Proven.Hash),
+		blockchain.EmptyHash,
+	), nil
 }
 
-// AztecVersionedTip flattens v3 ({number, hash}) and v4 ({block: {number, hash}})
-// shapes into a single {Number, Hash} pair.
-type AztecVersionedTip struct {
-	Number uint64
-	Hash   string
+func (a *AztecChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
+	tips := AztecL2Tips{}
+	err := sonic.Unmarshal(blockBytes, &tips)
+	if err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf(
+			"couldn't parse the aztec L2 tips, reason - %s", err.Error(),
+		)
+	}
+
+	height := tips.Proposed.Number
+	if height == 0 {
+		return protocol.ZeroBlock{}, fmt.Errorf(
+			"couldn't parse the aztec L2 tips, got '%s'", string(blockBytes),
+		)
+	}
+
+	return protocol.NewBlock(
+		height,
+		0,
+		blockchain.NewHashIdFromString(tips.Proposed.Hash),
+		blockchain.EmptyHash,
+	), nil
 }
 
-func (a *AztecVersionedTip) UnmarshalJSON(data []byte) error {
-	var nested struct {
-		Block *AztecTip `json:"block"`
-	}
-	if err := sonic.Unmarshal(data, &nested); err == nil && nested.Block != nil {
-		a.Number = nested.Block.Number
-		a.Hash = nested.Block.Hash
-		return nil
-	}
-	var flat AztecTip
-	if err := sonic.Unmarshal(data, &flat); err != nil {
-		return err
-	}
-	a.Number = flat.Number
-	a.Hash = flat.Hash
-	return nil
+func (a *AztecChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
+	return protocol.ZeroBlock{}, fmt.Errorf("aztec does not support websocket subscriptions")
+}
+
+func (a *AztecChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolder, error) {
+	return nil, fmt.Errorf("aztec does not support websocket subscriptions")
 }
 
 var _ ChainSpecific = (*AztecChainSpecificObject)(nil)

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -3,6 +3,7 @@ package specific
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -15,12 +16,18 @@ import (
 )
 
 type AztecChainSpecificObject struct {
-	upstreamId string
-	connector  connectors.ApiConnector
+	ctx             context.Context
+	upstreamId      string
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+	labelsDelay     time.Duration
 }
 
 func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
-	return nil
+	labelsDetectors := []labels.LabelsDetector{
+		labels.NewClientLabelDetectorHandler(a.upstreamId, a.connector, labels.NewAztecClientLabelsDetector(), a.internalTimeout),
+	}
+	return labels.NewBaseLabelsProcessor(a.ctx, a.upstreamId, labelsDetectors, a.labelsDelay)
 }
 
 func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
@@ -28,7 +35,9 @@ func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBound
 }
 
 func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
-	return nil
+	return []validations.Validator[protocol.AvailabilityStatus]{
+		validations.NewAztecHealthValidator(a.upstreamId, a.connector, a.internalTimeout),
+	}
 }
 
 func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
@@ -36,7 +45,7 @@ func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[
 }
 
 func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getBlock", []interface{}{"latest"}, chains.AZTEC_MAINNET)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", []interface{}{}, chains.AZTEC_MAINNET)
 	if err != nil {
 		return protocol.ZeroBlock{}, err
 	}
@@ -49,23 +58,50 @@ func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol
 	return a.ParseBlock(response.ResponseResult())
 }
 
-func (a *AztecChainSpecificObject) GetFinalizedBlock(_ context.Context) (protocol.Block, error) {
-	return protocol.ZeroBlock{}, nil
+func (a *AztecChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", []interface{}{}, chains.AZTEC_MAINNET)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return protocol.ZeroBlock{}, response.GetError()
+	}
+
+	tips := AztecL2Tips{}
+	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse aztec L2 tips, reason - %s", err.Error())
+	}
+	if tips.Proven.Number == 0 {
+		return protocol.ZeroBlock{}, nil
+	}
+	return protocol.NewBlock(
+		tips.Proven.Number,
+		0,
+		blockchain.NewHashIdFromString(tips.Proven.Hash),
+		blockchain.EmptyHash,
+	), nil
 }
 
 func (a *AztecChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
-	block := AztecBlock{}
-	err := sonic.Unmarshal(blockBytes, &block)
+	tips := AztecL2Tips{}
+	err := sonic.Unmarshal(blockBytes, &tips)
 	if err != nil {
-		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec block, reason - %s", err.Error())
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec L2 tips, reason - %s", err.Error())
 	}
 
-	height := block.Header.GlobalVariables.BlockNumber
+	height := tips.Proposed.Number
 	if height == 0 {
-		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec block, got '%s'", string(blockBytes))
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the aztec L2 tips, got '%s'", string(blockBytes))
 	}
 
-	return protocol.NewBlock(height, 0, blockchain.NewHashIdFromString(block.BlockHash), blockchain.EmptyHash), nil
+	return protocol.NewBlock(
+		height,
+		0,
+		blockchain.NewHashIdFromString(tips.Proposed.Hash),
+		blockchain.EmptyHash,
+	), nil
 }
 
 func (a *AztecChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
@@ -77,26 +113,29 @@ func (a *AztecChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolde
 }
 
 func NewAztecChainSpecificObject(
+	ctx context.Context,
 	upstreamId string,
 	connector connectors.ApiConnector,
+	internalTimeout, labelsDelay time.Duration,
 ) *AztecChainSpecificObject {
 	return &AztecChainSpecificObject{
-		upstreamId: upstreamId,
-		connector:  connector,
+		ctx:             ctx,
+		upstreamId:      upstreamId,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+		labelsDelay:     labelsDelay,
 	}
 }
 
-type AztecBlock struct {
-	BlockHash string      `json:"blockHash"`
-	Header    AztecHeader `json:"header"`
+type AztecL2Tips struct {
+	Proposed     AztecTip `json:"proposed"`
+	Proven       AztecTip `json:"proven"`
+	Checkpointed AztecTip `json:"checkpointed"`
 }
 
-type AztecHeader struct {
-	GlobalVariables AztecGlobalVariables `json:"globalVariables"`
-}
-
-type AztecGlobalVariables struct {
-	BlockNumber uint64 `json:"blockNumber"`
+type AztecTip struct {
+	Number uint64 `json:"number"`
+	Hash   string `json:"hash"`
 }
 
 var _ ChainSpecific = (*AztecChainSpecificObject)(nil)

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -22,21 +23,23 @@ type AztecChainSpecificObject struct {
 	internalTimeout time.Duration
 	labelsDelay     time.Duration
 	configuredChain *chains.ConfiguredChain
+	options         *config.UpstreamOptions
 }
 
 func NewAztecChainSpecificObject(
 	ctx context.Context,
 	configuredChain *chains.ConfiguredChain,
 	upstreamId string,
+	options *config.UpstreamOptions,
 	connector connectors.ApiConnector,
-	internalTimeout, labelsDelay time.Duration,
 ) *AztecChainSpecificObject {
 	return &AztecChainSpecificObject{
 		ctx:             ctx,
 		upstreamId:      upstreamId,
+		options:         options,
 		connector:       connector,
-		internalTimeout: internalTimeout,
-		labelsDelay:     labelsDelay,
+		internalTimeout: options.InternalTimeout,
+		labelsDelay:     options.ValidationInterval * 5,
 		configuredChain: configuredChain,
 	}
 }
@@ -71,6 +74,9 @@ func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBound
 }
 
 func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	if a.options != nil && *a.options.DisableHealthValidation {
+		return []validations.Validator[protocol.AvailabilityStatus]{}
+	}
 	return []validations.Validator[protocol.AvailabilityStatus]{
 		validations.NewAztecHealthValidator(
 			a.upstreamId, a.connector, a.configuredChain.Chain, a.internalTimeout,
@@ -81,6 +87,9 @@ func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[pr
 func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
 	if a.configuredChain == nil || a.configuredChain.ChainId == "" {
 		return nil
+	}
+	if a.options != nil && *a.options.DisableChainValidation {
+		return []validations.Validator[validations.ValidationSettingResult]{}
 	}
 	return []validations.Validator[validations.ValidationSettingResult]{
 		validations.NewAztecChainValidator(a.upstreamId, a.connector, a.configuredChain, a.internalTimeout),

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -56,7 +56,10 @@ func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
 	detectors := []lower_bounds.LowerBoundDetector{
 		lower_bounds.NewAztecLowerBoundDetector(
-			a.upstreamId, a.internalTimeout, a.connector,
+			a.upstreamId,
+			a.configuredChain.Chain,
+			a.internalTimeout,
+			a.connector,
 		),
 	}
 	return lower_bounds.NewBaseLowerBoundProcessor(

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -105,18 +105,6 @@ func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol
 	return a.ParseBlock(response.ResponseResult())
 }
 
-// AztecL2Tips models the response from node_getL2Tips. Aztec reshaped the payload
-// between v3 and v4: in v3 every tip was flat ({number, hash}); in v4 proven,
-// finalized and checkpointed each became {block: {number, hash}, checkpoint: {...}}
-// while proposed stayed flat. AztecVersionedTip handles both shapes transparently
-// so a node on either version is parsed correctly.
-type AztecL2Tips struct {
-	Proposed     validations.AztecTip          `json:"proposed"`
-	Proven       validations.AztecVersionedTip `json:"proven"`
-	Finalized    validations.AztecVersionedTip `json:"finalized"`
-	Checkpointed validations.AztecVersionedTip `json:"checkpointed"`
-}
-
 func (a *AztecChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
 		"node_getL2Tips",
@@ -132,25 +120,33 @@ func (a *AztecChainSpecificObject) GetFinalizedBlock(ctx context.Context) (proto
 		return protocol.ZeroBlock{}, response.GetError()
 	}
 
-	tips := AztecL2Tips{}
+	tips := validations.AztecL2Tips{}
 	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
 		return protocol.ZeroBlock{}, fmt.Errorf(
 			"couldn't parse aztec L2 tips, reason - %s", err.Error(),
 		)
 	}
-	if tips.Proven.Number == 0 {
+	// Aztec exposes both `proven` (zk proof submitted) and `finalized` (the L1
+	// block carrying that proof is finalized). Finalized is the stronger notion
+	// expected by GetFinalizedBlock callers; fall back to proven only if the
+	// node has not produced a finalized tip yet (early genesis blocks).
+	finalized := tips.Finalized
+	if finalized.Number == 0 {
+		finalized = tips.Proven
+	}
+	if finalized.Number == 0 {
 		return protocol.ZeroBlock{}, nil
 	}
 	return protocol.NewBlock(
-		tips.Proven.Number,
+		finalized.Number,
 		0,
-		blockchain.NewHashIdFromString(tips.Proven.Hash),
+		blockchain.NewHashIdFromString(finalized.Hash),
 		blockchain.EmptyHash,
 	), nil
 }
 
 func (a *AztecChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
-	tips := AztecL2Tips{}
+	tips := validations.AztecL2Tips{}
 	err := sonic.Unmarshal(blockBytes, &tips)
 	if err != nil {
 		return protocol.ZeroBlock{}, fmt.Errorf(

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -138,15 +138,46 @@ func NewAztecChainSpecificObject(
 	}
 }
 
+// AztecL2Tips models the response from node_getL2Tips. Aztec reshaped the payload
+// between v3 and v4: in v3 every tip was flat ({number, hash}); in v4 proven,
+// finalized and checkpointed each became {block: {number, hash}, checkpoint: {...}}
+// while proposed stayed flat. AztecVersionedTip handles both shapes transparently
+// so a node on either version is parsed correctly.
 type AztecL2Tips struct {
-	Proposed     AztecTip `json:"proposed"`
-	Proven       AztecTip `json:"proven"`
-	Checkpointed AztecTip `json:"checkpointed"`
+	Proposed     AztecTip          `json:"proposed"`
+	Proven       AztecVersionedTip `json:"proven"`
+	Finalized    AztecVersionedTip `json:"finalized"`
+	Checkpointed AztecVersionedTip `json:"checkpointed"`
 }
 
 type AztecTip struct {
 	Number uint64 `json:"number"`
 	Hash   string `json:"hash"`
+}
+
+// AztecVersionedTip flattens v3 ({number, hash}) and v4 ({block: {number, hash}})
+// shapes into a single {Number, Hash} pair.
+type AztecVersionedTip struct {
+	Number uint64
+	Hash   string
+}
+
+func (a *AztecVersionedTip) UnmarshalJSON(data []byte) error {
+	var nested struct {
+		Block *AztecTip `json:"block"`
+	}
+	if err := sonic.Unmarshal(data, &nested); err == nil && nested.Block != nil {
+		a.Number = nested.Block.Number
+		a.Hash = nested.Block.Hash
+		return nil
+	}
+	var flat AztecTip
+	if err := sonic.Unmarshal(data, &flat); err != nil {
+		return err
+	}
+	a.Number = flat.Number
+	a.Hash = flat.Hash
+	return nil
 }
 
 var _ ChainSpecific = (*AztecChainSpecificObject)(nil)

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -46,7 +46,7 @@ func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 		labels.NewClientLabelDetectorHandler(
 			a.upstreamId,
 			a.connector,
-			labels.NewAztecClientLabelsDetector(),
+			labels.NewAztecClientLabelsDetector(a.configuredChain.Chain),
 			a.internalTimeout,
 		),
 	}

--- a/internal/upstreams/chains_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific.go
@@ -21,6 +21,7 @@ type AztecChainSpecificObject struct {
 	connector       connectors.ApiConnector
 	internalTimeout time.Duration
 	labelsDelay     time.Duration
+	configuredChain *chains.ConfiguredChain
 }
 
 func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
@@ -31,7 +32,10 @@ func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 }
 
 func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
-	return nil
+	detectors := []lower_bounds.LowerBoundDetector{
+		lower_bounds.NewAztecLowerBoundDetector(a.upstreamId, a.internalTimeout, a.connector),
+	}
+	return lower_bounds.NewBaseLowerBoundProcessor(a.ctx, a.upstreamId, a.configuredChain.AverageRemoveSpeed(), detectors)
 }
 
 func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
@@ -41,7 +45,12 @@ func (a *AztecChainSpecificObject) HealthValidators() []validations.Validator[pr
 }
 
 func (a *AztecChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
-	return nil
+	if a.configuredChain == nil || a.configuredChain.ChainId == "" {
+		return nil
+	}
+	return []validations.Validator[validations.ValidationSettingResult]{
+		validations.NewAztecChainValidator(a.upstreamId, a.connector, a.configuredChain, a.internalTimeout),
+	}
 }
 
 func (a *AztecChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
@@ -114,6 +123,7 @@ func (a *AztecChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolde
 
 func NewAztecChainSpecificObject(
 	ctx context.Context,
+	configuredChain *chains.ConfiguredChain,
 	upstreamId string,
 	connector connectors.ApiConnector,
 	internalTimeout, labelsDelay time.Duration,
@@ -124,6 +134,7 @@ func NewAztecChainSpecificObject(
 		connector:       connector,
 		internalTimeout: internalTimeout,
 		labelsDelay:     labelsDelay,
+		configuredChain: configuredChain,
 	}
 }
 

--- a/internal/upstreams/chains_specific/aztec_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/aztec_chain_specific_test.go
@@ -1,0 +1,207 @@
+package specific_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAztecSubscribeHeadRequest(t *testing.T) {
+	req, err := test_utils.NewAztecChainSpecific(context.Background(), nil).SubscribeHeadRequest()
+	assert.Nil(t, req)
+	assert.EqualError(t, err, "aztec does not support websocket subscriptions")
+}
+
+func TestAztecParseSubscriptionBlock(t *testing.T) {
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), nil).ParseSubscriptionBlock([]byte(`{}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.EqualError(t, err, "aztec does not support websocket subscriptions")
+}
+
+func TestAztecParseBlock(t *testing.T) {
+	body := []byte(`{
+		"proposed":     {"number": 100, "hash": "0xaaaa"},
+		"proven":       {"number": 99,  "hash": "0xbbbb"},
+		"finalized":    {"number": 98,  "hash": "0xcccc"},
+		"checkpointed": {"number": 98,  "hash": "0xdddd"}
+	}`)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), nil).ParseBlock(body)
+	assert.Nil(t, err)
+
+	expected := protocol.NewBlock(100, 0, blockchain.NewHashIdFromString("0xaaaa"), blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAztecParseBlockV4Nested(t *testing.T) {
+	// Aztec v4 uses nested block shape for proven/finalized/checkpointed.
+	body := []byte(`{
+		"proposed":     {"number": 200, "hash": "0x1111"},
+		"proven":       {"block": {"number": 199, "hash": "0x2222"}},
+		"finalized":    {"block": {"number": 198, "hash": "0x3333"}},
+		"checkpointed": {"block": {"number": 198, "hash": "0x4444"}}
+	}`)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), nil).ParseBlock(body)
+	assert.Nil(t, err)
+
+	expected := protocol.NewBlock(200, 0, blockchain.NewHashIdFromString("0x1111"), blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAztecParseBlockInvalidJSON(t *testing.T) {
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), nil).ParseBlock([]byte(`not json`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the aztec L2 tips")
+}
+
+func TestAztecParseBlockZeroProposedNumber(t *testing.T) {
+	body := []byte(`{
+		"proposed": {"number": 0, "hash": "0xaaaa"},
+		"proven":   {"number": 0, "hash": "0xbbbb"}
+	}`)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), nil).ParseBlock(body)
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the aztec L2 tips")
+}
+
+func TestAztecGetLatestBlock(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"result": {
+			"proposed":     {"number": 500, "hash": "0xfeed"},
+			"proven":       {"number": 499, "hash": "0xbeef"},
+			"finalized":    {"number": 498, "hash": "0xdead"},
+			"checkpointed": {"number": 498, "hash": "0xcafe"}
+		}
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	assert.Nil(t, err)
+
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(500, 0, blockchain.NewHashIdFromString("0xfeed"), blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAztecGetLatestBlockWithError(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "rpc error", nil))
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+
+	var upErr *protocol.ResponseError
+	assert.True(t, errors.As(err, &upErr))
+	assert.Equal(t, 1, upErr.Code)
+	assert.Equal(t, "rpc error", upErr.Message)
+}
+
+func TestAztecGetFinalizedBlock(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"result": {
+			"proposed":  {"number": 500, "hash": "0xfeed"},
+			"proven":    {"number": 499, "hash": "0xbeef"},
+			"finalized": {"number": 498, "hash": "0xdead"}
+		}
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+	assert.Nil(t, err)
+
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(498, 0, blockchain.NewHashIdFromString("0xdead"), blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAztecGetFinalizedBlockFallbackToProven(t *testing.T) {
+	// When finalized.Number == 0, proven should be used.
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"result": {
+			"proposed":  {"number": 500, "hash": "0xfeed"},
+			"proven":    {"number": 499, "hash": "0xbeef"},
+			"finalized": {"number": 0, "hash": "0x0000"}
+		}
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+	assert.Nil(t, err)
+
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(499, 0, blockchain.NewHashIdFromString("0xbeef"), blockchain.EmptyHash)
+	assert.Equal(t, expected, block)
+}
+
+func TestAztecGetFinalizedBlockZeroWhenBothZero(t *testing.T) {
+	// When both finalized and proven are 0, a ZeroBlock should be returned.
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"result": {
+			"proposed":  {"number": 500, "hash": "0xfeed"},
+			"proven":    {"number": 0,   "hash": "0x0000"},
+			"finalized": {"number": 0,   "hash": "0x0000"}
+		}
+	}`)
+	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+	assert.Nil(t, err)
+	assert.True(t, block.IsFullEmpty())
+
+	connector.AssertExpectations(t)
+}
+
+func TestAztecGetFinalizedBlockWithError(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(2, "finalized error", nil))
+
+	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+
+	block, err := test_utils.NewAztecChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+
+	var upErr *protocol.ResponseError
+	assert.True(t, errors.As(err, &upErr))
+	assert.Equal(t, 2, upErr.Code)
+	assert.Equal(t, "finalized error", upErr.Message)
+}

--- a/internal/upstreams/labels/aztec_detectors.go
+++ b/internal/upstreams/labels/aztec_detectors.go
@@ -31,7 +31,10 @@ func (a *AztecClientLabelsDetector) ClientVersionAndType(data []byte) (string, s
 		// (e.g. node_getNodeInfo-like payload), fall back to extracting nodeVersion.
 		var info aztecNodeInfo
 		if err2 := sonic.Unmarshal(data, &info); err2 != nil {
-			return "", "", err
+			// Surface the object-decode failure (the string-decode error above
+			// only triggered the fallback - the actual reason we couldn't
+			// extract a version is err2).
+			return "", "", err2
 		}
 		version = info.NodeVersion
 	}

--- a/internal/upstreams/labels/aztec_detectors.go
+++ b/internal/upstreams/labels/aztec_detectors.go
@@ -9,10 +9,19 @@ import (
 )
 
 type AztecClientLabelsDetector struct {
+	chain chains.Chain
+}
+
+func NewAztecClientLabelsDetector(chain chains.Chain) *AztecClientLabelsDetector {
+	return &AztecClientLabelsDetector{chain: chain}
 }
 
 func (a *AztecClientLabelsDetector) NodeTypeRequest() (protocol.RequestHolder, error) {
-	return protocol.NewInternalUpstreamJsonRpcRequest("node_getNodeVersion", nil, chains.AZTEC_MAINNET)
+	return protocol.NewInternalUpstreamJsonRpcRequest("node_getNodeVersion", []string{}, a.chain)
+}
+
+type aztecNodeInfo struct {
+	NodeVersion string `json:"nodeVersion"`
 }
 
 func (a *AztecClientLabelsDetector) ClientVersionAndType(data []byte) (string, string, error) {
@@ -32,12 +41,4 @@ func (a *AztecClientLabelsDetector) ClientVersionAndType(data []byte) (string, s
 	return version, "aztec", nil
 }
 
-func NewAztecClientLabelsDetector() *AztecClientLabelsDetector {
-	return &AztecClientLabelsDetector{}
-}
-
 var _ ClientLabelsDetector = (*AztecClientLabelsDetector)(nil)
-
-type aztecNodeInfo struct {
-	NodeVersion string `json:"nodeVersion"`
-}

--- a/internal/upstreams/labels/aztec_detectors.go
+++ b/internal/upstreams/labels/aztec_detectors.go
@@ -1,0 +1,43 @@
+package labels
+
+import (
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+type AztecClientLabelsDetector struct {
+}
+
+func (a *AztecClientLabelsDetector) NodeTypeRequest() (protocol.RequestHolder, error) {
+	return protocol.NewInternalUpstreamJsonRpcRequest("node_getNodeVersion", nil, chains.AZTEC_MAINNET)
+}
+
+func (a *AztecClientLabelsDetector) ClientVersionAndType(data []byte) (string, string, error) {
+	var version string
+	if err := sonic.Unmarshal(data, &version); err != nil {
+		// node_getNodeVersion returns a JSON string. If it ever returns an object
+		// (e.g. node_getNodeInfo-like payload), fall back to extracting nodeVersion.
+		var info aztecNodeInfo
+		if err2 := sonic.Unmarshal(data, &info); err2 != nil {
+			return "", "", err
+		}
+		version = info.NodeVersion
+	}
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimPrefix(version, "V")
+	return version, "aztec", nil
+}
+
+func NewAztecClientLabelsDetector() *AztecClientLabelsDetector {
+	return &AztecClientLabelsDetector{}
+}
+
+var _ ClientLabelsDetector = (*AztecClientLabelsDetector)(nil)
+
+type aztecNodeInfo struct {
+	NodeVersion string `json:"nodeVersion"`
+}

--- a/internal/upstreams/lower_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_lower_bound.go
@@ -2,33 +2,27 @@ package lower_bounds
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
 )
 
 const aztecPeriod = 5 * time.Minute
 
-// aztecMaxProbe caps the exponential probe used to find an upper bound when the
-// upstream is not an archive node. Aztec mainnet block numbers grow at ~1 block/s,
-// so 100M is multiple decades of headroom and serves as a safety stop only.
-const aztecMaxProbe int64 = 100_000_000
-
-var errAztecNoBlock = errors.New("aztec upstream has no blocks within probing range")
-
-// AztecLowerBoundDetector binary-searches the lowest L2 block the upstream can
-// still serve. node_getBlockHeader(N) returns JSON `null` for blocks the node does
-// not have (no error, just null), so the probe treats a `null` (case-insensitive,
-// trimmed) result as "no data" and any non-null body as "has data". The header is
-// preferred over node_getBlock because we only need a presence signal and the
-// binary search performs ~log2(currentHeight) probes per refresh cycle.
+// AztecLowerBoundDetector reports the lowest L2 block for which the upstream
+// still has state available, by reading oldestHistoricBlockNumber from
+// node_getWorldStateSyncStatus (one RPC per refresh - the world-state
+// synchronizer publishes this number directly, no binary-search probing
+// needed).
 //
-// Most Aztec full nodes are archive nodes and converge to bound=1 immediately;
-// pruning-capable builds will converge to whatever block the prune kept.
+// On transient errors (the public Aztec endpoint occasionally returns code 19
+// on this method) we fall back to StateBound=1 since Aztec full nodes are
+// archive by default. Subsequent refresh ticks will retry and pick up the real
+// prune boundary if the node is actually pruning.
 type AztecLowerBoundDetector struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
@@ -48,51 +42,12 @@ func NewAztecLowerBoundDetector(
 }
 
 func (a *AztecLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	// Fast path: archive nodes have block 1 available.
-	if has, err := a.hasBlock(1); err == nil && has {
-		return []protocol.LowerBoundData{
-			protocol.NewLowerBoundDataNow(1, protocol.StateBound),
-		}, nil
+	bound := a.fetchOldestHistoric()
+	if bound < 1 {
+		bound = 1
 	}
-
-	// Find an upper bound by exponential probe.
-	var lo int64 = 2
-	var hi int64 = 1000
-	for {
-		has, err := a.hasBlock(hi)
-		if err != nil {
-			return nil, err
-		}
-		if has {
-			break
-		}
-		if hi >= aztecMaxProbe {
-			return nil, errAztecNoBlock
-		}
-		lo = hi + 1
-		next := hi * 10
-		if next > aztecMaxProbe {
-			next = aztecMaxProbe
-		}
-		hi = next
-	}
-
-	// Binary search [lo, hi] for the smallest block that has data.
-	for lo < hi {
-		mid := lo + (hi-lo)/2
-		has, err := a.hasBlock(mid)
-		if err != nil {
-			return nil, err
-		}
-		if has {
-			hi = mid
-		} else {
-			lo = mid + 1
-		}
-	}
-
 	return []protocol.LowerBoundData{
-		protocol.NewLowerBoundDataNow(lo, protocol.StateBound),
+		protocol.NewLowerBoundDataNow(bound, protocol.StateBound),
 	}, nil
 }
 
@@ -104,28 +59,34 @@ func (a *AztecLowerBoundDetector) Period() time.Duration {
 	return aztecPeriod
 }
 
-func (a *AztecLowerBoundDetector) hasBlock(number int64) (bool, error) {
+// fetchOldestHistoric returns the upstream's oldestHistoricBlockNumber, or 1
+// (the archive-node default) on any error or unparseable response.
+func (a *AztecLowerBoundDetector) fetchOldestHistoric() int64 {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getBlockHeader", []interface{}{number}, chains.AZTEC_MAINNET)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getWorldStateSyncStatus", []interface{}{}, chains.AZTEC_MAINNET)
 	if err != nil {
-		return false, err
+		log.Debug().Err(err).Msgf("aztec upstream '%s' couldn't build world state sync request, defaulting to STATE=1", a.upstreamId)
+		return 1
 	}
 
 	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
-		// RPC errors here usually mean "no block" / "pruned" / temporary upstream
-		// issue. Treat as "no data" - the binary search will move past this block.
-		// Real connectivity issues are caught by the surrounding retry/health flow.
-		return false, nil
+		log.Debug().Err(response.GetError()).Msgf("aztec upstream '%s' world state sync status unavailable, defaulting to STATE=1", a.upstreamId)
+		return 1
 	}
 
-	body := strings.TrimSpace(strings.ToLower(string(response.ResponseResult())))
-	if body == "" || body == "null" {
-		return false, nil
+	var status worldStateSyncStatus
+	if err := sonic.Unmarshal(response.ResponseResult(), &status); err != nil {
+		log.Debug().Err(err).Msgf("aztec upstream '%s' returned unparseable world state sync status, defaulting to STATE=1", a.upstreamId)
+		return 1
 	}
-	return true, nil
+	return int64(status.OldestHistoricBlockNumber)
+}
+
+type worldStateSyncStatus struct {
+	OldestHistoricBlockNumber uint64 `json:"oldestHistoricBlockNumber"`
 }
 
 var _ LowerBoundDetector = (*AztecLowerBoundDetector)(nil)

--- a/internal/upstreams/lower_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_lower_bound.go
@@ -21,9 +21,11 @@ const aztecMaxProbe int64 = 100_000_000
 var errAztecNoBlock = errors.New("aztec upstream has no blocks within probing range")
 
 // AztecLowerBoundDetector binary-searches the lowest L2 block the upstream can
-// still serve. node_getBlock(N) returns JSON `null` for blocks the node does not
-// have (no error, just null), so the probe treats a `null` (case-insensitive,
-// trimmed) result as "no data" and any non-null body as "has data".
+// still serve. node_getBlockHeader(N) returns JSON `null` for blocks the node does
+// not have (no error, just null), so the probe treats a `null` (case-insensitive,
+// trimmed) result as "no data" and any non-null body as "has data". The header is
+// preferred over node_getBlock because we only need a presence signal and the
+// binary search performs ~log2(currentHeight) probes per refresh cycle.
 //
 // Most Aztec full nodes are archive nodes and converge to bound=1 immediately;
 // pruning-capable builds will converge to whatever block the prune kept.
@@ -106,7 +108,7 @@ func (a *AztecLowerBoundDetector) hasBlock(number int64) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getBlock", []interface{}{number}, chains.AZTEC_MAINNET)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getBlockHeader", []interface{}{number}, chains.AZTEC_MAINNET)
 	if err != nil {
 		return false, err
 	}

--- a/internal/upstreams/lower_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_lower_bound.go
@@ -1,0 +1,129 @@
+package lower_bounds
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const aztecPeriod = 5 * time.Minute
+
+// aztecMaxProbe caps the exponential probe used to find an upper bound when the
+// upstream is not an archive node. Aztec mainnet block numbers grow at ~1 block/s,
+// so 100M is multiple decades of headroom and serves as a safety stop only.
+const aztecMaxProbe int64 = 100_000_000
+
+var errAztecNoBlock = errors.New("aztec upstream has no blocks within probing range")
+
+// AztecLowerBoundDetector binary-searches the lowest L2 block the upstream can
+// still serve. node_getBlock(N) returns JSON `null` for blocks the node does not
+// have (no error, just null), so the probe treats a `null` (case-insensitive,
+// trimmed) result as "no data" and any non-null body as "has data".
+//
+// Most Aztec full nodes are archive nodes and converge to bound=1 immediately;
+// pruning-capable builds will converge to whatever block the prune kept.
+type AztecLowerBoundDetector struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+}
+
+func NewAztecLowerBoundDetector(
+	upstreamId string,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *AztecLowerBoundDetector {
+	return &AztecLowerBoundDetector{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (a *AztecLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
+	// Fast path: archive nodes have block 1 available.
+	if has, err := a.hasBlock(1); err == nil && has {
+		return []protocol.LowerBoundData{
+			protocol.NewLowerBoundDataNow(1, protocol.StateBound),
+		}, nil
+	}
+
+	// Find an upper bound by exponential probe.
+	var lo int64 = 2
+	var hi int64 = 1000
+	for {
+		has, err := a.hasBlock(hi)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			break
+		}
+		if hi >= aztecMaxProbe {
+			return nil, errAztecNoBlock
+		}
+		lo = hi + 1
+		next := hi * 10
+		if next > aztecMaxProbe {
+			next = aztecMaxProbe
+		}
+		hi = next
+	}
+
+	// Binary search [lo, hi] for the smallest block that has data.
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		has, err := a.hasBlock(mid)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+
+	return []protocol.LowerBoundData{
+		protocol.NewLowerBoundDataNow(lo, protocol.StateBound),
+	}, nil
+}
+
+func (a *AztecLowerBoundDetector) SupportedTypes() []protocol.LowerBoundType {
+	return []protocol.LowerBoundType{protocol.StateBound}
+}
+
+func (a *AztecLowerBoundDetector) Period() time.Duration {
+	return aztecPeriod
+}
+
+func (a *AztecLowerBoundDetector) hasBlock(number int64) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getBlock", []interface{}{number}, chains.AZTEC_MAINNET)
+	if err != nil {
+		return false, err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		// RPC errors here usually mean "no block" / "pruned" / temporary upstream
+		// issue. Treat as "no data" - the binary search will move past this block.
+		// Real connectivity issues are caught by the surrounding retry/health flow.
+		return false, nil
+	}
+
+	body := strings.TrimSpace(strings.ToLower(string(response.ResponseResult())))
+	if body == "" || body == "null" {
+		return false, nil
+	}
+	return true, nil
+}
+
+var _ LowerBoundDetector = (*AztecLowerBoundDetector)(nil)

--- a/internal/upstreams/lower_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_lower_bound.go
@@ -30,17 +30,20 @@ var errAztecNoOldestHistoric = errors.New("aztec node returned no oldestHistoric
 type AztecLowerBoundDetector struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
+	chain           chains.Chain
 	internalTimeout time.Duration
 }
 
 func NewAztecLowerBoundDetector(
 	upstreamId string,
+	chain chains.Chain,
 	internalTimeout time.Duration,
 	connector connectors.ApiConnector,
 ) *AztecLowerBoundDetector {
 	return &AztecLowerBoundDetector{
 		upstreamId:      upstreamId,
 		connector:       connector,
+		chain:           chain,
 		internalTimeout: internalTimeout,
 	}
 }
@@ -67,7 +70,11 @@ func (a *AztecLowerBoundDetector) fetchOldestHistoric() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getWorldStateSyncStatus", []interface{}{}, chains.AZTEC_MAINNET)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"node_getWorldStateSyncStatus",
+		[]interface{}{},
+		a.chain,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/upstreams/lower_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_lower_bound.go
@@ -2,16 +2,19 @@ package lower_bounds
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/pkg/chains"
-	"github.com/rs/zerolog/log"
 )
 
 const aztecPeriod = 5 * time.Minute
+
+var errAztecNoOldestHistoric = errors.New("aztec node returned no oldestHistoricBlockNumber")
 
 // AztecLowerBoundDetector reports the lowest L2 block for which the upstream
 // still has state available, by reading oldestHistoricBlockNumber from
@@ -19,10 +22,11 @@ const aztecPeriod = 5 * time.Minute
 // synchronizer publishes this number directly, no binary-search probing
 // needed).
 //
-// On transient errors (the public Aztec endpoint occasionally returns code 19
-// on this method) we fall back to StateBound=1 since Aztec full nodes are
-// archive by default. Subsequent refresh ticks will retry and pick up the real
-// prune boundary if the node is actually pruning.
+// On any error the detector returns (nil, err). BaseLowerBoundProcessor
+// logs the error and skips the tick, so the previously cached lower bound
+// stays in place. Faking a default value here would risk clobbering a real
+// prune boundary on a transient endpoint outage (the public Aztec endpoint
+// occasionally returns code 19 on this method per the Aztec team's audit).
 type AztecLowerBoundDetector struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
@@ -42,9 +46,9 @@ func NewAztecLowerBoundDetector(
 }
 
 func (a *AztecLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	bound := a.fetchOldestHistoric()
-	if bound < 1 {
-		bound = 1
+	bound, err := a.fetchOldestHistoric()
+	if err != nil {
+		return nil, err
 	}
 	return []protocol.LowerBoundData{
 		protocol.NewLowerBoundDataNow(bound, protocol.StateBound),
@@ -59,30 +63,28 @@ func (a *AztecLowerBoundDetector) Period() time.Duration {
 	return aztecPeriod
 }
 
-// fetchOldestHistoric returns the upstream's oldestHistoricBlockNumber, or 1
-// (the archive-node default) on any error or unparseable response.
-func (a *AztecLowerBoundDetector) fetchOldestHistoric() int64 {
+func (a *AztecLowerBoundDetector) fetchOldestHistoric() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getWorldStateSyncStatus", []interface{}{}, chains.AZTEC_MAINNET)
 	if err != nil {
-		log.Debug().Err(err).Msgf("aztec upstream '%s' couldn't build world state sync request, defaulting to STATE=1", a.upstreamId)
-		return 1
+		return 0, err
 	}
 
 	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
-		log.Debug().Err(response.GetError()).Msgf("aztec upstream '%s' world state sync status unavailable, defaulting to STATE=1", a.upstreamId)
-		return 1
+		return 0, response.GetError()
 	}
 
 	var status worldStateSyncStatus
 	if err := sonic.Unmarshal(response.ResponseResult(), &status); err != nil {
-		log.Debug().Err(err).Msgf("aztec upstream '%s' returned unparseable world state sync status, defaulting to STATE=1", a.upstreamId)
-		return 1
+		return 0, fmt.Errorf("aztec world state sync status unparseable: %w", err)
 	}
-	return int64(status.OldestHistoricBlockNumber)
+	if status.OldestHistoricBlockNumber == 0 {
+		return 0, errAztecNoOldestHistoric
+	}
+	return int64(status.OldestHistoricBlockNumber), nil
 }
 
 type worldStateSyncStatus struct {

--- a/internal/upstreams/lower_bounds/lower_bound_processor.go
+++ b/internal/upstreams/lower_bounds/lower_bound_processor.go
@@ -28,8 +28,41 @@ type BaseLowerBoundProcessor struct {
 	lowerBounds          *LowerBounds
 }
 
-func (b *BaseLowerBoundProcessor) PredictLowerBound(boundType protocol.LowerBoundType, timeOffset int64) int64 {
-	return b.lowerBounds.PredictNextBound(boundType, timeOffset)
+func NewBaseLowerBoundProcessor(
+	ctx context.Context,
+	upstreamId string,
+	averageSpeed float64,
+	lowerBoundsDetectors []LowerBoundDetector,
+) *BaseLowerBoundProcessor {
+	return NewBaseLowerBoundProcessorWithDelay(
+		ctx, upstreamId, averageSpeed, 15*time.Second, lowerBoundsDetectors,
+	)
+}
+
+func NewBaseLowerBoundProcessorWithDelay(
+	ctx context.Context,
+	upstreamId string,
+	averageSpeed float64,
+	initialDelay time.Duration,
+	lowerBoundsDetectors []LowerBoundDetector,
+) *BaseLowerBoundProcessor {
+	if len(lowerBoundsDetectors) == 0 {
+		return nil
+	}
+
+	name := fmt.Sprintf("%s_lower_bound_service", upstreamId)
+	return &BaseLowerBoundProcessor{
+		upstreamId:           upstreamId,
+		initialDelay:         initialDelay,
+		subManager:           utils.NewSubscriptionManager[protocol.LowerBoundData](name),
+		lifecycle:            utils.NewBaseLifecycle(name, ctx),
+		lowerBoundsDetectors: lowerBoundsDetectors,
+		lowerBounds:          NewLowerBounds(averageSpeed),
+	}
+}
+
+func (b *BaseLowerBoundProcessor) PredictLowerBound(bt protocol.LowerBoundType, timeOffset int64) int64 {
+	return b.lowerBounds.PredictNextBound(bt, timeOffset)
 }
 
 func (b *BaseLowerBoundProcessor) Start() {
@@ -70,38 +103,10 @@ func (b *BaseLowerBoundProcessor) Subscribe(name string) *utils.Subscription[pro
 	return b.subManager.Subscribe(name)
 }
 
-func NewBaseLowerBoundProcessor(
+func (b *BaseLowerBoundProcessor) detectLowerBound(
 	ctx context.Context,
-	upstreamId string,
-	averageSpeed float64,
-	lowerBoundsDetectors []LowerBoundDetector,
-) *BaseLowerBoundProcessor {
-	return NewBaseLowerBoundProcessorWithDelay(ctx, upstreamId, averageSpeed, 15*time.Second, lowerBoundsDetectors)
-}
-
-func NewBaseLowerBoundProcessorWithDelay(
-	ctx context.Context,
-	upstreamId string,
-	averageSpeed float64,
-	initialDelay time.Duration,
-	lowerBoundsDetectors []LowerBoundDetector,
-) *BaseLowerBoundProcessor {
-	if len(lowerBoundsDetectors) == 0 {
-		return nil
-	}
-
-	name := fmt.Sprintf("%s_lower_bound_service", upstreamId)
-	return &BaseLowerBoundProcessor{
-		upstreamId:           upstreamId,
-		initialDelay:         initialDelay,
-		subManager:           utils.NewSubscriptionManager[protocol.LowerBoundData](name),
-		lifecycle:            utils.NewBaseLifecycle(name, ctx),
-		lowerBoundsDetectors: lowerBoundsDetectors,
-		lowerBounds:          NewLowerBounds(averageSpeed),
-	}
-}
-
-func (b *BaseLowerBoundProcessor) detectLowerBound(ctx context.Context, detector LowerBoundDetector) chan protocol.LowerBoundData {
+	detector LowerBoundDetector,
+) chan protocol.LowerBoundData {
 	boundsChan := make(chan protocol.LowerBoundData, 10)
 
 	go func() {
@@ -123,13 +128,19 @@ func (b *BaseLowerBoundProcessor) detectLowerBound(ctx context.Context, detector
 	return boundsChan
 }
 
-func (b *BaseLowerBoundProcessor) processBounds(detector LowerBoundDetector, boundsChan chan protocol.LowerBoundData) {
+func (b *BaseLowerBoundProcessor) processBounds(
+	detector LowerBoundDetector,
+	boundsChan chan protocol.LowerBoundData,
+) {
 	bounds, err := detector.DetectLowerBound()
 	if err != nil {
 		log.
 			Error().
 			Err(err).
-			Msgf("couldn't detect lower bounds %s for upstream '%s'", detector.SupportedTypes(), b.upstreamId)
+			Msgf(
+				"couldn't detect lower bounds %s for upstream '%s'",
+				detector.SupportedTypes(), b.upstreamId,
+			)
 		return
 	}
 

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -3,6 +3,7 @@ package upstreams
 import (
 	"context"
 	"fmt"
+
 	"github.com/drpcorg/nodecore/internal/stats/hook"
 
 	"github.com/drpcorg/nodecore/internal/config"
@@ -210,9 +211,8 @@ func getChainSpecific(
 			ctx,
 			configuredChain,
 			conf.Id,
+			conf.Options,
 			upstreamConnectorsInfo.internalRequestConnector,
-			conf.Options.InternalTimeout,
-			conf.Options.ValidationInterval*5,
 		)
 	case chains.Algorand:
 		return specific.NewAlgorandChainSpecificObject(
@@ -220,8 +220,7 @@ func getChainSpecific(
 			configuredChain,
 			conf.Id,
 			upstreamConnectorsInfo.internalRequestConnector,
-			conf.Options.InternalTimeout,
-			conf.Options.ValidationInterval*5,
+			conf.Options,
 		)
 	case chains.Solana:
 		return specific.NewSolanaChainSpecificObject(

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -206,7 +206,13 @@ func getChainSpecific(
 	case chains.Ethereum:
 		return specific.NewEvmChainSpecific(conf.Id, upstreamConnectorsInfo.internalRequestConnector, configuredChain, conf.Options)
 	case chains.Aztec:
-		return specific.NewAztecChainSpecificObject(conf.Id, upstreamConnectorsInfo.internalRequestConnector)
+		return specific.NewAztecChainSpecificObject(
+			ctx,
+			conf.Id,
+			upstreamConnectorsInfo.internalRequestConnector,
+			conf.Options.InternalTimeout,
+			conf.Options.ValidationInterval*5,
+		)
 	case chains.Algorand:
 		return specific.NewAlgorandChainSpecificObject(conf.Id, upstreamConnectorsInfo.internalRequestConnector)
 	case chains.Solana:

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -208,6 +208,7 @@ func getChainSpecific(
 	case chains.Aztec:
 		return specific.NewAztecChainSpecificObject(
 			ctx,
+			configuredChain,
 			conf.Id,
 			upstreamConnectorsInfo.internalRequestConnector,
 			conf.Options.InternalTimeout,

--- a/internal/upstreams/validations/aztec_chain_validator.go
+++ b/internal/upstreams/validations/aztec_chain_validator.go
@@ -40,7 +40,7 @@ func NewAztecChainValidator(
 func (a *AztecChainValidator) Validate() ValidationSettingResult {
 	chainId, err := a.getChainId()
 	if err != nil {
-		log.Error().Err(err).Msgf("failed to get chainId of aztec upstream '%s'", a.upstreamId)
+		log.Error().Err(err).Msgf("failed to get chainId of chain %s upstream '%s'", a.chain.Chain, a.upstreamId)
 		return SettingsError
 	}
 	if chainId == "" {
@@ -64,7 +64,7 @@ func (a *AztecChainValidator) getChainId() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getChainId", nil, a.chain.Chain)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getChainId", []string{}, a.chain.Chain)
 	if err != nil {
 		return "", err
 	}

--- a/internal/upstreams/validations/aztec_chain_validator.go
+++ b/internal/upstreams/validations/aztec_chain_validator.go
@@ -1,0 +1,118 @@
+package validations
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+var errAztecEmptyChainId = errors.New("aztec node returned empty chain id")
+
+type AztecChainValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           *chains.ConfiguredChain
+	internalTimeout time.Duration
+}
+
+func NewAztecChainValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+) *AztecChainValidator {
+	return &AztecChainValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (a *AztecChainValidator) Validate() ValidationSettingResult {
+	chainId, err := a.getChainId()
+	if err != nil {
+		log.Error().Err(err).Msgf("failed to get chainId of aztec upstream '%s'", a.upstreamId)
+		return SettingsError
+	}
+	if chainId == "" {
+		log.Error().Msgf("aztec upstream '%s' returned empty chain id", a.upstreamId)
+		return SettingsError
+	}
+	if !chainIdEqual(chainId, a.chain.ChainId) {
+		log.Error().Msgf(
+			"'%s' is specified for upstream '%s' with chainId '%s', but the node reports chainId '%s'",
+			a.chain.Chain.String(),
+			a.upstreamId,
+			a.chain.ChainId,
+			chainId,
+		)
+		return FatalSettingError
+	}
+	return Valid
+}
+
+func (a *AztecChainValidator) getChainId() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getChainId", nil, a.chain.Chain)
+	if err != nil {
+		return "", err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return "", response.GetError()
+	}
+
+	raw := response.ResponseResult()
+	if len(raw) == 0 {
+		return "", errAztecEmptyChainId
+	}
+
+	// node_getChainId may return either a JSON number (e.g. 1) or a JSON string ("1" / "0x1")
+	var asString string
+	if err := sonic.Unmarshal(raw, &asString); err == nil {
+		return strings.TrimSpace(asString), nil
+	}
+	var asNumber uint64
+	if err := sonic.Unmarshal(raw, &asNumber); err == nil {
+		return strings.ToLower((&big.Int{}).SetUint64(asNumber).String()), nil
+	}
+	return "", errAztecEmptyChainId
+}
+
+// chainIdEqual compares two chainId strings tolerating decimal/hex formats and 0x prefix.
+func chainIdEqual(a, b string) bool {
+	if strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b)) {
+		return true
+	}
+	an, aok := parseChainIdString(a)
+	bn, bok := parseChainIdString(b)
+	return aok && bok && an.Cmp(bn) == 0
+}
+
+func parseChainIdString(value string) (*big.Int, bool) {
+	v := strings.TrimSpace(strings.ToLower(value))
+	if v == "" {
+		return nil, false
+	}
+	base := 10
+	if strings.HasPrefix(v, "0x") {
+		v = strings.TrimPrefix(v, "0x")
+		base = 16
+	}
+	n, ok := new(big.Int).SetString(v, base)
+	return n, ok
+}
+
+var _ SettingsValidator = (*AztecChainValidator)(nil)

--- a/internal/upstreams/validations/aztec_chain_validator.go
+++ b/internal/upstreams/validations/aztec_chain_validator.go
@@ -3,6 +3,7 @@ package validations
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"time"
@@ -81,14 +82,17 @@ func (a *AztecChainValidator) getChainId() (string, error) {
 
 	// node_getChainId may return either a JSON number (e.g. 1) or a JSON string ("1" / "0x1")
 	var asString string
-	if err := sonic.Unmarshal(raw, &asString); err == nil {
+	if errStr := sonic.Unmarshal(raw, &asString); errStr == nil {
 		return strings.TrimSpace(asString), nil
 	}
 	var asNumber uint64
-	if err := sonic.Unmarshal(raw, &asNumber); err == nil {
+	errNum := sonic.Unmarshal(raw, &asNumber)
+	if errNum == nil {
 		return strings.ToLower((&big.Int{}).SetUint64(asNumber).String()), nil
 	}
-	return "", errAztecEmptyChainId
+	// Neither shape decoded - surface the raw payload and the last decode error
+	// so operators can diagnose misbehaving upstreams returning unexpected shapes.
+	return "", fmt.Errorf("aztec chain id payload %q is not a JSON string or number: %w", string(raw), errNum)
 }
 
 // chainIdEqual compares two chainId strings tolerating decimal/hex formats and 0x prefix.

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -103,13 +103,41 @@ func NewAztecHealthValidator(
 
 var _ HealthValidator = (*AztecHealthValidator)(nil)
 
+// AztecL2Tips models node_getL2Tips. Aztec reshaped the payload between v3 and v4:
+// v3 had every tip flat ({number, hash}); v4 nested proven/finalized/checkpointed
+// as {block: {number, hash}, checkpoint: {...}} and kept proposed flat.
+// AztecVersionedTip transparently handles both shapes.
 type AztecL2Tips struct {
-	Proposed     AztecTip `json:"proposed"`
-	Proven       AztecTip `json:"proven"`
-	Checkpointed AztecTip `json:"checkpointed"`
+	Proposed     AztecTip          `json:"proposed"`
+	Proven       AztecVersionedTip `json:"proven"`
+	Finalized    AztecVersionedTip `json:"finalized"`
+	Checkpointed AztecVersionedTip `json:"checkpointed"`
 }
 
 type AztecTip struct {
 	Number uint64 `json:"number"`
 	Hash   string `json:"hash"`
+}
+
+type AztecVersionedTip struct {
+	Number uint64
+	Hash   string
+}
+
+func (a *AztecVersionedTip) UnmarshalJSON(data []byte) error {
+	var nested struct {
+		Block *AztecTip `json:"block"`
+	}
+	if err := sonic.Unmarshal(data, &nested); err == nil && nested.Block != nil {
+		a.Number = nested.Block.Number
+		a.Hash = nested.Block.Hash
+		return nil
+	}
+	var flat AztecTip
+	if err := sonic.Unmarshal(data, &flat); err != nil {
+		return err
+	}
+	a.Number = flat.Number
+	a.Hash = flat.Hash
+	return nil
 }

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -60,7 +60,7 @@ func (a *AztecHealthValidator) checkReady() error {
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
-		"node_isReady", nil, a.chain,
+		"node_isReady", []string{}, a.chain,
 	)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (a *AztecHealthValidator) checkTips() error {
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
-		"node_getL2Tips", nil, a.chain,
+		"node_getL2Tips", []string{}, a.chain,
 	)
 	if err != nil {
 		return err

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -2,7 +2,6 @@ package validations
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -12,13 +11,36 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var errAztecNotReady = errors.New("aztec node is not ready")
-var errAztecEmptyTips = errors.New("aztec node returned empty L2 tips")
+type aztecHealthValidatorError string
+
+func (e aztecHealthValidatorError) Error() string {
+	return string(e)
+}
+
+const (
+	errAztecNotReady  aztecHealthValidatorError = "aztec node is not ready"
+	errAztecEmptyTips aztecHealthValidatorError = "aztec node returned empty L2 tips"
+)
 
 type AztecHealthValidator struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
+	chain           chains.Chain
 	internalTimeout time.Duration
+}
+
+func NewAztecHealthValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+) *AztecHealthValidator {
+	return &AztecHealthValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
 }
 
 func (a *AztecHealthValidator) Validate() protocol.AvailabilityStatus {
@@ -37,7 +59,9 @@ func (a *AztecHealthValidator) checkReady() error {
 	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_isReady", nil, chains.AZTEC_MAINNET)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"node_isReady", nil, a.chain,
+	)
 	if err != nil {
 		return err
 	}
@@ -61,47 +85,6 @@ func (a *AztecHealthValidator) checkReady() error {
 	}
 	return nil
 }
-
-func (a *AztecHealthValidator) checkTips() error {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
-	defer cancel()
-
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", nil, chains.AZTEC_MAINNET)
-	if err != nil {
-		return err
-	}
-
-	response := a.connector.SendRequest(ctx, request)
-	if response.HasError() {
-		return response.GetError()
-	}
-
-	tips := AztecL2Tips{}
-	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
-		return err
-	}
-	if tips.Proposed.Number == 0 {
-		return errAztecEmptyTips
-	}
-	if tips.Proven.Number > tips.Proposed.Number {
-		return errAztecEmptyTips
-	}
-	return nil
-}
-
-func NewAztecHealthValidator(
-	upstreamId string,
-	connector connectors.ApiConnector,
-	internalTimeout time.Duration,
-) *AztecHealthValidator {
-	return &AztecHealthValidator{
-		upstreamId:      upstreamId,
-		connector:       connector,
-		internalTimeout: internalTimeout,
-	}
-}
-
-var _ HealthValidator = (*AztecHealthValidator)(nil)
 
 // AztecL2Tips models node_getL2Tips. Aztec reshaped the payload between v3 and v4:
 // v3 had every tip flat ({number, hash}); v4 nested proven/finalized/checkpointed
@@ -141,3 +124,34 @@ func (a *AztecVersionedTip) UnmarshalJSON(data []byte) error {
 	a.Hash = flat.Hash
 	return nil
 }
+
+func (a *AztecHealthValidator) checkTips() error {
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"node_getL2Tips", nil, a.chain,
+	)
+	if err != nil {
+		return err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return response.GetError()
+	}
+
+	tips := AztecL2Tips{}
+	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
+		return err
+	}
+	if tips.Proposed.Number == 0 {
+		return errAztecEmptyTips
+	}
+	if tips.Proven.Number > tips.Proposed.Number {
+		return errAztecEmptyTips
+	}
+	return nil
+}
+
+var _ HealthValidator = (*AztecHealthValidator)(nil)

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -15,22 +15,6 @@ import (
 var errAztecNotReady = errors.New("aztec node is not ready")
 var errAztecEmptyTips = errors.New("aztec node returned empty L2 tips")
 
-const (
-	aztecMaxRetries     = 2
-	aztecRetryBackoff   = 200 * time.Millisecond
-	aztecMaxRetryBackoff = time.Second
-)
-
-// transientHttpCodes are 5xx statuses the public Aztec endpoint occasionally
-// emits during deploys / sequencer failovers. They almost always recover on
-// retry, so the health validator should not flap an upstream into Unavailable
-// on a single hit.
-var transientHttpCodes = map[int]struct{}{
-	502: {},
-	503: {},
-	504: {},
-}
-
 type AztecHealthValidator struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
@@ -50,10 +34,15 @@ func (a *AztecHealthValidator) Validate() protocol.AvailabilityStatus {
 }
 
 func (a *AztecHealthValidator) checkReady() error {
-	response, err := a.sendWithRetry("node_isReady")
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_isReady", nil, chains.AZTEC_MAINNET)
 	if err != nil {
 		return err
 	}
+
+	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
 		return response.GetError()
 	}
@@ -74,10 +63,15 @@ func (a *AztecHealthValidator) checkReady() error {
 }
 
 func (a *AztecHealthValidator) checkTips() error {
-	response, err := a.sendWithRetry("node_getL2Tips")
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", nil, chains.AZTEC_MAINNET)
 	if err != nil {
 		return err
 	}
+
+	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
 		return response.GetError()
 	}
@@ -93,50 +87,6 @@ func (a *AztecHealthValidator) checkTips() error {
 		return errAztecEmptyTips
 	}
 	return nil
-}
-
-// sendWithRetry sends the JSON-RPC method up to aztecMaxRetries+1 times when
-// the upstream answers with a transient HTTP 5xx (502/503/504). The final
-// response is returned regardless of success - callers handle non-retryable
-// errors as before.
-func (a *AztecHealthValidator) sendWithRetry(method string) (protocol.ResponseHolder, error) {
-	var response protocol.ResponseHolder
-	backoff := aztecRetryBackoff
-	for attempt := 0; attempt <= aztecMaxRetries; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
-		request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, nil, chains.AZTEC_MAINNET)
-		if err != nil {
-			cancel()
-			return nil, err
-		}
-		response = a.connector.SendRequest(ctx, request)
-		cancel()
-
-		if !isTransientHttpStatus(response) {
-			return response, nil
-		}
-		if attempt == aztecMaxRetries {
-			break
-		}
-		log.Warn().Msgf(
-			"aztec upstream '%s' answered HTTP %d for %s; retry %d/%d after %s",
-			a.upstreamId, response.ResponseCode(), method, attempt+1, aztecMaxRetries, backoff,
-		)
-		time.Sleep(backoff)
-		backoff *= 2
-		if backoff > aztecMaxRetryBackoff {
-			backoff = aztecMaxRetryBackoff
-		}
-	}
-	return response, nil
-}
-
-func isTransientHttpStatus(response protocol.ResponseHolder) bool {
-	if response == nil || !response.HasError() {
-		return false
-	}
-	_, ok := transientHttpCodes[response.ResponseCode()]
-	return ok
 }
 
 func NewAztecHealthValidator(

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -1,0 +1,115 @@
+package validations
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+var errAztecNotReady = errors.New("aztec node is not ready")
+var errAztecEmptyTips = errors.New("aztec node returned empty L2 tips")
+
+type AztecHealthValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+}
+
+func (a *AztecHealthValidator) Validate() protocol.AvailabilityStatus {
+	if err := a.checkReady(); err != nil {
+		log.Error().Err(err).Msgf("aztec upstream '%s' health validation failed", a.upstreamId)
+		return protocol.Unavailable
+	}
+	if err := a.checkTips(); err != nil {
+		log.Error().Err(err).Msgf("aztec upstream '%s' tips validation failed", a.upstreamId)
+		return protocol.Unavailable
+	}
+	return protocol.Available
+}
+
+func (a *AztecHealthValidator) checkReady() error {
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_isReady", nil, chains.AZTEC_MAINNET)
+	if err != nil {
+		return err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return response.GetError()
+	}
+
+	var ready bool
+	if err := sonic.Unmarshal(response.ResponseResult(), &ready); err != nil {
+		// some nodes wrap the answer as a string "true"/"false"
+		var s string
+		if err2 := sonic.Unmarshal(response.ResponseResult(), &s); err2 != nil {
+			return err
+		}
+		ready = s == "true"
+	}
+	if !ready {
+		return errAztecNotReady
+	}
+	return nil
+}
+
+func (a *AztecHealthValidator) checkTips() error {
+	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", nil, chains.AZTEC_MAINNET)
+	if err != nil {
+		return err
+	}
+
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return response.GetError()
+	}
+
+	tips := AztecL2Tips{}
+	if err := sonic.Unmarshal(response.ResponseResult(), &tips); err != nil {
+		return err
+	}
+	if tips.Proposed.Number == 0 {
+		return errAztecEmptyTips
+	}
+	if tips.Proven.Number > tips.Proposed.Number {
+		return errAztecEmptyTips
+	}
+	return nil
+}
+
+func NewAztecHealthValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	internalTimeout time.Duration,
+) *AztecHealthValidator {
+	return &AztecHealthValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+	}
+}
+
+var _ HealthValidator = (*AztecHealthValidator)(nil)
+
+type AztecL2Tips struct {
+	Proposed     AztecTip `json:"proposed"`
+	Proven       AztecTip `json:"proven"`
+	Checkpointed AztecTip `json:"checkpointed"`
+}
+
+type AztecTip struct {
+	Number uint64 `json:"number"`
+	Hash   string `json:"hash"`
+}

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -15,6 +15,22 @@ import (
 var errAztecNotReady = errors.New("aztec node is not ready")
 var errAztecEmptyTips = errors.New("aztec node returned empty L2 tips")
 
+const (
+	aztecMaxRetries     = 2
+	aztecRetryBackoff   = 200 * time.Millisecond
+	aztecMaxRetryBackoff = time.Second
+)
+
+// transientHttpCodes are 5xx statuses the public Aztec endpoint occasionally
+// emits during deploys / sequencer failovers. They almost always recover on
+// retry, so the health validator should not flap an upstream into Unavailable
+// on a single hit.
+var transientHttpCodes = map[int]struct{}{
+	502: {},
+	503: {},
+	504: {},
+}
+
 type AztecHealthValidator struct {
 	upstreamId      string
 	connector       connectors.ApiConnector
@@ -34,15 +50,10 @@ func (a *AztecHealthValidator) Validate() protocol.AvailabilityStatus {
 }
 
 func (a *AztecHealthValidator) checkReady() error {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
-	defer cancel()
-
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_isReady", nil, chains.AZTEC_MAINNET)
+	response, err := a.sendWithRetry("node_isReady")
 	if err != nil {
 		return err
 	}
-
-	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
 		return response.GetError()
 	}
@@ -63,15 +74,10 @@ func (a *AztecHealthValidator) checkReady() error {
 }
 
 func (a *AztecHealthValidator) checkTips() error {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
-	defer cancel()
-
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest("node_getL2Tips", nil, chains.AZTEC_MAINNET)
+	response, err := a.sendWithRetry("node_getL2Tips")
 	if err != nil {
 		return err
 	}
-
-	response := a.connector.SendRequest(ctx, request)
 	if response.HasError() {
 		return response.GetError()
 	}
@@ -87,6 +93,50 @@ func (a *AztecHealthValidator) checkTips() error {
 		return errAztecEmptyTips
 	}
 	return nil
+}
+
+// sendWithRetry sends the JSON-RPC method up to aztecMaxRetries+1 times when
+// the upstream answers with a transient HTTP 5xx (502/503/504). The final
+// response is returned regardless of success - callers handle non-retryable
+// errors as before.
+func (a *AztecHealthValidator) sendWithRetry(method string) (protocol.ResponseHolder, error) {
+	var response protocol.ResponseHolder
+	backoff := aztecRetryBackoff
+	for attempt := 0; attempt <= aztecMaxRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+		request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, nil, chains.AZTEC_MAINNET)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		response = a.connector.SendRequest(ctx, request)
+		cancel()
+
+		if !isTransientHttpStatus(response) {
+			return response, nil
+		}
+		if attempt == aztecMaxRetries {
+			break
+		}
+		log.Warn().Msgf(
+			"aztec upstream '%s' answered HTTP %d for %s; retry %d/%d after %s",
+			a.upstreamId, response.ResponseCode(), method, attempt+1, aztecMaxRetries, backoff,
+		)
+		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > aztecMaxRetryBackoff {
+			backoff = aztecMaxRetryBackoff
+		}
+	}
+	return response, nil
+}
+
+func isTransientHttpStatus(response protocol.ResponseHolder) bool {
+	if response == nil || !response.HasError() {
+		return false
+	}
+	_, ok := transientHttpCodes[response.ResponseCode()]
+	return ok
 }
 
 func NewAztecHealthValidator(

--- a/internal/upstreams/validations/aztec_health_validator.go
+++ b/internal/upstreams/validations/aztec_health_validator.go
@@ -76,7 +76,9 @@ func (a *AztecHealthValidator) checkReady() error {
 		// some nodes wrap the answer as a string "true"/"false"
 		var s string
 		if err2 := sonic.Unmarshal(response.ResponseResult(), &s); err2 != nil {
-			return err
+			// Surface the actual string-decode failure (the bool-decode error
+			// above is just the trigger for the fallback path).
+			return err2
 		}
 		ready = s == "true"
 	}

--- a/pkg/methods/specs/aztec.json
+++ b/pkg/methods/specs/aztec.json
@@ -42,6 +42,40 @@
       "params": []
     },
     {
+      "name": "node_getBlockByArchive",
+      "params": []
+    },
+    {
+      "name": "node_getBlockByHash",
+      "params": []
+    },
+    {
+      "name": "node_getBlockHeaderByArchive",
+      "params": []
+    },
+    {
+      "name": "node_getCheckpointNumber",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "node_getCheckpointedBlockNumber",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "node_getCheckpointedBlocks",
+      "params": []
+    },
+    {
+      "name": "node_getCheckpoints",
+      "params": []
+    },
+    {
       "name": "node_sendTx",
       "params": [],
       "settings": {
@@ -58,6 +92,10 @@
     },
     {
       "name": "node_getTxByHash",
+      "params": []
+    },
+    {
+      "name": "node_getTxsByHash",
       "params": []
     },
     {
@@ -140,11 +178,19 @@
       "params": []
     },
     {
+      "name": "node_getBlockHashMembershipWitness",
+      "params": []
+    },
+    {
       "name": "node_getL1ToL2MessageMembershipWitness",
       "params": []
     },
     {
       "name": "node_getL1ToL2MessageBlock",
+      "params": []
+    },
+    {
+      "name": "node_getL1ToL2MessageCheckpoint",
       "params": []
     },
     {
@@ -160,7 +206,15 @@
       "params": []
     },
     {
+      "name": "node_getPrivateLogsByTags",
+      "params": []
+    },
+    {
       "name": "node_getPublicLogs",
+      "params": []
+    },
+    {
+      "name": "node_getPublicLogsByTagsFromContract",
       "params": []
     },
     {
@@ -222,6 +276,20 @@
     },
     {
       "name": "node_getCurrentBaseFees",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "node_getCurrentMinFees",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "node_getMaxPriorityFees",
       "params": [],
       "settings": {
         "cacheable": false

--- a/pkg/test_utils/test_helpers.go
+++ b/pkg/test_utils/test_helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
 	"github.com/drpcorg/nodecore/pkg/utils"
 	"github.com/failsafe-go/failsafe-go"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -184,6 +185,26 @@ func NewEvmChainSpecific(connector connectors.ApiConnector) *specific.EvmChainSp
 
 func NewSolanaChainSpecific(ctx context.Context, connector connectors.ApiConnector) *specific.SolanaChainSpecificObject {
 	return specific.NewSolanaChainSpecificObject(ctx, chains.GetChain("solana"), "id", connector, 5*time.Second, 10*time.Second)
+}
+
+func NewAztecChainSpecific(ctx context.Context, connector connectors.ApiConnector) *specific.AztecChainSpecificObject {
+	options := &config.UpstreamOptions{
+		InternalTimeout:        5 * time.Second,
+		ValidationInterval:     10 * time.Second,
+		DisableChainValidation: lo.ToPtr(false),
+		DisableHealthValidation: lo.ToPtr(false),
+	}
+	return specific.NewAztecChainSpecificObject(ctx, chains.GetChain("aztec-mainnet"), "id", options, connector)
+}
+
+func NewAlgorandChainSpecific(ctx context.Context, connector connectors.ApiConnector) *specific.AlgorandChainSpecificObject {
+	options := &config.UpstreamOptions{
+		InternalTimeout:        5 * time.Second,
+		ValidationInterval:     10 * time.Second,
+		DisableChainValidation: lo.ToPtr(false),
+		DisableHealthValidation: lo.ToPtr(false),
+	}
+	return specific.NewAlgorandChainSpecificObject(ctx, chains.GetChain("algorand-mainnet"), "id", connector, options)
 }
 
 func CreateChainSupervisor() upstreams.ChainSupervisor {


### PR DESCRIPTION
## Summary
This PR adds comprehensive validation and monitoring infrastructure for Aztec upstreams, including health checks, chain ID validation, lower bound detection, and client version labeling.

## Key Changes

- **New Health Validator** (`aztec_health_validator.go`): Implements health checks for Aztec nodes by validating:
  - Node readiness via `node_isReady` RPC call
  - L2 tips availability and consistency via `node_getL2Tips` RPC call

- **New Chain Validator** (`aztec_chain_validator.go`): Validates that the upstream's reported chain ID matches the configured chain ID, with support for both decimal and hexadecimal formats

- **New Lower Bound Detector** (`aztec_lower_bound.go`): Detects the oldest historic block number available on the node via `node_getWorldStateSyncStatus`, enabling state availability tracking with a 5-minute refresh period

- **Client Labels Detector** (`aztec_detectors.go`): Extracts Aztec node version information via `node_getNodeVersion` for client labeling

- **Updated Chain-Specific Object** (`aztec_chain_specific.go`):
  - Refactored to use `node_getL2Tips` instead of `node_getBlock` for latest block detection
  - Implemented `GetFinalizedBlock()` to return the proven block from L2 tips
  - Added support for both Aztec v3 and v4 API response formats via `AztecVersionedTip` custom unmarshaler
  - Integrated health validators, chain validators, labels processor, and lower bound processor
  - Updated constructor to accept context, configured chain, and timeout parameters

- **Updated Upstream Factory** (`upstream_factory.go`): Modified to pass required parameters (context, configured chain, timeouts) when instantiating Aztec chain-specific objects

- **Extended Method Specs** (`aztec.json`): Added 16 new RPC method definitions including checkpoint-related methods, additional block/transaction queries, and fee-related endpoints

## Notable Implementation Details

- The `AztecVersionedTip` type transparently handles both Aztec v3 (flat `{number, hash}`) and v4 (nested `{block: {number, hash}}`) response formats through custom JSON unmarshaling
- Chain ID comparison is format-agnostic, supporting both decimal and hexadecimal representations with optional `0x` prefix
- Health validation includes fallback handling for nodes that return boolean values as strings
- Lower bound detection returns `nil` on errors to preserve previously cached bounds during transient endpoint issues

https://claude.ai/code/session_01UfVi8B7BPsEPocH6Jfbt9C