### PR TITLE
fix(algorand): emit real block hash and parent hash in HeadEvent

### DIFF
--- a/internal/upstreams/chains_specific/algorand_chain_specific.go
+++ b/internal/upstreams/chains_specific/algorand_chain_specific.go
@@ -2,7 +2,9 @@ package specific
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -97,20 +99,42 @@ func (a *AlgorandChainSpecificObject) SettingsValidators() []validations.Validat
 }
 
 func (a *AlgorandChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
-	request := protocol.NewInternalUpstreamRestRequest("GET", "/v2/status", a.configuredChain.Chain)
-
-	response := a.connector.SendRequest(ctx, request)
-	if response.HasError() {
-		return protocol.ZeroBlock{}, response.GetError()
+	statusReq := protocol.NewInternalUpstreamRestRequest("GET", "/v2/status", a.configuredChain.Chain)
+	statusResp := a.connector.SendRequest(ctx, statusReq)
+	if statusResp.HasError() {
+		return protocol.ZeroBlock{}, statusResp.GetError()
+	}
+	var status validations.AlgorandStatus
+	if err := sonic.Unmarshal(statusResp.ResponseResult(), &status); err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse algorand status: %w", err)
+	}
+	if status.LastRound == 0 {
+		return protocol.ZeroBlock{}, fmt.Errorf("algorand upstream '%s' has no last-round", a.upstreamId)
 	}
 
-	return a.ParseBlock(response.ResponseResult())
+	// Fetch the block header to extract hash + parent hash. Without this the
+	// HeadEvent emitted to subscribers would carry empty BlockId /
+	// ParentBlockId fields, since /v2/status only carries the round number.
+	block, err := a.fetchBlockHeader(ctx, status.LastRound)
+	if err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't fetch algorand block %d header: %w", status.LastRound, err)
+	}
+
+	return protocol.NewBlock(
+		status.LastRound,
+		0,
+		decodeAlgorandHash(block.Seed, block.Txn, status.LastRound),
+		decodeAlgorandHash(block.Prev, "", subOne(status.LastRound)),
+	), nil
 }
 
 func (a *AlgorandChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
 	return a.GetLatestBlock(ctx)
 }
 
+// ParseBlock keeps the legacy shape - some callers feed the raw /v2/status
+// payload here and expect just height back. The hash-aware path lives in
+// GetLatestBlock above.
 func (a *AlgorandChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
 	status := validations.AlgorandStatus{}
 	err := sonic.Unmarshal(blockBytes, &status)
@@ -132,6 +156,78 @@ func (a *AlgorandChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol
 
 func (a *AlgorandChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolder, error) {
 	return nil, fmt.Errorf("algorand does not support websocket subscriptions")
+}
+
+func (a *AlgorandChainSpecificObject) fetchBlockHeader(ctx context.Context, round uint64) (*algorandBlockHeader, error) {
+	path := fmt.Sprintf("/v2/blocks/%d?header-only=true", round)
+	request := protocol.NewInternalUpstreamRestRequest("GET", path, a.configuredChain.Chain)
+	response := a.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	raw := response.ResponseResult()
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty body")
+	}
+	var wrapper algorandBlockResponse
+	if err := sonic.Unmarshal(raw, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Block, nil
+}
+
+type algorandBlockResponse struct {
+	Block algorandBlockHeader `json:"block"`
+}
+
+type algorandBlockHeader struct {
+	Round uint64 `json:"rnd"`
+	Prev  string `json:"prev"`
+	Seed  string `json:"seed"`
+	Txn   string `json:"txn"`
+}
+
+// decodeAlgorandHash maps an algod block-header hash field (32-byte value
+// base64-encoded, sometimes prefixed with "blk-") to a 32-byte HashId. Falls
+// back to a deterministic round encoding so downstream consumers always
+// receive a fixed-width identifier instead of an empty hash.
+func decodeAlgorandHash(primary, secondary string, round uint64) blockchain.HashId {
+	for _, raw := range []string{primary, secondary} {
+		if decoded, ok := tryBase64Decode(raw); ok && len(decoded) > 0 {
+			return blockchain.NewHashIdFromBytes(decoded)
+		}
+	}
+	return blockchain.NewHashIdFromBytes(roundToBytes(round))
+}
+
+func tryBase64Decode(raw string) ([]byte, bool) {
+	raw = strings.TrimPrefix(raw, "blk-")
+	if raw == "" {
+		return nil, false
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil {
+		return decoded, true
+	}
+	if decoded, err := base64.URLEncoding.DecodeString(raw); err == nil {
+		return decoded, true
+	}
+	return nil, false
+}
+
+func roundToBytes(round uint64) []byte {
+	out := make([]byte, 32)
+	for i := 0; i < 8; i++ {
+		out[31-i] = byte(round & 0xff)
+		round >>= 8
+	}
+	return out
+}
+
+func subOne(round uint64) uint64 {
+	if round == 0 {
+		return 0
+	}
+	return round - 1
 }
 
 var _ ChainSpecific = (*AlgorandChainSpecificObject)(nil)

--- a/internal/upstreams/chains_specific/algorand_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/algorand_chain_specific_test.go
@@ -2,6 +2,7 @@ package specific_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 
@@ -53,36 +54,94 @@ func TestAlgorandParseBlockZeroLastRound(t *testing.T) {
 	assert.ErrorContains(t, err, "couldn't parse the algorand status")
 }
 
-func TestAlgorandGetLatestBlock(t *testing.T) {
+// TestAlgorandGetLatestBlockUsesBlockHeader covers the head poll path that
+// derives Hash from `seed` and ParentHash from `prev` returned by
+// /v2/blocks/{round}?header-only=true. algod stores both as base64-encoded
+// 32-byte values.
+func TestAlgorandGetLatestBlockUsesBlockHeader(t *testing.T) {
 	ctx := context.Background()
 	connector := mocks.NewConnectorMock()
-	body := []byte(`{
+
+	statusBody := []byte(`{
 		"last-round": 99999,
 		"catchup-time": 0,
 		"stopped-at-unsupported-round": false
 	}`)
-	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.Rest)
+	statusResp := protocol.NewHttpUpstreamResponse("1", statusBody, 200, protocol.Rest)
 
-	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+	seedBytes := bytes32(0xAA)
+	prevBytes := bytes32(0xBB)
+	blockBody := []byte(`{
+		"block": {
+			"rnd": 99999,
+			"seed": "` + base64.StdEncoding.EncodeToString(seedBytes) + `",
+			"prev": "` + base64.StdEncoding.EncodeToString(prevBytes) + `"
+		}
+	}`)
+	blockResp := protocol.NewHttpUpstreamResponse("1", blockBody, 200, protocol.Rest)
+
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/status"
+	})).Return(statusResp).Once()
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/blocks/99999?header-only=true"
+	})).Return(blockResp).Once()
 
 	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
 	assert.Nil(t, err)
-
 	connector.AssertExpectations(t)
 
-	expected := protocol.NewBlock(99999, 0, blockchain.EmptyHash, blockchain.EmptyHash)
+	expected := protocol.NewBlock(
+		99999, 0,
+		blockchain.NewHashIdFromBytes(seedBytes),
+		blockchain.NewHashIdFromBytes(prevBytes),
+	)
 	assert.Equal(t, expected, block)
 }
 
-func TestAlgorandGetLatestBlockWithError(t *testing.T) {
+// TestAlgorandGetLatestBlockFallsBackToRoundBytes covers the case where the
+// block header is reachable but `seed`/`prev` are missing; the implementation
+// must produce a deterministic 32-byte HashId so consumers never see an empty
+// BlockId/ParentBlockId in the HeadEvent.
+func TestAlgorandGetLatestBlockFallsBackToRoundBytes(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+
+	statusBody := []byte(`{"last-round": 99999, "catchup-time": 0}`)
+	statusResp := protocol.NewHttpUpstreamResponse("1", statusBody, 200, protocol.Rest)
+	blockBody := []byte(`{"block": {"rnd": 99999}}`) // no seed / prev
+	blockResp := protocol.NewHttpUpstreamResponse("1", blockBody, 200, protocol.Rest)
+
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/status"
+	})).Return(statusResp).Once()
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/blocks/99999?header-only=true"
+	})).Return(blockResp).Once()
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	assert.Nil(t, err)
+	connector.AssertExpectations(t)
+
+	assert.Equal(t, uint64(99999), block.Height)
+	assert.Len(t, []byte(block.Hash), 32, "hash must always be 32 bytes")
+	assert.Len(t, []byte(block.ParentHash), 32, "parent hash must always be 32 bytes")
+	// Last 4 bytes of the round-encoded fallback carry the round itself
+	// (big-endian); parent encodes round-1.
+	assert.Equal(t, encodeRound(99999), []byte(block.Hash))
+	assert.Equal(t, encodeRound(99998), []byte(block.ParentHash))
+}
+
+func TestAlgorandGetLatestBlockStatusError(t *testing.T) {
 	ctx := context.Background()
 	connector := mocks.NewConnectorMock()
 	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "block error", nil))
 
-	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/status"
+	})).Return(response).Once()
 
 	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
-
 	connector.AssertExpectations(t)
 	assert.True(t, block.IsFullEmpty())
 
@@ -92,24 +151,81 @@ func TestAlgorandGetLatestBlockWithError(t *testing.T) {
 	assert.Equal(t, "block error", upErr.Message)
 }
 
-func TestAlgorandGetFinalizedBlockDelegatesToLatest(t *testing.T) {
-	// GetFinalizedBlock delegates to GetLatestBlock for Algorand.
+func TestAlgorandGetLatestBlockBlockFetchError(t *testing.T) {
+	// Status succeeds but the block-header fetch fails. We must surface the
+	// error so the head poller skips this tick rather than publishing a
+	// HeadEvent with empty hashes.
 	ctx := context.Background()
 	connector := mocks.NewConnectorMock()
-	body := []byte(`{
-		"last-round": 77777,
-		"catchup-time": 0,
-		"stopped-at-unsupported-round": false
-	}`)
-	response := protocol.NewHttpUpstreamResponse("1", body, 200, protocol.Rest)
+	statusBody := []byte(`{"last-round": 42, "catchup-time": 0}`)
+	statusResp := protocol.NewHttpUpstreamResponse("1", statusBody, 200, protocol.Rest)
+	blockErr := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(2, "boom", nil))
 
-	connector.On("SendRequest", ctx, mock.Anything).Return(response)
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/status"
+	})).Return(statusResp).Once()
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/blocks/42?header-only=true"
+	})).Return(blockErr).Once()
+
+	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't fetch algorand block 42 header")
+}
+
+// TestAlgorandGetFinalizedBlockDelegatesToLatest exercises the same code
+// path - GetFinalizedBlock simply forwards to GetLatestBlock for Algorand,
+// since every committed round is final under pure proof-of-stake.
+func TestAlgorandGetFinalizedBlockDelegatesToLatest(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+
+	statusBody := []byte(`{"last-round": 77777, "catchup-time": 0}`)
+	statusResp := protocol.NewHttpUpstreamResponse("1", statusBody, 200, protocol.Rest)
+	seedBytes := bytes32(0xCC)
+	prevBytes := bytes32(0xDD)
+	blockBody := []byte(`{
+		"block": {
+			"rnd": 77777,
+			"seed": "` + base64.StdEncoding.EncodeToString(seedBytes) + `",
+			"prev": "` + base64.StdEncoding.EncodeToString(prevBytes) + `"
+		}
+	}`)
+	blockResp := protocol.NewHttpUpstreamResponse("1", blockBody, 200, protocol.Rest)
+
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/status"
+	})).Return(statusResp).Once()
+	connector.On("SendRequest", ctx, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+		return r.Method() == "GET#/v2/blocks/77777?header-only=true"
+	})).Return(blockResp).Once()
 
 	block, err := test_utils.NewAlgorandChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
 	assert.Nil(t, err)
-
 	connector.AssertExpectations(t)
 
-	expected := protocol.NewBlock(77777, 0, blockchain.EmptyHash, blockchain.EmptyHash)
+	expected := protocol.NewBlock(
+		77777, 0,
+		blockchain.NewHashIdFromBytes(seedBytes),
+		blockchain.NewHashIdFromBytes(prevBytes),
+	)
 	assert.Equal(t, expected, block)
+}
+
+func bytes32(fill byte) []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = fill
+	}
+	return out
+}
+
+func encodeRound(round uint64) []byte {
+	out := make([]byte, 32)
+	for i := 0; i < 8; i++ {
+		out[31-i] = byte(round & 0xff)
+		round >>= 8
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
`AlgorandChainSpecificObject.GetLatestBlock` only fetched `/v2/status`,
which carries `last-round` but **no hashes**, and built the resulting
`protocol.Block` with `blockchain.EmptyHash` for both `Hash` and
`ParentHash`. The downstream `HeadToApi` mapper passes those through to
`dshackle.HeadEvent`, so subscribers saw `block_id = ""` and
`parent_block_id = ""` for every Algorand head update.

dshackle's `AvmChainSpecific.parseBlock` does it correctly: it follows
the status fetch with `GET /v2/blocks/{round}?header-only=true` and
reads `seed` (current block hash) and `prev` (parent block hash) from
the block header. This PR mirrors that pattern in nodecore.

## Changes
- `GetLatestBlock` now performs a second small RPC after `/v2/status`:
  `GET /v2/blocks/{last-round}?header-only=true` — header-only mode
  keeps the response small.
- `decodeAlgorandHash` decodes algod's base64 32-byte hash fields
  (stripping the optional `blk-` prefix and trying both standard and
  URL base64 alphabets, matching the dshackle implementation).
- When a hash field is missing or unparseable, fall back to a
  deterministic round-based byte encoding so consumers always receive
  a fixed-width identifier instead of an empty hash. dshackle's
  `toHashBytes` does the same thing for parity.
- The legacy `ParseBlock` entry point keeps its previous status-only
  behaviour for backwards compatibility — only `GetLatestBlock` does
  the extra fetch.

## Test plan
- [ ] `go build ./...` clean.
- [ ] Smoke test against algod via the head poller:
  - HeadEvent emitted with `block_id` populated (32-byte hex from `seed`)
    and `parent_block_id` populated (32-byte hex from `prev`).
  - `parent_block_id` of round N matches `block_id` of round N-1
    once two consecutive ticks have run.
- [ ] Configure dshackle to point at this nodecore as an Algorand
  upstream — its log line `Detected node version` now also gets
  non-empty `parent_block_id` in HeadEvent (was `""`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfVi8B7BPsEPocH6Jfbt9C)_