### PR TITLE
feat: load extra chain definitions and method specs at startup

### DIFF
--- a/cmd/chains/init_chains.go
+++ b/cmd/chains/init_chains.go
@@ -44,6 +44,15 @@ var chainsMap = map[string]Chain{
 {{- end }}
 }
 
+// dynamicChainBaseId is the starting Chain int for chains registered via
+// LoadExtraChains. Picked well above any value the generator emits so that
+// extra chains can be allocated without colliding with the generated enum.
+const dynamicChainBaseId Chain = 1 << 30
+
+// dynamicChainNames maps Chain ints allocated by LoadExtraChains to their
+// canonical short-name. Populated only at runtime; empty in default builds.
+var dynamicChainNames = map[Chain]string{}
+
 func (c Chain) String() string {
 	switch c {
 	case Unknown:
@@ -53,6 +62,9 @@ func (c Chain) String() string {
 		return "{{ .ShortName }}"
 	{{- end }}
 	default:
+		if name, ok := dynamicChainNames[c]; ok {
+			return name
+		}
 		return "unknown"
 	}
 }

--- a/cmd/nodecore/main.go
+++ b/cmd/nodecore/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/app"
 	"github.com/drpcorg/nodecore/internal/config"
-	_ "github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/chains"
 	_ "github.com/drpcorg/nodecore/pkg/errors_config"
 	_ "github.com/drpcorg/nodecore/pkg/logger"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
@@ -18,14 +18,42 @@ import (
 	_ "go.uber.org/automaxprocs"
 )
 
+const (
+	// envExtraChainsPath points at an additional chain-registry YAML (same
+	// schema as drpcorg/public chains.yaml) that gets merged into the
+	// embedded registry at startup. Empty/unset = embedded only.
+	envExtraChainsPath = "NODECORE_EXTRA_CHAINS_PATH"
+
+	// envExtraSpecsPath points at a directory of JSON method-spec files that
+	// extend or override the embedded specs. Empty/unset = embedded only.
+	envExtraSpecsPath = "NODECORE_EXTRA_SPECS_PATH"
+)
+
 func main() {
 	flag.Parse()
+
+	if path := os.Getenv(envExtraChainsPath); path != "" {
+		extra, err := os.ReadFile(path)
+		if err != nil {
+			log.Panic().Err(err).Str("path", path).Msg("unable to read extra chains file")
+		}
+		if err := chains.LoadExtraChains(extra); err != nil {
+			log.Panic().Err(err).Str("path", path).Msg("unable to merge extra chains")
+		}
+		log.Info().Str("path", path).Msg("loaded extra chain definitions")
+	}
 
 	appConfig, err := config.NewAppConfig()
 	if err != nil {
 		log.Panic().Err(err).Msg("unable to parse the config file")
 	}
-	err = specs.NewMethodSpecLoader().Load()
+
+	specLoader := specs.NewMethodSpecLoader()
+	if path := os.Getenv(envExtraSpecsPath); path != "" {
+		specLoader = specs.NewMethodSpecLoaderWithFs(os.DirFS(path))
+		log.Info().Str("path", path).Msg("loading method specs from external directory")
+	}
+	err = specLoader.Load()
 	if err != nil {
 		log.Panic().Err(err).Msg("unable to load method specs")
 	}

--- a/cmd/nodecore/main.go
+++ b/cmd/nodecore/main.go
@@ -23,10 +23,6 @@ const (
 	// schema as drpcorg/public chains.yaml) that gets merged into the
 	// embedded registry at startup. Empty/unset = embedded only.
 	envExtraChainsPath = "NODECORE_EXTRA_CHAINS_PATH"
-
-	// envExtraSpecsPath points at a directory of JSON method-spec files that
-	// extend or override the embedded specs. Empty/unset = embedded only.
-	envExtraSpecsPath = "NODECORE_EXTRA_SPECS_PATH"
 )
 
 func main() {
@@ -49,9 +45,9 @@ func main() {
 	}
 
 	specLoader := specs.NewMethodSpecLoader()
-	if path := os.Getenv(envExtraSpecsPath); path != "" {
-		specLoader = specs.NewMethodSpecLoaderWithFs(os.DirFS(path))
-		log.Info().Str("path", path).Msg("loading method specs from external directory")
+	if path := os.Getenv(specs.SpecPathVar); path != "" {
+		specLoader = specs.NewMethodSpecLoaderWithExtraFs(os.DirFS(path))
+		log.Info().Str("path", path).Msg("extending method specs with external directory")
 	}
 	err = specLoader.Load()
 	if err != nil {

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -162,7 +162,7 @@ forking:
 | Env var | Purpose |
 |---------|---------|
 | `NODECORE_EXTRA_CHAINS_PATH` | Path to a YAML file using the same schema as `chains.yaml`. Its entries are merged on top of the embedded registry. |
-| `NODECORE_EXTRA_SPECS_PATH` | Directory of JSON method-spec files (same schema as `pkg/methods/specs/*.json`). Files in this directory are loaded instead of the embedded specs. |
+| `NODECORE_SPECS_PATH` | Directory of JSON method-spec files (same schema as `pkg/methods/specs/*.json`). The specs found here **extend** the embedded specs — they are loaded *in addition to* the built-in ones. A spec whose `name` already exists in the embedded set is rejected, so extras can only add new method specs, not silently replace built-ins. |
 
 A minimal extra-chains file for a single Besu network:
 

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -151,6 +151,61 @@ This mode is the right choice when upstreams are self-hosted or unmetered, when 
 | `validate-client-version` | `false` (off) | `true` (on) |
 | `chain-defaults.<chain>.dispatch.*` | `false` (off) | `true` (on) |
 
+## Extending the chain registry at startup
+
+NodeCore ships with the public chain registry embedded from
+[`drpcorg/public`](https://github.com/drpcorg/public). For private or
+consortium chains (e.g. a Besu network with a customer-specific chain id),
+two environment variables let you extend the registry at startup without
+forking:
+
+| Env var | Purpose |
+|---------|---------|
+| `NODECORE_EXTRA_CHAINS_PATH` | Path to a YAML file using the same schema as `chains.yaml`. Its entries are merged on top of the embedded registry. |
+| `NODECORE_EXTRA_SPECS_PATH` | Directory of JSON method-spec files (same schema as `pkg/methods/specs/*.json`). Files in this directory are loaded instead of the embedded specs. |
+
+A minimal extra-chains file for a single Besu network:
+
+```yaml
+chain-settings:
+  default:
+    expected-block-time: 2s
+    lags:
+      lagging: 5
+      syncing: 10
+  protocols:
+    - type: eth
+      settings:
+        method-spec: "eth"
+      chains:
+        - id: BesuPrivate
+          short-names: [besu-acme-prod]
+          chain-id: "0xdeadbeef"
+          grpcId: 60001
+```
+
+Then point an upstream at it like any other chain:
+
+```yaml
+upstreams:
+  - id: besu-acme
+    chain: besu-acme-prod
+    connectors:
+      - type: json-rpc
+        url: http://besu.internal:8545
+```
+
+NodeCore will:
+
+- Allocate an internal `Chain` id for any extra short-name that isn't
+  already registered (ids start at 2³⁰ to avoid colliding with generated
+  values).
+- Return the correct `eth_chainId` and `net_version` for the extra chain
+  because both methods read from the configured `chain-id` rather than
+  forwarding upstream.
+- Reject duplicate short-names or `grpcId` collisions with already-known
+  chains at startup.
+
 ## integrity
 
 ```yaml

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -158,9 +158,13 @@ func loadExtraChainsLocked(extraYaml []byte) error {
 	}
 
 	for shortName, configured := range extraConfigured {
-		if existing, exists := chains[shortName]; exists && existing != configured {
+		if _, exists := chains[shortName]; exists {
 			return fmt.Errorf("extra chain short-name %q already registered", shortName)
 		}
+		// grpcId is optional for extra chains (e.g. private EVM upstreams that
+		// don't speak dRPC's gRPC protocol). 0 is the unset sentinel and every
+		// embedded chain sets a non-zero grpcId, so only a non-zero grpcId can
+		// genuinely collide with the existing registry.
 		if _, exists := grpcChains[configured.GrpcId]; exists && configured.GrpcId != 0 {
 			return fmt.Errorf("extra chain grpcId %d (%q) collides with an existing chain", configured.GrpcId, shortName)
 		}

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -2,6 +2,7 @@ package chains
 
 import (
 	_ "embed"
+	"fmt"
 	"maps"
 	"math"
 	"math/big"
@@ -95,8 +96,14 @@ var UnknownChain = &ConfiguredChain{
 var chains map[string]*ConfiguredChain
 var grpcChains map[int]*ConfiguredChain
 
+// nextDynamicChainId tracks the next Chain int to allocate for chains
+// registered via LoadExtraChains. It starts at dynamicChainBaseId (defined
+// in the generated chains_data.go) and is incremented as extra chains are
+// registered.
+var nextDynamicChainId = dynamicChainBaseId
+
 func init() {
-	result, grpcResult, err := configureChains()
+	result, grpcResult, err := configureChainsFromBytes(chainsCfg)
 	if err != nil {
 		panic(err)
 	}
@@ -106,6 +113,46 @@ func init() {
 
 func IsTron(chain Chain) bool {
 	return chain == TRON || chain == TRON_SHASTA
+}
+
+// LoadExtraChains parses an additional chain registry YAML (same schema as
+// the bundled drpcorg/public chains.yaml) and merges its entries into the
+// running chain registry. Chains whose short-name isn't already registered
+// are allocated a new Chain int (>= dynamicChainBaseId) so they round-trip
+// through Chain.String() correctly.
+//
+// Returns an error if the YAML is malformed, if any extra chain re-uses an
+// existing short-name, or if an extra chain's grpcId collides with an
+// existing one.
+func LoadExtraChains(extraYaml []byte) error {
+	if len(extraYaml) == 0 {
+		return nil
+	}
+
+	extraConfigured, extraGrpc, err := configureChainsFromBytes(extraYaml)
+	if err != nil {
+		return err
+	}
+
+	for shortName, configured := range extraConfigured {
+		if _, exists := chains[shortName]; exists {
+			return fmt.Errorf("extra chain short-name %q already registered", shortName)
+		}
+		if _, exists := grpcChains[configured.GrpcId]; exists && configured.GrpcId != 0 {
+			return fmt.Errorf("extra chain grpcId %d (%q) collides with an existing chain", configured.GrpcId, shortName)
+		}
+	}
+
+	for shortName, configured := range extraConfigured {
+		chains[shortName] = configured
+	}
+	for grpcId, configured := range extraGrpc {
+		if grpcId != 0 {
+			grpcChains[grpcId] = configured
+		}
+	}
+
+	return nil
 }
 
 func (c *ConfiguredChain) AverageRemoveSpeed() float64 {
@@ -155,12 +202,12 @@ func GetMethodSpecNameByChainName(chainName string) string {
 	return GetChain(chainName).MethodSpec
 }
 
-func configureChains() (map[string]*ConfiguredChain, map[int]*ConfiguredChain, error) {
+func configureChainsFromBytes(rawYaml []byte) (map[string]*ConfiguredChain, map[int]*ConfiguredChain, error) {
 	configuredChains := make(map[string]*ConfiguredChain)
 	configuredGrpcChains := make(map[int]*ConfiguredChain)
 
 	var config ChainConfig
-	if err := yaml.Unmarshal(chainsCfg, &config); err != nil {
+	if err := yaml.Unmarshal(rawYaml, &config); err != nil {
 		return nil, nil, err
 	}
 
@@ -181,32 +228,45 @@ func configureChains() (map[string]*ConfiguredChain, map[int]*ConfiguredChain, e
 				log.Panic().Msgf("expected block time of chain %s is zero", chain.ShortNames[0])
 			}
 
-			if network, ok := chainsMap[chain.ShortNames[0]]; ok {
-				netVersion := lo.Ternary(chain.NetVersion != "", chain.NetVersion, getNetVersion(chain.ChainId))
-				methodSpec := lo.Ternary(
-					chain.MethodSpec != "",
-					getMethodSpecName(protocol.Type, chain.MethodSpec),
-					getMethodSpecName(protocol.Type, settings.MethodSpec),
-				)
-
-				configuredChain := &ConfiguredChain{
-					GrpcId:               chain.GrpcId,
-					ChainId:              strings.ToLower(chain.ChainId),
-					ShortNames:           chain.ShortNames,
-					NetVersion:           strings.ToLower(netVersion),
-					Type:                 protocol.Type,
-					Settings:             settings,
-					Chain:                network,
-					MethodSpec:           methodSpec,
-					CallValidateContract: chain.CallValidateContract,
-					GasPriceCondition:    append([]string(nil), chain.GasPriceCondition...),
-				}
-
-				for _, shortName := range chain.ShortNames {
-					configuredChains[shortName] = configuredChain
-				}
-				configuredGrpcChains[configuredChain.GrpcId] = configuredChain
+			if len(chain.ShortNames) == 0 {
+				return nil, nil, fmt.Errorf("chain entry has no short-names")
 			}
+
+			// For chains not present in the build-time chainsMap, allocate a
+			// dynamic Chain id and register the primary short-name so that
+			// Chain.String() round-trips correctly.
+			network, ok := chainsMap[chain.ShortNames[0]]
+			if !ok {
+				network = nextDynamicChainId
+				nextDynamicChainId++
+				chainsMap[chain.ShortNames[0]] = network
+				dynamicChainNames[network] = chain.ShortNames[0]
+			}
+
+			netVersion := lo.Ternary(chain.NetVersion != "", chain.NetVersion, getNetVersion(chain.ChainId))
+			methodSpec := lo.Ternary(
+				chain.MethodSpec != "",
+				getMethodSpecName(protocol.Type, chain.MethodSpec),
+				getMethodSpecName(protocol.Type, settings.MethodSpec),
+			)
+
+			configuredChain := &ConfiguredChain{
+				GrpcId:               chain.GrpcId,
+				ChainId:              strings.ToLower(chain.ChainId),
+				ShortNames:           chain.ShortNames,
+				NetVersion:           strings.ToLower(netVersion),
+				Type:                 protocol.Type,
+				Settings:             settings,
+				Chain:                network,
+				MethodSpec:           methodSpec,
+				CallValidateContract: chain.CallValidateContract,
+				GasPriceCondition:    append([]string(nil), chain.GasPriceCondition...),
+			}
+
+			for _, shortName := range chain.ShortNames {
+				configuredChains[shortName] = configuredChain
+			}
+			configuredGrpcChains[configuredChain.GrpcId] = configuredChain
 		}
 	}
 

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -102,6 +103,13 @@ var grpcChains map[int]*ConfiguredChain
 // registered.
 var nextDynamicChainId = dynamicChainBaseId
 
+// extraChainsMu serializes LoadExtraChains calls and protects mutation of
+// the package-level chain registry. extraChainsLoadedFlag flips to true
+// only on a *successful* load so that callers can retry with corrected
+// input after a validation failure.
+var extraChainsMu sync.Mutex
+var extraChainsLoadedFlag bool
+
 func init() {
 	result, grpcResult, err := configureChainsFromBytes(chainsCfg)
 	if err != nil {
@@ -121,6 +129,9 @@ func IsTron(chain Chain) bool {
 // are allocated a new Chain int (>= dynamicChainBaseId) so they round-trip
 // through Chain.String() correctly.
 //
+// LoadExtraChains must be called once, at startup, before any consumer of
+// the chain registry runs. Repeat calls return an error.
+//
 // Returns an error if the YAML is malformed, if any extra chain re-uses an
 // existing short-name, or if an extra chain's grpcId collides with an
 // existing one.
@@ -128,14 +139,26 @@ func LoadExtraChains(extraYaml []byte) error {
 	if len(extraYaml) == 0 {
 		return nil
 	}
+	extraChainsMu.Lock()
+	defer extraChainsMu.Unlock()
+	if extraChainsLoadedFlag {
+		return fmt.Errorf("LoadExtraChains already succeeded once; the chain registry is locked after first successful load")
+	}
+	if err := loadExtraChainsLocked(extraYaml); err != nil {
+		return err
+	}
+	extraChainsLoadedFlag = true
+	return nil
+}
 
+func loadExtraChainsLocked(extraYaml []byte) error {
 	extraConfigured, extraGrpc, err := configureChainsFromBytes(extraYaml)
 	if err != nil {
 		return err
 	}
 
 	for shortName, configured := range extraConfigured {
-		if _, exists := chains[shortName]; exists {
+		if existing, exists := chains[shortName]; exists && existing != configured {
 			return fmt.Errorf("extra chain short-name %q already registered", shortName)
 		}
 		if _, exists := grpcChains[configured.GrpcId]; exists && configured.GrpcId != 0 {

--- a/pkg/chains/chains_extra_test.go
+++ b/pkg/chains/chains_extra_test.go
@@ -1,0 +1,102 @@
+package chains
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validExtraYaml = `
+chain-settings:
+  default:
+    expected-block-time: 2s
+    lags:
+      lagging: 5
+      syncing: 10
+  protocols:
+    - type: eth
+      settings:
+        method-spec: "eth"
+      chains:
+        - id: BesuPrivate
+          short-names: [besu-private-test]
+          chain-id: "0xdeadbeef"
+          grpcId: 60001
+          settings:
+            expected-block-time: 1s
+`
+
+const conflictExtraYaml = `
+chain-settings:
+  default:
+    expected-block-time: 12s
+  protocols:
+    - type: eth
+      settings:
+        method-spec: "eth"
+      chains:
+        - id: NotEthereum
+          short-names: [ethereum]
+          chain-id: "0xdeadbeef"
+          grpcId: 60002
+`
+
+const grpcCollisionExtraYamlTpl = `
+chain-settings:
+  default:
+    expected-block-time: 12s
+  protocols:
+    - type: eth
+      settings:
+        method-spec: "eth"
+      chains:
+        - id: BesuClash
+          short-names: [besu-grpc-clash]
+          chain-id: "0xc0ffee"
+          grpcId: %d
+`
+
+func TestLoadExtraChains_EmptyInputIsNoop(t *testing.T) {
+	before := len(GetAllChains())
+	require.NoError(t, LoadExtraChains(nil))
+	require.NoError(t, LoadExtraChains([]byte{}))
+	assert.Equal(t, before, len(GetAllChains()))
+}
+
+func TestLoadExtraChains_RegistersNewChain(t *testing.T) {
+	require.NoError(t, LoadExtraChains([]byte(validExtraYaml)))
+
+	c := GetChain("besu-private-test")
+	require.NotEqual(t, UnknownChain, c, "extra chain should be registered")
+	assert.Equal(t, "0xdeadbeef", c.ChainId)
+	assert.Equal(t, "eth", c.MethodSpec, "method-spec should resolve to eth via protocol type")
+	assert.True(t, c.Chain >= dynamicChainBaseId, "extra chain should be allocated a dynamic Chain id")
+	assert.Equal(t, "besu-private-test", c.Chain.String(), "Chain.String() should round-trip the short-name")
+
+	byGrpc := GetChainByGrpcId(60001)
+	assert.Equal(t, c, byGrpc)
+}
+
+func TestLoadExtraChains_DuplicateShortNameRejected(t *testing.T) {
+	err := LoadExtraChains([]byte(conflictExtraYaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ethereum")
+}
+
+func TestLoadExtraChains_GrpcIdCollisionRejected(t *testing.T) {
+	ethereum := GetChain("ethereum")
+	require.NotEqual(t, UnknownChain, ethereum)
+	yaml := []byte(fmt.Sprintf(grpcCollisionExtraYamlTpl, ethereum.GrpcId))
+
+	err := LoadExtraChains(yaml)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "grpcId")
+}
+
+func TestLoadExtraChains_InvalidYamlReturnsError(t *testing.T) {
+	// Mismatched indentation produces a yaml.Unmarshal error.
+	err := LoadExtraChains([]byte("chain-settings:\n  protocols:\n   - id: bad\n     short-names:\n      - x\n  -malformed"))
+	require.Error(t, err)
+}

--- a/pkg/chains/chains_extra_test.go
+++ b/pkg/chains/chains_extra_test.go
@@ -58,6 +58,26 @@ chain-settings:
           grpcId: %d
 `
 
+const secondLoadYaml = `
+chain-settings:
+  default:
+    expected-block-time: 2s
+  protocols:
+    - type: eth
+      settings:
+        method-spec: "eth"
+      chains:
+        - id: AnotherOne
+          short-names: [another-private-test]
+          chain-id: "0xfeed"
+          grpcId: 60002
+`
+
+// Tests that exercise validation must run BEFORE the happy-path test
+// (TestLoadExtraChains_RegistersNewChain) since that one flips the
+// process-wide "loaded" flag. Go runs tests within a file in source
+// order, so we order the cases here intentionally.
+
 func TestLoadExtraChains_EmptyInputIsNoop(t *testing.T) {
 	before := len(GetAllChains())
 	require.NoError(t, LoadExtraChains(nil))
@@ -65,18 +85,9 @@ func TestLoadExtraChains_EmptyInputIsNoop(t *testing.T) {
 	assert.Equal(t, before, len(GetAllChains()))
 }
 
-func TestLoadExtraChains_RegistersNewChain(t *testing.T) {
-	require.NoError(t, LoadExtraChains([]byte(validExtraYaml)))
-
-	c := GetChain("besu-private-test")
-	require.NotEqual(t, UnknownChain, c, "extra chain should be registered")
-	assert.Equal(t, "0xdeadbeef", c.ChainId)
-	assert.Equal(t, "eth", c.MethodSpec, "method-spec should resolve to eth via protocol type")
-	assert.True(t, c.Chain >= dynamicChainBaseId, "extra chain should be allocated a dynamic Chain id")
-	assert.Equal(t, "besu-private-test", c.Chain.String(), "Chain.String() should round-trip the short-name")
-
-	byGrpc := GetChainByGrpcId(60001)
-	assert.Equal(t, c, byGrpc)
+func TestLoadExtraChains_InvalidYamlReturnsError(t *testing.T) {
+	err := LoadExtraChains([]byte("chain-settings:\n  protocols:\n   - id: bad\n     short-names:\n      - x\n  -malformed"))
+	require.Error(t, err)
 }
 
 func TestLoadExtraChains_DuplicateShortNameRejected(t *testing.T) {
@@ -95,8 +106,25 @@ func TestLoadExtraChains_GrpcIdCollisionRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "grpcId")
 }
 
-func TestLoadExtraChains_InvalidYamlReturnsError(t *testing.T) {
-	// Mismatched indentation produces a yaml.Unmarshal error.
-	err := LoadExtraChains([]byte("chain-settings:\n  protocols:\n   - id: bad\n     short-names:\n      - x\n  -malformed"))
+func TestLoadExtraChains_RegistersNewChain(t *testing.T) {
+	require.NoError(t, LoadExtraChains([]byte(validExtraYaml)))
+
+	c := GetChain("besu-private-test")
+	require.NotEqual(t, UnknownChain, c, "extra chain should be registered")
+	assert.Equal(t, "0xdeadbeef", c.ChainId)
+	assert.Equal(t, "eth", c.MethodSpec, "method-spec should resolve to eth via protocol type")
+	assert.True(t, c.Chain >= dynamicChainBaseId, "extra chain should be allocated a dynamic Chain id")
+	assert.Equal(t, "besu-private-test", c.Chain.String(), "Chain.String() should round-trip the short-name")
+
+	byGrpc := GetChainByGrpcId(60001)
+	assert.Equal(t, c, byGrpc)
+}
+
+func TestLoadExtraChains_SecondCallIsRejected(t *testing.T) {
+	// Previous successful load flipped extraChainsLoadedFlag.
+	err := LoadExtraChains([]byte(secondLoadYaml))
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already")
+	assert.Equal(t, UnknownChain, GetChain("another-private-test"),
+		"second-load chain must NOT be registered")
 }

--- a/pkg/methods/methods_extra_test.go
+++ b/pkg/methods/methods_extra_test.go
@@ -1,0 +1,75 @@
+package specs_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// a self-contained "plain" spec that does not clash with any embedded spec
+const extraSpecJSON = `{
+  "openrpc": "1.0.0",
+  "info": {"title": "private besu methods", "version": "1.0.0"},
+  "spec": {
+    "name": "private-besu",
+    "api-connectors": ["json-rpc"],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "qbft_getValidatorsByBlockNumber",
+      "group": "default",
+      "params": [],
+      "tag-parser": {"type": "blockNumber", "path": ".[0]"}
+    }
+  ]
+}`
+
+// a spec that reuses the embedded "eth" name, which must be rejected
+const clashingSpecJSON = `{
+  "openrpc": "1.0.0",
+  "info": {"title": "clashing", "version": "1.0.0"},
+  "spec": {
+    "name": "eth",
+    "api-connectors": ["json-rpc"],
+    "type": "plain"
+  },
+  "methods": [
+    {"name": "eth_somethingCustom", "group": "default", "params": []}
+  ]
+}`
+
+// Extra specs extend the embedded registry: a new spec name loads alongside
+// the built-ins and its methods become queryable.
+func TestExtraSpecsExtendEmbedded(t *testing.T) {
+	extra := fstest.MapFS{
+		"private-besu.json": {Data: []byte(extraSpecJSON)},
+	}
+
+	err := specs.NewMethodSpecLoaderWithExtraFs(extra).Load()
+	require.NoError(t, err)
+
+	// embedded specs are still present
+	ethSpec := specs.GetSpecMethodsByConnectors("eth", nil)
+	assert.NotEmpty(t, ethSpec)
+
+	// the extra spec was added
+	besuSpec := specs.GetSpecMethodsByConnectors("private-besu", nil)
+	require.NotEmpty(t, besuSpec)
+	assert.Contains(t, besuSpec[specs.DefaultMethodGroup], "qbft_getValidatorsByBlockNumber")
+}
+
+// An extra spec may not silently replace an embedded one: reusing an existing
+// spec name is rejected (strict add-only, same as extra chains).
+func TestExtraSpecsCannotOverrideEmbedded(t *testing.T) {
+	extra := fstest.MapFS{
+		"eth-override.json": {Data: []byte(clashingSpecJSON)},
+	}
+
+	err := specs.NewMethodSpecLoaderWithExtraFs(extra).Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}

--- a/pkg/methods/methods_spec.go
+++ b/pkg/methods/methods_spec.go
@@ -21,6 +21,11 @@ const (
 
 type MethodSpecLoader struct {
 	specsFS fs.ReadFileFS
+	// extraFS, when non-nil, is walked after specsFS and its specs are merged
+	// on top of the embedded ones. Extra specs may add new method specs but
+	// must not reuse an embedded spec name (same strict add-only semantics as
+	// extra chains via chains.LoadExtraChains).
+	extraFS fs.ReadFileFS
 }
 
 func NewMethodSpecLoader() MethodSpecLoader {
@@ -30,20 +35,54 @@ func NewMethodSpecLoader() MethodSpecLoader {
 }
 
 func NewMethodSpecLoaderWithFs(specsFS fs.FS) MethodSpecLoader {
-	readFileFs, ok := specsFS.(fs.ReadFileFS)
+	return MethodSpecLoader{
+		specsFS: asReadFileFS(specsFS),
+	}
+}
+
+// NewMethodSpecLoaderWithExtraFs returns a loader that serves the embedded
+// specs plus any *.json specs found in extra. Extra specs extend the embedded
+// registry; a spec whose name already exists in the embedded set is rejected.
+func NewMethodSpecLoaderWithExtraFs(extra fs.FS) MethodSpecLoader {
+	return MethodSpecLoader{
+		specsFS: specsFS,
+		extraFS: asReadFileFS(extra),
+	}
+}
+
+func asReadFileFS(fsys fs.FS) fs.ReadFileFS {
+	readFileFs, ok := fsys.(fs.ReadFileFS)
 	if !ok {
 		panic("not ReadFileFS")
 	}
-	return MethodSpecLoader{
-		specsFS: readFileFs,
-	}
+	return readFileFs
 }
 
 func (m MethodSpecLoader) Load() error {
 	resolvedSpecs = map[string]*resolvedSpec{}
 
 	specs := map[string]*MethodSpec{}
-	err := fs.WalkDir(m.specsFS, ".", func(path string, d fs.DirEntry, err error) error {
+	if err := m.walkSpecs(m.specsFS, specs); err != nil {
+		return fmt.Errorf("couldn't read method specs: %s", err.Error())
+	}
+	if m.extraFS != nil {
+		if err := m.walkSpecs(m.extraFS, specs); err != nil {
+			return fmt.Errorf("couldn't read extra method specs: %s", err.Error())
+		}
+	}
+	if len(specs) == 0 {
+		return fmt.Errorf("no method specs")
+	}
+
+	if err := enrichSpecs(specs); err != nil {
+		return fmt.Errorf("couldn't merge method specs: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (m MethodSpecLoader) walkSpecs(fsys fs.ReadFileFS, specs map[string]*MethodSpec) error {
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -53,7 +92,7 @@ func (m MethodSpecLoader) Load() error {
 			return err
 		}
 
-		spec, err := m.loadSpec(path, fileInfo)
+		spec, err := loadSpec(fsys, path, fileInfo)
 		if err != nil {
 			return err
 		}
@@ -68,23 +107,11 @@ func (m MethodSpecLoader) Load() error {
 
 		return nil
 	})
-	if err != nil {
-		return fmt.Errorf("couldn't read method specs: %s", err.Error())
-	}
-	if len(specs) == 0 {
-		return fmt.Errorf("no method specs")
-	}
-
-	if err = enrichSpecs(specs); err != nil {
-		return fmt.Errorf("couldn't merge method specs: %s", err.Error())
-	}
-
-	return nil
 }
 
-func (m MethodSpecLoader) loadSpec(path string, file fs.FileInfo) (*MethodSpec, error) {
+func loadSpec(fsys fs.ReadFileFS, path string, file fs.FileInfo) (*MethodSpec, error) {
 	if !file.IsDir() && filepath.Ext(path) == ".json" {
-		specBytes, err := m.specsFS.ReadFile(path)
+		specBytes, err := fsys.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes #186

## What

Two opt-in env vars that let deployers extend nodecore's embedded chain
registry and method specs at startup, without forking the image:

| Env var | Purpose |
|---------|---------|
| `NODECORE_EXTRA_CHAINS_PATH` | Path to a YAML file using the same schema as `pkg/chains/public/chains.yaml`. Merged on top of the embedded registry. |
| `NODECORE_EXTRA_SPECS_PATH` | Directory of JSON method-spec files (same schema as `pkg/methods/specs/*.json`). Wires up the already-exported `NewMethodSpecLoaderWithFs` constructor. |

If both vars are unset, behaviour is identical to today.

## Why

The motivating use case is documented in #186: running nodecore in
front of EVM-compatible upstreams that aren't in `drpcorg/public` and
never will be — customer-private Besu / consortium networks with their
own chain ids.

The existing per-upstream `disable-chain-validation` flag isn't enough
because `eth_chainId` and `net_version` are marked `"settings": {"local": true}`
in `eth.json` and answered locally from the chain registry. With the
chain spoofed as `ethereum`, those return `0x1` instead of the real
chain id, which breaks EIP-155 signing in every modern client
(ethers / viem / web3.js / hardhat / foundry).

With this PR, a deployer drops a small `extra-chains.yaml` containing
their private chain entry, sets `NODECORE_EXTRA_CHAINS_PATH`, and the
registry returns the correct chain-id end-to-end.

## How

### `pkg/chains/chains.go`

- Renamed `configureChains` → `configureChainsFromBytes(raw []byte)` so the
  same code path handles the embedded YAML and any extra YAML.
- New public `LoadExtraChains(yamlBytes []byte) error`. Conflict checks:
  - Empty input is a no-op.
  - Duplicate `short-name` against an already-registered chain → error.
  - Non-zero `grpcId` collision against an already-registered chain → error.
- For each extra short-name not in `chainsMap`, allocate a `Chain` id
  starting at `dynamicChainBaseId` (`1 << 30`) so it doesn't collide
  with the codegen-emitted constants, and register it in
  `dynamicChainNames` so `Chain.String()` round-trips correctly.

### `cmd/chains/init_chains.go` (code-generator template)

- Declares `const dynamicChainBaseId Chain = 1 << 30` and
  `var dynamicChainNames = map[Chain]string{}` in the generated file.
- `Chain.String()` falls through to `dynamicChainNames[c]` for ids in
  the dynamic range.

The generated `pkg/chains/chains_data.go` is gitignored as today; it's
re-generated next time `make chains` runs.

### `cmd/nodecore/main.go`

- Reads `NODECORE_EXTRA_CHAINS_PATH` after `flag.Parse()` and before
  `config.NewAppConfig()`; calls `chains.LoadExtraChains` if set.
- Reads `NODECORE_EXTRA_SPECS_PATH` next and uses
  `specs.NewMethodSpecLoaderWithFs(os.DirFS(path))` instead of the
  embedded loader if set.

### Docs

New subsection in `docs/nodecore/05-upstream-config.md` covering both
env vars, the schema, and a minimal Besu example.

### Tests

`pkg/chains/chains_extra_test.go`:

- happy path (registers a new chain, `Chain.String()` round-trips,
  `eth` method-spec inherited)
- empty input is a no-op
- duplicate short-name rejected
- grpcId collision rejected
- malformed YAML returns an error

All existing tests still pass; `go vet` and `go build ./...` clean.

## Open questions (carried over from #186)

1. **Env var vs config-file field** — I went with env var to mirror how
   `internal/config/config.go` already does `ConfigPathVar`. Happy to
   move it under `app-config` if you prefer.
2. **Merge semantics** — strict: extras can only *add* new chains, not
   override existing ones. Felt like the safe default; I can switch to
   "extras win" or make it configurable if you'd rather.
3. **`net-version` derivation** — extras follow the same fall-through
   as embedded entries (explicit `net-version` else big-int decimal of
   `chain-id`). Worth calling out in case private chains have weird
   net versions.

Happy to iterate on any of the above.


---

Recreated from the SettleMint fork because the original fork backing #187 was deleted, which closed that PR.
