### PR TITLE
Fix grpc streaming

### DIFF
--- a/internal/protocol/json_rpc_stream.go
+++ b/internal/protocol/json_rpc_stream.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/rs/zerolog"
@@ -38,6 +39,232 @@ func ResponseCanBeStreamed(reader *bufio.Reader, chunkSize int) bool {
 	}
 
 	return true
+}
+
+// counterKind selects how ResultCounter interprets bytes.
+type counterKind uint8
+
+const (
+	counterObject counterKind = iota + 1
+	counterArray
+	counterString
+	counterScalar
+)
+
+// ResultCounter is a byte-level state machine that tracks how much of a
+// JSON value's structure is still open.
+//
+// For object/array kinds, the counter ignores brackets inside string
+// literals and respects '\\' escapes. For string kind, it tracks escapes.
+// For scalar kind (null / true / false / number), it terminates on the
+// first byte that cannot belong to the scalar (',', '}', ']', or whitespace).
+type ResultCounter struct {
+	kind   counterKind
+	depth  int
+	inStr  bool
+	escape bool
+}
+
+// StepResult tells the caller what to do with the byte just fed to Step.
+type StepResult uint8
+
+const (
+	// StepContinue byte is part of the result; keep reading.
+	StepContinue StepResult = iota
+	// StepFinishHere byte is the last byte of the result (e.g. closing
+	// '}', ']', or '"'); include it, then stop.
+	StepFinishHere
+	// StepStopBefore byte is NOT part of the result (scalar delimiter);
+	// do not include it; stop.
+	StepStopBefore
+)
+
+// Step feeds one byte into the counter and returns what the caller should
+// do with that byte.
+func (c *ResultCounter) Step(b byte) StepResult {
+	switch c.kind {
+	case counterObject:
+		return c.stepBracket(b, '{', '}')
+	case counterArray:
+		return c.stepBracket(b, '[', ']')
+	case counterString:
+		return c.stepString(b)
+	case counterScalar:
+		return c.stepScalar(b)
+	}
+	return StepFinishHere
+}
+
+func (c *ResultCounter) stepBracket(b byte, open, close byte) StepResult {
+	if c.inStr {
+		if c.escape {
+			c.escape = false
+			return StepContinue
+		}
+		switch b {
+		case '\\':
+			c.escape = true
+		case '"':
+			c.inStr = false
+		}
+		return StepContinue
+	}
+	switch b {
+	case '"':
+		c.inStr = true
+	case open:
+		c.depth++
+	case close:
+		if c.depth > 0 {
+			c.depth--
+			if c.depth == 0 {
+				return StepFinishHere
+			}
+		}
+	}
+	return StepContinue
+}
+
+func (c *ResultCounter) stepString(b byte) StepResult {
+	if c.escape {
+		c.escape = false
+		return StepContinue
+	}
+	if b == '\\' {
+		c.escape = true
+		return StepContinue
+	}
+	if b == '"' {
+		if !c.inStr {
+			c.inStr = true
+			return StepContinue
+		}
+		return StepFinishHere
+	}
+	return StepContinue
+}
+
+func (c *ResultCounter) stepScalar(b byte) StepResult {
+	switch b {
+	case ',', '}', ']', ' ', '\t', '\n', '\r':
+		return StepStopBefore
+	}
+	return StepContinue
+}
+
+// ErrNoResultField is returned by FindResultStart when the envelope has no
+// "result" key (either it ends, or it has an "error" before result).
+var ErrNoResultField = errors.New("result field is missing")
+
+// FindResultStart inspects buf — the first chunk of a JSON-RPC response —
+// and locates the byte offset where the "result" value begins. It returns
+// an initialized ResultCounter primed for that value's JSON type (object /
+// array / string / scalar). The caller then byte-counts buf[start:] (and
+// any subsequent bytes from the underlying reader) by calling Step on each
+// byte until Step signals completion.
+//
+// Implementation:
+//   - json.Decoder is used only to walk envelope keys; it stops as soon as
+//     "result" or "error" is encountered.
+//   - The value itself is NOT parsed — its first byte is enough to classify
+//     the JSON type and initialize the counter.
+func FindResultStart(buf []byte) (start int, counter ResultCounter, err error) {
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, ResultCounter{}, fmt.Errorf("unable to parse stream response: %w", err)
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return 0, ResultCounter{}, errors.New("unable to parse stream response: expected json object")
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return 0, ResultCounter{}, fmt.Errorf("unable to parse stream response: %w", err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return 0, ResultCounter{}, errors.New("unable to parse stream response: invalid json key")
+		}
+		if key == "error" {
+			return 0, ResultCounter{}, ErrNoResultField
+		}
+		if key != "result" {
+			if err := skipNextValue(dec); err != nil {
+				return 0, ResultCounter{}, fmt.Errorf("unable to parse stream response: %w", err)
+			}
+			continue
+		}
+		// dec.InputOffset() points just past the closing quote of the
+		// "result" key string. Advance past whitespace, the ':' separator,
+		// and any following whitespace to find the first byte of the value.
+		p := int(dec.InputOffset())
+		for p < len(buf) && isJSONWhitespace(buf[p]) {
+			p++
+		}
+		if p >= len(buf) || buf[p] != ':' {
+			return 0, ResultCounter{}, errors.New("unable to parse stream response: missing ':' after result key")
+		}
+		p++
+		for p < len(buf) && isJSONWhitespace(buf[p]) {
+			p++
+		}
+		if p >= len(buf) {
+			return 0, ResultCounter{}, errors.New("unable to parse stream response: truncated result value")
+		}
+		switch buf[p] {
+		case '{':
+			counter = ResultCounter{kind: counterObject}
+		case '[':
+			counter = ResultCounter{kind: counterArray}
+		case '"':
+			counter = ResultCounter{kind: counterString}
+		default:
+			counter = ResultCounter{kind: counterScalar}
+		}
+		return p, counter, nil
+	}
+	return 0, ResultCounter{}, ErrNoResultField
+}
+
+func isJSONWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// skipNextValue consumes the next JSON value from dec without retaining it.
+// It assumes the value's opening token has not yet been read.
+func skipNextValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		for dec.More() {
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+			if err := skipNextValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	case '[':
+		for dec.More() {
+			if err := skipNextValue(dec); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	}
+	return nil
 }
 
 type CloseReader struct {

--- a/internal/protocol/json_rpc_stream_test.go
+++ b/internal/protocol/json_rpc_stream_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessFirstChunk(t *testing.T) {
@@ -34,6 +35,11 @@ func TestProcessFirstChunk(t *testing.T) {
 			body:     []byte(`{"id": 1, "result": {"message": "mess`),
 			expected: true,
 		},
+		{
+			name:     "error key anywhere in envelope then no stream",
+			body:     []byte(`{"id": 1, "result": null, "error": {"code": -1}}`),
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -43,6 +49,217 @@ func TestProcessFirstChunk(t *testing.T) {
 			canBeStreamed := protocol.ResponseCanBeStreamed(reader, protocol.MaxChunkSize)
 
 			assert.Equal(t, test.expected, canBeStreamed)
+		})
+	}
+}
+
+func TestFindResultStart(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantHead string // first few bytes of result (buf[start:])
+	}{
+		{
+			name:     "object result",
+			body:     `{"jsonrpc":"2.0","id":1,"result":{"a":1}}`,
+			wantHead: `{"a":1}}`,
+		},
+		{
+			name:     "array result",
+			body:     `{"jsonrpc":"2.0","id":1,"result":[1,2,3]}`,
+			wantHead: `[1,2,3]}`,
+		},
+		{
+			name:     "string result",
+			body:     `{"jsonrpc":"2.0","id":1,"result":"ok"}`,
+			wantHead: `"ok"}`,
+		},
+		{
+			name:     "scalar number result",
+			body:     `{"jsonrpc":"2.0","id":1,"result":42}`,
+			wantHead: `42}`,
+		},
+		{
+			name:     "scalar null result",
+			body:     `{"jsonrpc":"2.0","id":1,"result":null}`,
+			wantHead: `null}`,
+		},
+		{
+			name:     "whitespace around value",
+			body:     `{"jsonrpc":"2.0","id":1,"result"  :  {"a":1}}`,
+			wantHead: `{"a":1}}`,
+		},
+		{
+			name:     "result is first key",
+			body:     `{"result":[1,2]}`,
+			wantHead: `[1,2]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(te *testing.T) {
+			start, _, err := protocol.FindResultStart([]byte(test.body))
+			require.NoError(te, err)
+			assert.Equal(te, test.wantHead, test.body[start:])
+		})
+	}
+}
+
+func TestFindResultStartTruncatedValue(t *testing.T) {
+	// First chunk contains the "result" key but not the full value — the
+	// value continues in a follow-up chunk. FindResultStart must still
+	// succeed on the first chunk and the counter must carry enough state
+	// (depth, inStr, escape) to keep byte-counting across the chunk
+	// boundary until the value really ends.
+	tests := []struct {
+		name   string
+		chunk1 string
+		chunk2 string
+		want   string
+	}{
+		{
+			name:   "object truncated inside nested array",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":{"big":[1,2`,
+			chunk2: `,3,4]}}`,
+			want:   `{"big":[1,2,3,4]}`,
+		},
+		{
+			name:   "object truncated mid-key",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":{"abc`,
+			chunk2: `def":1}}`,
+			want:   `{"abcdef":1}`,
+		},
+		{
+			name:   "array truncated mid-element",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":[1,2,3`,
+			chunk2: `,4,5]}`,
+			want:   `[1,2,3,4,5]`,
+		},
+		{
+			name:   "string truncated mid-content",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":"abcdef`,
+			chunk2: `ghij"}`,
+			want:   `"abcdefghij"`,
+		},
+		{
+			name:   "string truncated mid-escape so escape state carries",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":"a\`,
+			chunk2: `"b"}`,
+			want:   `"a\"b"`,
+		},
+		{
+			name:   "scalar number truncated",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":123`,
+			chunk2: `456}`,
+			want:   `123456`,
+		},
+		{
+			name:   "object truncated inside string value",
+			chunk1: `{"jsonrpc":"2.0","id":1,"result":{"k":"unfini`,
+			chunk2: `shed"}}`,
+			want:   `{"k":"unfinished"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(te *testing.T) {
+			start, counter, err := protocol.FindResultStart([]byte(test.chunk1))
+			require.NoError(te, err)
+
+			var out bytes.Buffer
+			done := stepThrough(&out, &counter, test.chunk1[start:])
+			require.False(te, done, "value should not have ended in the first chunk")
+			done = stepThrough(&out, &counter, test.chunk2)
+			require.True(te, done, "value should end inside the second chunk")
+			assert.Equal(te, test.want, out.String())
+		})
+	}
+}
+
+// stepThrough feeds chunk to counter byte-by-byte, appending the bytes that
+// belong to the result value to out. Returns true once the counter signals
+// the end of the value.
+func stepThrough(out *bytes.Buffer, counter *protocol.ResultCounter, chunk string) bool {
+	flush := 0
+	for i := 0; i < len(chunk); i++ {
+		switch counter.Step(chunk[i]) {
+		case protocol.StepContinue:
+			continue
+		case protocol.StepFinishHere:
+			out.WriteString(chunk[flush : i+1])
+			return true
+		case protocol.StepStopBefore:
+			out.WriteString(chunk[flush:i])
+			return true
+		}
+	}
+	out.WriteString(chunk[flush:])
+	return false
+}
+
+func TestFindResultStartErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string // substring expected in err
+	}{
+		{name: "error envelope", body: `{"id":1,"error":{"code":-1}}`, want: "result field is missing"},
+		{name: "no result, no error", body: `{"jsonrpc":"2.0","id":1}`, want: "result field is missing"},
+		{name: "top-level array", body: `[1,2,3]`, want: "expected json object"},
+		{name: "empty buffer", body: ``, want: "unable to parse stream response"},
+		{name: "garbage", body: `not json`, want: "unable to parse stream response"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(te *testing.T) {
+			_, _, err := protocol.FindResultStart([]byte(c.body))
+			require.Error(te, err)
+			assert.Contains(te, err.Error(), c.want)
+		})
+	}
+}
+
+func TestResultCounter(t *testing.T) {
+	// Each case feeds the bytes of `result` one at a time and asserts the
+	// counter emits the expected sequence of result bytes — the same bytes
+	// the streaming output should write.
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "object", body: `{"a":1}`, want: `{"a":1}`},
+		{name: "nested objects", body: `{"a":{"b":{"c":1}}}xtra`, want: `{"a":{"b":{"c":1}}}`},
+		{name: "object containing array", body: `{"arr":[1,2,3]}rest`, want: `{"arr":[1,2,3]}`},
+		{name: "array of objects", body: `[{"a":1},{"b":2}],rest`, want: `[{"a":1},{"b":2}]`},
+		{name: "string with brackets inside", body: `{"a":"]}{["}rest`, want: `{"a":"]}{["}`},
+		{name: "string with escaped quote", body: `{"a":"x\"y"}rest`, want: `{"a":"x\"y"}`},
+		{name: "string with escaped backslash", body: `{"a":"x\\"}rest`, want: `{"a":"x\\"}`},
+		{name: "top-level string with escaped quote", body: `"a\"b"rest`, want: `"a\"b"`},
+		{name: "scalar terminated by comma", body: `12345,more`, want: `12345`},
+		{name: "scalar terminated by close brace", body: `true}`, want: `true`},
+		{name: "scalar terminated by whitespace", body: `false }`, want: `false`},
+		{name: "scalar null", body: `null}`, want: `null`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(te *testing.T) {
+			env := `{"result":` + test.body + `}`
+			start, counter, err := protocol.FindResultStart([]byte(env))
+			require.NoError(te, err)
+			var out bytes.Buffer
+			flush := start
+			for i := start; i < len(env); i++ {
+				switch counter.Step(env[i]) {
+				case protocol.StepContinue:
+					continue
+				case protocol.StepFinishHere:
+					out.Write([]byte(env[flush : i+1]))
+					i = len(env) // break outer
+				case protocol.StepStopBefore:
+					out.Write([]byte(env[flush:i]))
+					i = len(env)
+				}
+			}
+			assert.Equal(te, test.want, out.String())
 		})
 	}
 }

--- a/internal/server/emerald/json_rpc_result_stream.go
+++ b/internal/server/emerald/json_rpc_result_stream.go
@@ -1,234 +1,109 @@
 package emerald
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
 )
 
+// streamJsonRPCResult extracts the bytes of the "result" field from a
+// JSON-RPC response read from reader and writes them verbatim to output.
+//
+// The first up-to-MaxChunkSize bytes are buffered and inspected with a
+// tokenizer just long enough to locate the result value's start offset and
+// classify its JSON type. From that offset onward, bytes flow through
+// unmodified, with a small byte-level state machine
+// (protocol.ResultCounter) tracking bracket nesting / string escapes /
+// scalar termination to decide when the value ends. No JSON tokens are
+// allocated for the result body — it is copied byte-for-byte.
 func streamJsonRPCResult(reader io.Reader, output io.Writer) error {
-	decoder := json.NewDecoder(reader)
-	decoder.UseNumber()
-
-	token, err := decoder.Token()
-	if err != nil {
+	prefix := make([]byte, protocol.MaxChunkSize)
+	n, err := io.ReadFull(reader, prefix)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("unable to parse stream response: %w", err)
 	}
-	objectStart, ok := token.(json.Delim)
-	if !ok || objectStart != '{' {
-		return fmt.Errorf("unable to parse stream response: expected json object")
-	}
+	prefix = prefix[:n]
+	exhausted := err != nil // io.ReadFull only stops short on EOF / UnexpectedEOF
 
-	resultFound := false
-	for decoder.More() {
-		keyToken, err := decoder.Token()
-		if err != nil {
-			return fmt.Errorf("unable to parse stream response: %w", err)
-		}
-		key, ok := keyToken.(string)
-		if !ok {
-			return fmt.Errorf("unable to parse stream response: invalid json key token %T", keyToken)
-		}
-
-		valueToken, err := decoder.Token()
-		if err != nil {
-			return fmt.Errorf("unable to parse stream response: %w", err)
-		}
-		if key == "result" {
-			resultFound = true
-			if err := writeJSONValue(output, decoder, valueToken); err != nil {
-				return err
-			}
-		} else {
-			if err := skipJSONValue(decoder, valueToken); err != nil {
-				return err
-			}
-		}
-	}
-
-	objectEnd, err := decoder.Token()
-	if err != nil {
-		return fmt.Errorf("unable to parse stream response: %w", err)
-	}
-	endDelim, ok := objectEnd.(json.Delim)
-	if !ok || endDelim != '}' {
-		return fmt.Errorf("unable to parse stream response: expected json object end")
-	}
-	if !resultFound {
-		return fmt.Errorf("unable to parse stream response: result field is missing")
-	}
-	return nil
-}
-
-func skipJSONValue(decoder *json.Decoder, token json.Token) error {
-	delim, ok := token.(json.Delim)
-	if !ok {
-		return nil
-	}
-
-	switch delim {
-	case '{':
-		for decoder.More() {
-			keyToken, err := decoder.Token()
-			if err != nil {
-				return fmt.Errorf("unable to parse stream response: %w", err)
-			}
-			if _, ok := keyToken.(string); !ok {
-				return fmt.Errorf("unable to parse stream response: invalid json key token %T", keyToken)
-			}
-			valueToken, err := decoder.Token()
-			if err != nil {
-				return fmt.Errorf("unable to parse stream response: %w", err)
-			}
-			if err := skipJSONValue(decoder, valueToken); err != nil {
-				return err
-			}
-		}
-		end, err := decoder.Token()
-		if err != nil {
-			return fmt.Errorf("unable to parse stream response: %w", err)
-		}
-		endDelim, ok := end.(json.Delim)
-		if !ok || endDelim != '}' {
-			return fmt.Errorf("unable to parse stream response: expected json object end")
-		}
-	case '[':
-		for decoder.More() {
-			valueToken, err := decoder.Token()
-			if err != nil {
-				return fmt.Errorf("unable to parse stream response: %w", err)
-			}
-			if err := skipJSONValue(decoder, valueToken); err != nil {
-				return err
-			}
-		}
-		end, err := decoder.Token()
-		if err != nil {
-			return fmt.Errorf("unable to parse stream response: %w", err)
-		}
-		endDelim, ok := end.(json.Delim)
-		if !ok || endDelim != ']' {
-			return fmt.Errorf("unable to parse stream response: expected json array end")
-		}
-	default:
-		return fmt.Errorf("unable to parse stream response: unexpected json delimiter %q", delim)
-	}
-
-	return nil
-}
-
-func writeJSONValue(output io.Writer, decoder *json.Decoder, token json.Token) error {
-	delim, ok := token.(json.Delim)
-	if ok {
-		switch delim {
-		case '{':
-			if _, err := output.Write([]byte{'{'}); err != nil {
-				return err
-			}
-			first := true
-			for decoder.More() {
-				keyToken, err := decoder.Token()
-				if err != nil {
-					return fmt.Errorf("unable to parse stream response: %w", err)
-				}
-				key, ok := keyToken.(string)
-				if !ok {
-					return fmt.Errorf("unable to parse stream response: invalid json key token %T", keyToken)
-				}
-				if !first {
-					if _, err := output.Write([]byte{','}); err != nil {
-						return err
-					}
-				}
-				keyBytes, err := json.Marshal(key)
-				if err != nil {
-					return err
-				}
-				if _, err := output.Write(keyBytes); err != nil {
-					return err
-				}
-				if _, err := output.Write([]byte{':'}); err != nil {
-					return err
-				}
-
-				valueToken, err := decoder.Token()
-				if err != nil {
-					return fmt.Errorf("unable to parse stream response: %w", err)
-				}
-				if err := writeJSONValue(output, decoder, valueToken); err != nil {
-					return err
-				}
-				first = false
-			}
-
-			end, err := decoder.Token()
-			if err != nil {
-				return fmt.Errorf("unable to parse stream response: %w", err)
-			}
-			endDelim, ok := end.(json.Delim)
-			if !ok || endDelim != '}' {
-				return fmt.Errorf("unable to parse stream response: expected json object end")
-			}
-			_, err = output.Write([]byte{'}'})
-			return err
-		case '[':
-			if _, err := output.Write([]byte{'['}); err != nil {
-				return err
-			}
-			first := true
-			for decoder.More() {
-				if !first {
-					if _, err := output.Write([]byte{','}); err != nil {
-						return err
-					}
-				}
-				valueToken, err := decoder.Token()
-				if err != nil {
-					return fmt.Errorf("unable to parse stream response: %w", err)
-				}
-				if err := writeJSONValue(output, decoder, valueToken); err != nil {
-					return err
-				}
-				first = false
-			}
-
-			end, err := decoder.Token()
-			if err != nil {
-				return fmt.Errorf("unable to parse stream response: %w", err)
-			}
-			endDelim, ok := end.(json.Delim)
-			if !ok || endDelim != ']' {
-				return fmt.Errorf("unable to parse stream response: expected json array end")
-			}
-			_, err = output.Write([]byte{']'})
-			return err
-		default:
-			return fmt.Errorf("unable to parse stream response: unexpected json delimiter %q", delim)
-		}
-	}
-
-	primitive, err := jsonTokenBytes(token)
+	start, counter, err := protocol.FindResultStart(prefix)
 	if err != nil {
 		return err
 	}
-	_, err = output.Write(primitive)
-	return err
+
+	done, err := emitFromBuffer(output, prefix[start:], &counter)
+	if err != nil {
+		return err
+	}
+
+	if !done {
+		if exhausted {
+			return errors.New("unable to parse stream response: result value truncated")
+		}
+		if err := emitFromReader(output, reader, &counter); err != nil {
+			return err
+		}
+	}
+
+	// Drain whatever envelope tail remains so the protocol.CloseReader
+	// wrapping the upstream body observes EOF and closes resp.Body. The
+	// tail is small (a few bytes of trailing keys plus '}').
+	_, _ = io.Copy(io.Discard, reader)
+	return nil
 }
 
-func jsonTokenBytes(token json.Token) ([]byte, error) {
-	switch value := token.(type) {
-	case nil:
-		return []byte("null"), nil
-	case bool:
-		if value {
-			return []byte("true"), nil
+// emitFromBuffer feeds bytes from buf into counter, writing the consumed
+// bytes to output. Returns done=true once the result value's end is
+// observed.
+func emitFromBuffer(output io.Writer, buf []byte, counter *protocol.ResultCounter) (bool, error) {
+	flushStart := 0
+	for i := 0; i < len(buf); i++ {
+		switch counter.Step(buf[i]) {
+		case protocol.StepContinue:
+			continue
+		case protocol.StepFinishHere:
+			if _, err := output.Write(buf[flushStart : i+1]); err != nil {
+				return false, err
+			}
+			return true, nil
+		case protocol.StepStopBefore:
+			if i > flushStart {
+				if _, err := output.Write(buf[flushStart:i]); err != nil {
+					return false, err
+				}
+			}
+			return true, nil
 		}
-		return []byte("false"), nil
-	case string:
-		return json.Marshal(value)
-	case json.Number:
-		return []byte(value.String()), nil
-	default:
-		return json.Marshal(value)
+	}
+	if len(buf) > flushStart {
+		if _, err := output.Write(buf[flushStart:]); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+// emitFromReader reads further chunks from reader and feeds them through
+// counter until the result value's end is observed or reader is exhausted.
+func emitFromReader(output io.Writer, reader io.Reader, counter *protocol.ResultCounter) error {
+	chunk := make([]byte, protocol.MaxChunkSize)
+	for {
+		n, err := reader.Read(chunk)
+		if n > 0 {
+			done, werr := emitFromBuffer(output, chunk[:n], counter)
+			if werr != nil {
+				return werr
+			}
+			if done {
+				return nil
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return errors.New("unable to parse stream response: result value truncated")
+			}
+			return fmt.Errorf("unable to parse stream response: %w", err)
+		}
 	}
 }

--- a/internal/server/emerald/json_rpc_result_stream_test.go
+++ b/internal/server/emerald/json_rpc_result_stream_test.go
@@ -1,6 +1,9 @@
 package emerald
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -34,14 +37,64 @@ func TestStreamJsonRPCResultExtractsPrimitiveResult(t *testing.T) {
 			expected: `12345`,
 		},
 		{
-			name:     "boolean result",
+			name:     "negative number result",
+			response: `{"jsonrpc":"2.0","id":"1","result":-42}`,
+			expected: `-42`,
+		},
+		{
+			name:     "floating number result",
+			response: `{"jsonrpc":"2.0","id":"1","result":3.14159}`,
+			expected: `3.14159`,
+		},
+		{
+			name:     "scientific notation result",
+			response: `{"jsonrpc":"2.0","id":"1","result":1.5e10}`,
+			expected: `1.5e10`,
+		},
+		{
+			name:     "boolean true result",
 			response: `{"jsonrpc":"2.0","id":"1","result":true}`,
 			expected: `true`,
+		},
+		{
+			name:     "boolean false result",
+			response: `{"jsonrpc":"2.0","id":"1","result":false}`,
+			expected: `false`,
 		},
 		{
 			name:     "null result",
 			response: `{"jsonrpc":"2.0","id":"1","result":null}`,
 			expected: `null`,
+		},
+		{
+			name:     "empty string result",
+			response: `{"jsonrpc":"2.0","id":"1","result":""}`,
+			expected: `""`,
+		},
+		{
+			name:     "string with escaped quote",
+			response: `{"jsonrpc":"2.0","id":"1","result":"a\"b"}`,
+			expected: `"a\"b"`,
+		},
+		{
+			name:     "string with escaped backslash",
+			response: `{"jsonrpc":"2.0","id":"1","result":"a\\b"}`,
+			expected: `"a\\b"`,
+		},
+		{
+			name:     "string with unicode escape",
+			response: `{"jsonrpc":"2.0","id":"1","result":"ÿA"}`,
+			expected: `"ÿA"`,
+		},
+		{
+			name:     "string containing brackets",
+			response: `{"jsonrpc":"2.0","id":"1","result":"{[}]"}`,
+			expected: `"{[}]"`,
+		},
+		{
+			name:     "string ending with escaped backslash",
+			response: `{"jsonrpc":"2.0","id":"1","result":"end\\"}`,
+			expected: `"end\\"`,
 		},
 	}
 
@@ -53,6 +106,165 @@ func TestStreamJsonRPCResultExtractsPrimitiveResult(t *testing.T) {
 			assert.Equal(te, tc.expected, out.String())
 		})
 	}
+}
+
+func TestStreamJsonRPCResultContainerEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected string
+	}{
+		{
+			name:     "empty object",
+			response: `{"jsonrpc":"2.0","id":1,"result":{}}`,
+			expected: `{}`,
+		},
+		{
+			name:     "empty array",
+			response: `{"jsonrpc":"2.0","id":1,"result":[]}`,
+			expected: `[]`,
+		},
+		{
+			name:     "array of strings containing close-bracket",
+			response: `{"jsonrpc":"2.0","id":1,"result":["]","["]}`,
+			expected: `["]","["]`,
+		},
+		{
+			name:     "deeply nested object",
+			response: `{"jsonrpc":"2.0","id":1,"result":{"a":{"b":{"c":{"d":{"e":1}}}}}}`,
+			expected: `{"a":{"b":{"c":{"d":{"e":1}}}}}`,
+		},
+		{
+			name:     "array of mixed scalars",
+			response: `{"jsonrpc":"2.0","id":1,"result":[1,"two",true,null,3.14]}`,
+			expected: `[1,"two",true,null,3.14]`,
+		},
+		{
+			name:     "object whose value contains escape inside string with bracket",
+			response: `{"jsonrpc":"2.0","id":1,"result":{"k":"v\"]}{["}}`,
+			expected: `{"k":"v\"]}{["}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(te *testing.T) {
+			var out strings.Builder
+			err := streamJsonRPCResult(strings.NewReader(tc.response), &out)
+			require.NoError(te, err)
+			assert.Equal(te, tc.expected, out.String())
+		})
+	}
+}
+
+func TestStreamJsonRPCResultEnvelopeShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected string
+	}{
+		{
+			name:     "result is the only key",
+			response: `{"result":[1,2,3]}`,
+			expected: `[1,2,3]`,
+		},
+		{
+			name:     "result is the first key",
+			response: `{"result":42,"jsonrpc":"2.0","id":1}`,
+			expected: `42`,
+		},
+		{
+			name:     "result is the last key",
+			response: `{"jsonrpc":"2.0","id":1,"result":42}`,
+			expected: `42`,
+		},
+		{
+			name:     "result preceded by several ignored keys",
+			response: `{"jsonrpc":"2.0","id":1,"meta":{"a":1,"b":[1,2]},"trace":"x","result":"ok"}`,
+			expected: `"ok"`,
+		},
+		{
+			name:     "whitespace formatted envelope",
+			response: "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"result\": {\n    \"a\": 1\n  }\n}",
+			expected: "{\n    \"a\": 1\n  }",
+		},
+		{
+			name:     "tabs and CRLF in envelope",
+			response: "{\r\n\t\"jsonrpc\":\"2.0\",\r\n\t\"id\":1,\r\n\t\"result\":\"ok\"\r\n}",
+			expected: `"ok"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(te *testing.T) {
+			var out strings.Builder
+			err := streamJsonRPCResult(strings.NewReader(tc.response), &out)
+			require.NoError(te, err)
+			assert.Equal(te, tc.expected, out.String())
+		})
+	}
+}
+
+func TestStreamJsonRPCResultLargeResultSpanningChunks(t *testing.T) {
+	// Build a result whose array is much bigger than MaxChunkSize so the
+	// streamer has to read past the buffered prefix and keep byte-counting.
+	inner := strings.Repeat(`{"x":1},`, 4096) + `{"x":1}`
+	body := `{"jsonrpc":"2.0","id":1,"result":[` + inner + `],"trailing":"ignored"}`
+
+	var out strings.Builder
+	err := streamJsonRPCResult(strings.NewReader(body), &out)
+	require.NoError(t, err)
+	assert.Equal(t, "["+inner+"]", out.String())
+}
+
+func TestStreamJsonRPCResultStringResultSpansChunks(t *testing.T) {
+	// A single large string whose closing quote falls well past
+	// MaxChunkSize; escape state must carry correctly across chunks.
+	payload := strings.Repeat(`x`, 16384) + `\"` + strings.Repeat(`y`, 4096)
+	body := `{"jsonrpc":"2.0","id":1,"result":"` + payload + `"}`
+
+	var out strings.Builder
+	err := streamJsonRPCResult(strings.NewReader(body), &out)
+	require.NoError(t, err)
+	assert.Equal(t, `"`+payload+`"`, out.String())
+}
+
+func TestStreamJsonRPCResultScalarSpansChunks(t *testing.T) {
+	// Pathological but legal: a number whose digits stretch past the
+	// first-chunk boundary. Scalar counter must keep going until it sees a
+	// delimiter byte.
+	digits := strings.Repeat("9", 20000)
+	body := `{"jsonrpc":"2.0","id":1,"result":` + digits + `}`
+
+	var out strings.Builder
+	err := streamJsonRPCResult(strings.NewReader(body), &out)
+	require.NoError(t, err)
+	assert.Equal(t, digits, out.String())
+}
+
+func TestStreamJsonRPCResultDrainsTrailingEnvelope(t *testing.T) {
+	// After the result value ends, the streamer should still read through
+	// the rest of the body so the wrapping CloseReader observes EOF and
+	// closes resp.Body. countingReader verifies the bytes after the result
+	// were actually read.
+	body := `{"jsonrpc":"2.0","id":1,"result":42,"ignored":"tail","more":[1,2,3]}`
+	cr := &countingReader{src: strings.NewReader(body)}
+
+	var out strings.Builder
+	err := streamJsonRPCResult(cr, &out)
+	require.NoError(t, err)
+	assert.Equal(t, `42`, out.String())
+	assert.Equal(t, len(body), cr.bytesRead, "entire body should be read so the upstream body closer fires")
+}
+
+func TestStreamJsonRPCResultHandlesSlowReader(t *testing.T) {
+	// A reader that hands out one byte at a time forces emitFromReader to
+	// iterate many times. The output must still be byte-exact.
+	inner := strings.Repeat(`{"x":1},`, 2000) + `{"x":1}`
+	body := `{"jsonrpc":"2.0","id":1,"result":[` + inner + `]}`
+	want := "[" + inner + "]"
+
+	var out strings.Builder
+	err := streamJsonRPCResult(iotest1ByteReader(strings.NewReader(body)), &out)
+	require.NoError(t, err)
+	assert.Equal(t, want, out.String())
 }
 
 func TestStreamJsonRPCResultMissingResult(t *testing.T) {
@@ -69,9 +281,269 @@ func TestStreamJsonRPCResultInvalidTopLevel(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected json object")
 }
 
+func TestStreamJsonRPCResultEmptyBody(t *testing.T) {
+	var out strings.Builder
+	err := streamJsonRPCResult(strings.NewReader(``), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse stream response")
+}
+
+func TestStreamJsonRPCResultGarbage(t *testing.T) {
+	var out strings.Builder
+	err := streamJsonRPCResult(strings.NewReader(`not json at all`), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse stream response")
+}
+
 func TestStreamJsonRPCResultInvalidJSON(t *testing.T) {
 	var out strings.Builder
 	err := streamJsonRPCResult(strings.NewReader(`{"jsonrpc":"2.0","id":"1","result":{"a":1`), &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to parse stream response")
+}
+
+func TestStreamJsonRPCResultTruncated(t *testing.T) {
+	// Every input here is missing the closing bracket / quote of the
+	// "result" value. streamJsonRPCResult must return an error that
+	// mentions truncation rather than silently emit a partial value.
+	//
+	// The cases are split between the two code paths that emit this error:
+	//   (1) "result value truncated"   — body is smaller than MaxChunkSize
+	//                                    so io.ReadFull returns
+	//                                    ErrUnexpectedEOF and emitFromBuffer
+	//                                    runs out of bytes with the counter
+	//                                    still open (`exhausted && !done`
+	//                                    branch in streamJsonRPCResult).
+	//   (2) "result value truncated"   — body is larger than MaxChunkSize so
+	//                                    emitFromReader is engaged and hits
+	//                                    EOF before the counter closes.
+	//   (3) "truncated result value"   — FindResultStart sees the "result"
+	//                                    key but the buffer ends before any
+	//                                    byte of the value is available.
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "object truncated, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"a":1`,
+			want: "result value truncated",
+		},
+		{
+			name: "object truncated mid-key, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"abc`,
+			want: "result value truncated",
+		},
+		{
+			name: "array truncated, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":[1,2,3`,
+			want: "result value truncated",
+		},
+		{
+			name: "string truncated mid-content, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":"abcdef`,
+			want: "result value truncated",
+		},
+		{
+			name: "string truncated mid-escape, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":"a\`,
+			want: "result value truncated",
+		},
+		{
+			name: "scalar truncated, body fits first chunk",
+			body: `{"jsonrpc":"2.0","id":1,"result":12345`,
+			want: "result value truncated",
+		},
+		{
+			name: "object truncated, body spans many chunks",
+			body: `{"jsonrpc":"2.0","id":1,"result":[` + strings.Repeat(`{"x":1},`, 4096),
+			want: "result value truncated",
+		},
+		{
+			name: "string truncated, body spans many chunks",
+			body: `{"jsonrpc":"2.0","id":1,"result":"` + strings.Repeat(`x`, 20000),
+			want: "result value truncated",
+		},
+		{
+			name: "scalar truncated, body spans many chunks",
+			body: `{"jsonrpc":"2.0","id":1,"result":` + strings.Repeat(`9`, 20000),
+			want: "result value truncated",
+		},
+		{
+			name: "body ends right after ':' before value byte",
+			body: `{"jsonrpc":"2.0","id":1,"result":`,
+			want: "truncated result value",
+		},
+		{
+			name: "body ends with whitespace after ':' before value byte",
+			body: `{"jsonrpc":"2.0","id":1,"result":   `,
+			want: "truncated result value",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(te *testing.T) {
+			var out strings.Builder
+			err := streamJsonRPCResult(strings.NewReader(tc.body), &out)
+			require.Error(te, err)
+			assert.Contains(te, err.Error(), tc.want, "got: %s", err.Error())
+			assert.Contains(te, err.Error(), "unable to parse stream response")
+		})
+	}
+}
+
+func TestStreamJsonRPCResultTruncatedByReaderEOFMidStream(t *testing.T) {
+	// emitFromReader sees io.EOF before the counter closes. This is the
+	// network-side variant of the truncation case: bytes arrive then the
+	// connection ends cleanly without delivering the full result.
+	first := []byte(`{"jsonrpc":"2.0","id":1,"result":[` + strings.Repeat(`{"x":1},`, 2048))
+	r := &errReader{data: first, err: io.EOF}
+
+	var out strings.Builder
+	err := streamJsonRPCResult(r, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse stream response")
+	assert.Contains(t, err.Error(), "result value truncated")
+}
+
+func TestStreamJsonRPCResultReaderErrorBeforeFirstChunk(t *testing.T) {
+	// io.ReadFull surfaces a non-EOF reader error — streamer must wrap it
+	// with the "unable to parse stream response" prefix.
+	want := errors.New("upstream connection reset")
+	r := &errReader{err: want}
+
+	var out strings.Builder
+	err := streamJsonRPCResult(r, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse stream response")
+	assert.ErrorIs(t, err, want)
+}
+
+func TestStreamJsonRPCResultReaderErrorDuringStream(t *testing.T) {
+	// First chunk parses fine and the result value starts, but a network
+	// error cuts the stream mid-body. The streamer must propagate the
+	// error rather than emit a silently truncated value.
+	want := errors.New("conn closed")
+	first := []byte(`{"jsonrpc":"2.0","id":1,"result":[` + strings.Repeat(`{"x":1},`, 1024))
+	// Pad first chunk past MaxChunkSize so emitFromReader is engaged.
+	first = append(first, []byte(strings.Repeat(`{"x":1},`, 1024))...)
+	r := &errReader{data: first, err: want}
+
+	var out strings.Builder
+	err := streamJsonRPCResult(r, &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to parse stream response")
+	assert.ErrorIs(t, err, want)
+}
+
+func TestStreamJsonRPCResultWriterError(t *testing.T) {
+	// Writer failure inside the buffered prefix path must surface as an
+	// error from streamJsonRPCResult.
+	body := `{"jsonrpc":"2.0","id":1,"result":[1,2,3,4,5]}`
+	wantErr := errors.New("downstream pipe broken")
+	w := &errWriter{failAt: 2, err: wantErr}
+
+	err := streamJsonRPCResult(strings.NewReader(body), w)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestStreamJsonRPCResultWriterErrorInStreamingPath(t *testing.T) {
+	// Same as above but the failure happens after emitFromReader takes
+	// over, i.e. past the first chunk.
+	inner := strings.Repeat(`{"x":1},`, 4096) + `{"x":1}`
+	body := `{"jsonrpc":"2.0","id":1,"result":[` + inner + `]}`
+	wantErr := errors.New("downstream pipe broken")
+	// Fail well after the first chunk has been emitted.
+	w := &errWriter{failAt: 10000, err: wantErr}
+
+	err := streamJsonRPCResult(strings.NewReader(body), w)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func BenchmarkStreamJsonRPCResult(b *testing.B) {
+	inner := strings.Repeat(`{"address":"0x000000000000000000000000000000000000dead","topics":["0xdeadbeef"],"data":"0x01"},`, 8192)
+	inner = inner[:len(inner)-1] // drop trailing comma
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":[` + inner + `]}`)
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := streamJsonRPCResult(bytes.NewReader(body), io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// --- test helpers -----------------------------------------------------------
+
+// errReader emits the bytes in data, then returns err. If data is empty the
+// error is returned on the first Read.
+type errReader struct {
+	data []byte
+	err  error
+	pos  int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if r.pos >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+// errWriter accepts the first failAt bytes then returns err on subsequent
+// writes.
+type errWriter struct {
+	failAt  int
+	written int
+	err     error
+}
+
+func (w *errWriter) Write(p []byte) (int, error) {
+	remaining := w.failAt - w.written
+	if remaining <= 0 {
+		return 0, w.err
+	}
+	if len(p) <= remaining {
+		w.written += len(p)
+		return len(p), nil
+	}
+	w.written += remaining
+	return remaining, w.err
+}
+
+// countingReader wraps an io.Reader and tracks how many bytes were read,
+// used to verify the streamer drains the body after the result value ends.
+type countingReader struct {
+	src       io.Reader
+	bytesRead int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.src.Read(p)
+	c.bytesRead += n
+	return n, err
+}
+
+// iotest1ByteReader returns a reader that hands out at most one byte per
+// Read call. Equivalent to iotest.OneByteReader but avoids the iotest
+// import (this package keeps its imports minimal).
+func iotest1ByteReader(src io.Reader) io.Reader {
+	return &oneByteReader{src: src}
+}
+
+type oneByteReader struct{ src io.Reader }
+
+func (r *oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return r.src.Read(p[:1])
 }


### PR DESCRIPTION
# Byte-counting JSON-RPC result streamer

## Summary

Replace the token-decoding JSON-RPC result streamer with a byte-counting parser. The streaming hot path no longer tokenizes the response body it is supposed to be passing through.

## Why

`streamJsonRPCResult` previously walked the entire upstream response body
with `encoding/json`'s tokenizer and re-marshaled every value byte-by-byte
through `writeJSONValue` / `jsonTokenBytes`:

- O(response_size) `json.Decoder.Token()` calls.
- One `json.Marshal` per string and number in the result.
- Per-byte `output.Write` for every `{`, `}`, `[`, `]`, `,`, `:`.

For multi-MB payloads (`eth_getLogs` on wide block ranges,
`eth_getBlockByNumber` with full txs) this is a steep CPU bill for a task
that is morally _"find `"result":` and copy its bytes through"_.

Now nodecore solves the same problem differently: parse only enough of the
first chunk to find where the `"result"` value starts, then stream the
remaining bytes verbatim while a tiny state machine counts brackets and
quotes (with `\` escape tracking) to detect where the value ends.

## What changed

### `internal/protocol/json_rpc_stream.go`

Added a byte-level state machine:

- `ResultCounter` — `kind` (`counterObject` / `counterArray` /
  `counterString` / `counterScalar`) + `depth` / `inStr` / `escape`.
- `Step(b byte) StepResult` — feeds one byte and returns
  `StepContinue` / `StepFinishHere` / `StepStopBefore`. Objects and arrays
  ignore brackets inside string literals; strings respect `\` escapes;
  scalars terminate on the first `,`, `}`, `]`, or whitespace byte.
- `FindResultStart(buf []byte)` — walks envelope keys with
  `json.Decoder`, stops the moment it finds `"result"` or `"error"`, and
  returns the byte offset of the `"result"` value's first byte plus a
  `ResultCounter` primed for that value's JSON type.

`ResponseCanBeStreamed` and `CloseReader` are unchanged.

### `internal/server/emerald/json_rpc_result_stream.go`

Rewrote `streamJsonRPCResult`:

1. `io.ReadFull` up to `MaxChunkSize` bytes into a buffer.
2. `protocol.FindResultStart(buf)` → start offset + counter.
3. Walk `buf[start:]` byte-by-byte, feeding `counter.Step`; bytes flow
   directly into `output`. Stop on completion.
4. If the result spans beyond the buffer, keep reading from `reader` in
   `MaxChunkSize` chunks, still byte-counting via `counter.Step`.
5. Drain any trailing envelope bytes so `protocol.CloseReader` observes
   EOF and closes `resp.Body`.

Deleted: `writeJSONValue`, `skipJSONValue`, `jsonTokenBytes` — no JSON
tokens are allocated for the result body anymore.

### Untouched wiring

- `internal/upstreams/connectors/http_connector.go` — same
  `ResponseCanBeStreamed` / `NewCloseReader` calls.
- `internal/server/emerald/native_call_adapter.go` — same
  `streamJsonRPCResult(reader, emitter)` call site.

## Benchmark

| Metric                    |       Old algorithm | New streaming `result` algorithm |                                 Improvement |
| ------------------------- | ------------------: | -------------------------------: | ------------------------------------------: |
| Iterations                |                `86` |                            `828` | Benchmark could run ~`9.6x` more iterations |
| Time per operation        |       `13.06 ms/op` |                     `1.34 ms/op` |                             ~`9.75x` faster |
| Throughput                |        `59.59 MB/s` |                    `581.18 MB/s` |                             ~`9.75x` higher |
| Memory per operation      |    `8,399,170 B/op` |                    `17,928 B/op` |                         ~`468x` less memory |
| Allocations per operation | `524,358 allocs/op` |                   `41 allocs/op` |                ~`12,789x` fewer allocations |

