### PR TITLE
Label balancing

### DIFF
--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -206,7 +206,7 @@ To eliminate these issues, nodecore implements a pure hedging strategy with clea
 
 1. The `retry` section:
    - `attempts` - Maximum number of request attempts, including the initial one. **_Default_**: `3`
-   - `delay` - Base wait time before a retry. Used as the starting backoff. **_Defaults_**: `300ms`
+   - `delay` - Base wait time before a retry. Used as the starting backoff.
    - `max-delay` - Upper bound for retry backoff. The effective delay will never exceed this value
    - `jitter` - Adds randomization to each backoff
 2. The `hedge` section:
@@ -257,6 +257,7 @@ The `chain-defaults` section defines per-chain baseline settings that apply to a
   * `call-limit-size` - Threshold (in bytes) of the smallest acceptable `eth_call` return-data limit. **_Default_**: `1000000` (1 MB)
 * `<chain>.poll-interval` - How often nodecore polls upstreams of that chain for new head / finality information
   * Example: `ethereum.poll-interval: 45s` means all Ethereum upstreams are polled every 45 seconds unless overridden. The **_default_** is `1m` in `mode: default`, and the chain's expected block time in `mode: strict`
+* `<chain>.label-balancing` - Per-chain override of the global [label-balancing](#label-balancing) block. When set it fully replaces the global block for this chain
 
 > **⚠️ Note**: Chain names in this section must match the identifiers defined in [chains.yaml](https://github.com/drpcorg/public/blob/main/chains.yaml)
 
@@ -331,6 +332,78 @@ function sortUpstreams(upstreamData: UpstreamData[]): SortResponse;
 - `calculation-function-file-path` - Path to a custom TypeScript file implementing your own scoring function
 
 > **⚠️ Note**: Both `calculation-function-name` and `calculation-function-file-path` can't be set at the same time.
+
+## label-balancing
+
+```yaml
+upstream-config:
+  # global default — applies to every chain unless overridden under chain-defaults
+  label-balancing:
+    order:
+      - full
+      - archive
+      - fast
+    pass-on-error: false
+    include-default: true
+  chain-defaults:
+    polygon:
+      # per-chain override — fully replaces the global block for this chain
+      label-balancing:
+        order:
+          - archive
+          - full
+  upstreams:
+    - id: up1
+      chain: ethereum
+      group-labels: [full, fast]
+      connectors:
+        - type: json-rpc
+          url: https://full-node.example.com
+    - id: up2
+      chain: ethereum
+      group-labels: [archive]
+      connectors:
+        - type: json-rpc
+          url: https://archive-node.example.com
+```
+
+By default nodecore balances every request across **all** of a chain's upstreams using the
+[score-policy](#score-policy-config) rating. `label-balancing` layers an optional
+**priority-group** mode on top: you tag upstreams with `group-labels` and declare an
+`order` of those labels; requests are served from the highest-priority group first and fall
+through to lower-priority groups when the current group cannot serve. Rating still decides
+ordering **within** a group.
+
+It is configured as a **global default** under `upstream-config.label-balancing` (applies to
+every chain) and can be **overridden per chain** under `chain-defaults.<chain>.label-balancing`
+(the per-chain block fully replaces the global one for that chain). When neither is set,
+behavior is unchanged (pure rating).
+
+How groups are traversed:
+
+- Groups are visited in `order`, then the default group (unlabeled upstreams) last.
+- Within a group, upstreams keep the usual rating order.
+- An upstream is selected **at most once per request**, even if it carries several labels and
+  thus belongs to several groups.
+- An entirely-dead group (every upstream unavailable / method banned / rate-limited) **always**
+  falls through to the next group, regardless of `pass-on-error`.
+
+`label-balancing` fields:
+
+- `order` - Ordered list of group label names, highest priority first. **_Required_** when
+  `label-balancing` is set; entries must be non-empty and unique.
+- `pass-on-error` - Controls retry routing after a *retryable error response* (each error
+  triggers a fresh upstream selection):
+  - `false` (**_default_**) - retry **within the current group** (next-best untried upstream);
+    advance to the next group only once the current group has no selectable upstream left.
+  - `true` - **jump straight to the next group** on a retryable error, skipping any untried
+    upstreams in the current group.
+- `include-default` - When `true` (**_default_**), upstreams carrying none of the `order`
+  labels form a final fallback group tried after all configured groups. When `false`, those
+  upstreams are excluded from routing while label-balancing is active.
+
+The per-upstream `group-labels` field (see [Fields](#fields)) assigns an upstream to one or
+more groups. Labels not present in `order` route the upstream to the default group.
 
 ## upstreams
 
@@ -451,6 +524,7 @@ When NodeCore detects a `.onion` hostname, it automatically routes the connectio
 - `rate-limit` - Inline rate limiting configuration specific to this upstream. Cannot be used together with `rate-limit-budget`. See [Rate Limiting](06-rate-limiting.md) for details
 - `rate-limit-auto-tune` - Automatically adjusts the upstream's outgoing rate limit based on observed error rate and utilization. See [Rate Limiting](06-rate-limiting.md#auto-tune-rate-limiting) for the field semantics
 - `failsafe-config` - Upstream-level failsafe configuration. Only the `retry` policy can be specified at this level (hedging and timeouts are configured globally on `upstream-config.failsafe-config`)
+- `group-labels` - List of priority-group labels this upstream belongs to, used by [label-balancing](#label-balancing). These are **config-defined** labels, independent of the runtime labels produced by label detectors. An upstream may belong to several groups but is still selected at most once per request
 
 ## Validators and labels
 

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -379,6 +379,16 @@ every chain) and can be **overridden per chain** under `chain-defaults.<chain>.l
 (the per-chain block fully replaces the global one for that chain). When neither is set,
 behavior is unchanged (pure rating).
 
+> **⚠️ Requires a retry policy.** Falling through to the next group **after an error** is
+> driven by retries: each retry re-selects an upstream, which is how the request advances
+> within and across groups. Retries only happen when a [`failsafe-config`](#failsafe-config)
+> `retry` policy is configured. Without one,
+> a request makes a **single** upstream selection and will not advance on an error response —
+> so `pass-on-error` and within-group error retries have no effect. (Falling through a group
+> that is *entirely* unavailable at selection time still works without retries, since that
+> happens within the single selection.) Set a `retry` policy with enough `attempts` to cover
+> the upstreams you expect to traverse.
+
 How groups are traversed:
 
 - Groups are visited in `order`, then the default group (unlabeled upstreams) last.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -273,7 +273,6 @@ func TestReadFullConfig(t *testing.T) {
 					FailsafeConfig: &config.FailsafeConfig{
 						RetryConfig: &config.RetryConfig{
 							Attempts: 7,
-							Delay:    300 * time.Millisecond,
 						},
 					},
 					Connectors: []*config.ApiConnectorConfig{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -242,6 +242,10 @@ func (u *UpstreamConfig) setDefaults() {
 		u.ScorePolicyConfig = &ScorePolicyConfig{}
 	}
 	u.ScorePolicyConfig.setDefaults()
+	u.LabelBalancing.setDefaults()
+	for _, chainDefaults := range u.ChainDefaults {
+		chainDefaults.LabelBalancing.setDefaults()
+	}
 	for _, upstream := range u.Upstreams {
 		chainDefaults := u.ChainDefaults[upstream.ChainName]
 		upstream.setDefaults(chainDefaults, u.Mode)
@@ -273,6 +277,15 @@ func (r *RateLimitAutoTuneConfig) setDefaults() {
 	}
 	if r.InitRateLimitPeriod == 0 {
 		r.InitRateLimitPeriod = 1 * time.Second
+	}
+}
+
+func (l *LabelBalancingConfig) setDefaults() {
+	if l == nil {
+		return
+	}
+	if l.IncludeDefault == nil {
+		l.IncludeDefault = new(true)
 	}
 }
 
@@ -342,9 +355,6 @@ func (m *MethodsConfig) setDefaults() {
 func (r *RetryConfig) setDefaults() {
 	if r.Attempts == 0 {
 		r.Attempts = 3
-	}
-	if r.Delay == 0 {
-		r.Delay = 300 * time.Millisecond
 	}
 }
 

--- a/internal/config/label_balancing_test.go
+++ b/internal/config/label_balancing_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelBalancingValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		order     []string
+		errSubstr string
+	}{
+		{name: "empty order", order: nil, errSubstr: "at least one label"},
+		{name: "empty label", order: []string{"full", ""}, errSubstr: "must not contain an empty label"},
+		{name: "duplicate label", order: []string{"full", "archive", "full"}, errSubstr: "duplicate label 'full'"},
+		{name: "valid", order: []string{"full", "archive", "fast"}, errSubstr: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(te *testing.T) {
+			err := (&LabelBalancingConfig{Order: test.order}).validate()
+			if test.errSubstr == "" {
+				assert.NoError(te, err)
+			} else {
+				assert.ErrorContains(te, err, test.errSubstr)
+			}
+		})
+	}
+}
+
+func TestLabelBalancingSetDefaultsIncludeDefault(t *testing.T) {
+	l := &LabelBalancingConfig{Order: []string{"full"}}
+	l.setDefaults()
+	require.NotNil(t, l.IncludeDefault)
+	assert.True(t, *l.IncludeDefault, "include-default should default to true")
+
+	l2 := &LabelBalancingConfig{Order: []string{"full"}, IncludeDefault: new(false)}
+	l2.setDefaults()
+	assert.False(t, *l2.IncludeDefault, "explicit include-default=false must be preserved")
+
+	var l3 *LabelBalancingConfig
+	assert.NotPanics(t, func() { l3.setDefaults() }, "nil receiver must be safe")
+}
+
+func TestLabelBalancingFor(t *testing.T) {
+	global := &LabelBalancingConfig{Order: []string{"full"}}
+	perChain := &LabelBalancingConfig{Order: []string{"archive"}}
+	u := &UpstreamConfig{
+		LabelBalancing: global,
+		ChainDefaults: map[string]*ChainDefaults{
+			"polygon":  {LabelBalancing: perChain},
+			"optimism": {},
+		},
+	}
+
+	assert.Same(t, perChain, u.LabelBalancingFor("polygon"), "per-chain override wins")
+	assert.Same(t, global, u.LabelBalancingFor("optimism"), "chain without override falls back to global")
+	assert.Same(t, global, u.LabelBalancingFor("ethereum"), "chain absent from chain-defaults falls back to global")
+
+	noGlobal := &UpstreamConfig{}
+	assert.Nil(t, noGlobal.LabelBalancingFor("ethereum"), "no config anywhere -> nil")
+}

--- a/internal/config/upstream_config.go
+++ b/internal/config/upstream_config.go
@@ -24,7 +24,18 @@ type UpstreamConfig struct {
 	FailsafeConfig    *FailsafeConfig           `yaml:"failsafe-config"`
 	ScorePolicyConfig *ScorePolicyConfig        `yaml:"score-policy-config"`
 	IntegrityConfig   *IntegrityConfig          `yaml:"integrity"`
+	LabelBalancing    *LabelBalancingConfig     `yaml:"label-balancing"`
 	Mode              UpstreamMode              `yaml:"mode"`
+}
+
+// LabelBalancingFor resolves the effective label-balancing config for a chain:
+// a per-chain override under chain-defaults wins over the global default; if
+// neither is set it returns nil (rating-only balancing).
+func (u *UpstreamConfig) LabelBalancingFor(chain string) *LabelBalancingConfig {
+	if chainDefaults, ok := u.ChainDefaults[chain]; ok && chainDefaults.LabelBalancing != nil {
+		return chainDefaults.LabelBalancing
+	}
+	return u.LabelBalancing
 }
 
 type UpstreamMode string
@@ -55,6 +66,7 @@ type Upstream struct {
 	RateLimitBudget   string                   `yaml:"rate-limit-budget"`
 	RateLimit         *RateLimiterConfig       `yaml:"rate-limit"`
 	RateLimitAutoTune *RateLimitAutoTuneConfig `yaml:"rate-limit-auto-tune"`
+	GroupLabels       []string                 `yaml:"group-labels"`
 }
 
 func (u *Upstream) GetApiConnectorTypes() []specs.ApiConnectorType {
@@ -96,8 +108,45 @@ func (u *Upstream) GetBestConnector(upstreamMode UpstreamMode) specs.ApiConnecto
 }
 
 type ChainDefaults struct {
-	PollInterval time.Duration   `yaml:"poll-interval"`
-	Options      *chains.Options `yaml:"options"`
+	PollInterval   time.Duration         `yaml:"poll-interval"`
+	Options        *chains.Options       `yaml:"options"`
+	LabelBalancing *LabelBalancingConfig `yaml:"label-balancing"`
+}
+
+// LabelBalancingConfig enables priority-group balancing: upstreams tagged with
+// group-labels are served in the configured Order, falling through to the next
+// group when the current one can't serve. Within a group the usual rating order
+// applies. See docs/nodecore/05-upstream-config.md.
+type LabelBalancingConfig struct {
+	// Order is the ordered list of group label names, highest priority first.
+	Order []string `yaml:"order"`
+	// PassOnError, when true, jumps to the next group on a retryable error even
+	// if the current group still has untried upstreams. When false (default), a
+	// retryable error retries within the current group and only advances once
+	// the current group has no selectable upstream left.
+	PassOnError bool `yaml:"pass-on-error"`
+	// IncludeDefault, when true (the default), routes upstreams that carry none
+	// of the Order labels as a final fallback group tried after all configured
+	// groups. When false those upstreams are excluded while label-balancing is
+	// active.
+	IncludeDefault *bool `yaml:"include-default"`
+}
+
+func (l *LabelBalancingConfig) validate() error {
+	if len(l.Order) == 0 {
+		return errors.New("label-balancing order must contain at least one label")
+	}
+	seen := mapset.NewThreadUnsafeSet[string]()
+	for _, label := range l.Order {
+		if label == "" {
+			return errors.New("label-balancing order must not contain an empty label")
+		}
+		if seen.Contains(label) {
+			return fmt.Errorf("label-balancing order contains a duplicate label '%s'", label)
+		}
+		seen.Add(label)
+	}
+	return nil
 }
 
 type FailsafeConfig struct {
@@ -218,6 +267,12 @@ func (u *UpstreamConfig) validate(rateLimitBudgetNames mapset.Set[string], torPr
 		return fmt.Errorf("error during score policy config validation, cause: %s", err.Error())
 	}
 
+	if u.LabelBalancing != nil {
+		if err := u.LabelBalancing.validate(); err != nil {
+			return fmt.Errorf("error during label-balancing config validation, cause: %s", err.Error())
+		}
+	}
+
 	for chain, chainDefault := range u.ChainDefaults {
 		if !chains.IsSupported(chain) {
 			return fmt.Errorf("error during chain defaults validation, cause: not supported chain %s", chain)
@@ -299,7 +354,7 @@ func (r *RetryConfig) validate() error {
 	if r.Attempts < 1 {
 		return errors.New("the number of attempts can't be less than 1")
 	}
-	if r.Delay <= 0 {
+	if r.Delay < 0 {
 		return errors.New("the retry delay can't be less than 0")
 	}
 	if r.MaxDelay != nil && *r.MaxDelay <= 0 {
@@ -379,6 +434,12 @@ func (u *Upstream) validate(torProxyUrl string) error {
 		return err
 	}
 
+	for _, label := range u.GroupLabels {
+		if label == "" {
+			return errors.New("group-labels must not contain an empty label")
+		}
+	}
+
 	return nil
 }
 
@@ -415,6 +476,11 @@ func (m *MethodsConfig) validate() error {
 func (c *ChainDefaults) validate() error {
 	if c.Options != nil {
 		if err := c.Options.Validate(); err != nil {
+			return err
+		}
+	}
+	if c.LabelBalancing != nil {
+		if err := c.LabelBalancing.validate(); err != nil {
 			return err
 		}
 	}

--- a/internal/upstreams/flow/execution_flow.go
+++ b/internal/upstreams/flow/execution_flow.go
@@ -204,6 +204,11 @@ func (e *BaseExecutionFlow) createStrategy(ctx context.Context, request protocol
 		}
 		return NewSpecificOrderUpstreamStrategy(drpcIds, chainSupervisor).WithAdditionalMatchers(additionalMatchers).WithOrder(order)
 	}
+	if cfg := e.appConfig.UpstreamConfig.LabelBalancingFor(e.chain.String()); cfg != nil {
+		return NewLabelGroupStrategy(e.chain, request.Method(), cfg, chainSupervisor, e.upstreamSupervisor, e.registry).
+			WithAdditionalMatchers(additionalMatchers).
+			WithOrder(order)
+	}
 	return NewRatingStrategy(e.chain, request.Method(), additionalMatchers, chainSupervisor, e.registry).WithOrder(order)
 }
 

--- a/internal/upstreams/flow/label_group_strategy.go
+++ b/internal/upstreams/flow/label_group_strategy.go
@@ -1,0 +1,170 @@
+package flow
+
+import (
+	"sync"
+
+	mapset "github.com/deckarep/golang-set/v2"
+
+	"github.com/drpcorg/nodecore/internal/config"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/rating"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/samber/lo"
+)
+
+// LabelGroupStrategy balances requests across ordered priority groups of
+// upstreams (grouped by config-defined group-labels). Groups are tried in
+// order; within a group the usual rating order applies via filterUpstreams.
+//
+// Like the other strategies, a single instance lives for one request and its
+// selectedUpstreams set accumulates across failsafe attempts (retries/hedges),
+// so an upstream is selected at most once per request even if it belongs to
+// several groups.
+//
+// passOnError controls retry routing after a retryable error (each error
+// triggers a fresh SelectUpstream call):
+//   - false (default): stay in the current group, picking the next untried
+//     upstream; advance only once the current group has no selectable upstream.
+//   - true: jump straight to the next group, skipping untried upstreams in the
+//     current one.
+//
+// In both modes an entirely-dead group (nothing selectable) always falls
+// through to the next group.
+type LabelGroupStrategy struct {
+	groups             [][]string
+	passOnError        bool
+	chainSupervisor    upstreams.ChainSupervisor
+	selectedUpstreams  mapset.Set[string]
+	additionalMatchers []Matcher
+	order              UpstreamOrder
+	currentGroupIdx    int
+	firstCall          bool
+	cursorMu           sync.Mutex
+	mu                 sync.Mutex
+}
+
+// NewLabelGroupStrategy builds a LabelGroupStrategy from the rating registry:
+// it takes the rating-sorted upstreams for (chain, method) and partitions them
+// into ordered groups per the label-balancing config (see PartitionLabelGroups),
+// reading each upstream's config group-labels via the supervisor. This mirrors
+// NewRatingStrategy, which likewise pulls its sorted list from the registry.
+func NewLabelGroupStrategy(
+	chain chains.Chain,
+	method string,
+	labelBalancing *config.LabelBalancingConfig,
+	chainSupervisor upstreams.ChainSupervisor,
+	upstreamSupervisor upstreams.UpstreamSupervisor,
+	registry *rating.RatingRegistry,
+) *LabelGroupStrategy {
+	sorted := registry.GetSortedUpstreams(chain, method)
+	includeDefault := labelBalancing.IncludeDefault == nil || *labelBalancing.IncludeDefault
+	groups := PartitionLabelGroups(sorted, labelBalancing.Order, includeDefault, func(id string) mapset.Set[string] {
+		up := upstreamSupervisor.GetUpstream(id)
+		if up == nil {
+			return mapset.NewThreadUnsafeSet[string]()
+		}
+		return up.GetGroupLabels()
+	})
+	return NewLabelGroupStrategyWithGroups(groups, labelBalancing.PassOnError, chainSupervisor)
+}
+
+// NewLabelGroupStrategyWithGroups builds a LabelGroupStrategy from already
+// partitioned groups. NewLabelGroupStrategy is the usual entry point; this one
+// is handy when the ordered groups are known up front (e.g. tests).
+func NewLabelGroupStrategyWithGroups(groups [][]string, passOnError bool, chainSupervisor upstreams.ChainSupervisor) *LabelGroupStrategy {
+	return &LabelGroupStrategy{
+		groups:            groups,
+		passOnError:       passOnError,
+		chainSupervisor:   chainSupervisor,
+		selectedUpstreams: mapset.NewThreadUnsafeSet[string](),
+		firstCall:         true,
+	}
+}
+
+func (s *LabelGroupStrategy) WithOrder(order UpstreamOrder) *LabelGroupStrategy {
+	s.order = order
+	return s
+}
+
+func (s *LabelGroupStrategy) WithAdditionalMatchers(additionalMatchers []Matcher) *LabelGroupStrategy {
+	s.additionalMatchers = additionalMatchers
+	return s
+}
+
+func (s *LabelGroupStrategy) SelectUpstream(request protocol.RequestHolder) (string, error) {
+	if len(s.groups) == 0 {
+		return "", protocol.NoAvailableUpstreamsError()
+	}
+
+	s.cursorMu.Lock()
+	if s.passOnError && !s.firstCall {
+		// a retryable error brought us back here: skip the rest of the current group
+		s.currentGroupIdx++
+	}
+	s.firstCall = false
+	idx := s.currentGroupIdx
+	s.cursorMu.Unlock()
+
+	var currentReason MatchResponse
+	var trace *UpstreamsMatchTrace
+	for ; idx < len(s.groups); idx++ {
+		selectedUpstream, reason, groupTrace := filterUpstreams(&s.mu, request, s.groups[idx], s.chainSupervisor, s.selectedUpstreams, s.additionalMatchers, s.order)
+		trace = groupTrace
+		if selectedUpstream != "" {
+			s.cursorMu.Lock()
+			s.currentGroupIdx = idx
+			s.cursorMu.Unlock()
+			return selectedUpstream, nil
+		}
+		// group is exhausted (all tried) or dead (nothing selectable) -> fall through
+		if reason != nil && (currentReason == nil || reason.Type() < currentReason.Type()) {
+			currentReason = reason
+		}
+	}
+	s.cursorMu.Lock()
+	s.currentGroupIdx = idx
+	s.cursorMu.Unlock()
+
+	return "", selectionError(currentReason, trace)
+}
+
+var _ UpstreamStrategy = (*LabelGroupStrategy)(nil)
+
+// PartitionLabelGroups builds the ordered group lists for a LabelGroupStrategy.
+// sortedIds must be in rating order; that order is preserved within each group.
+// For every label in order a group is produced containing the ids carrying that
+// label (an id may appear in several groups). When includeDefault is true, ids
+// carrying none of the order labels are appended as a final fallback group.
+//
+// labelsOf returns the set of group-labels for an upstream id; it is invoked
+// once per id and the result reused, so membership checks are O(1).
+func PartitionLabelGroups(sortedIds []string, order []string, includeDefault bool, labelsOf func(string) mapset.Set[string]) [][]string {
+	labelSets := make(map[string]mapset.Set[string], len(sortedIds))
+	for _, id := range sortedIds {
+		labelSets[id] = labelsOf(id)
+	}
+
+	groups := make([][]string, 0, len(order)+1)
+	for _, label := range order {
+		group := make([]string, 0)
+		for _, id := range sortedIds {
+			if labelSets[id].ContainsOne(label) {
+				group = append(group, id)
+			}
+		}
+		groups = append(groups, group)
+	}
+	if includeDefault {
+		defaultGroup := make([]string, 0)
+		for _, id := range sortedIds {
+			if !lo.SomeBy(order, func(label string) bool { return labelSets[id].ContainsOne(label) }) {
+				defaultGroup = append(defaultGroup, id)
+			}
+		}
+		if len(defaultGroup) > 0 {
+			groups = append(groups, defaultGroup)
+		}
+	}
+	return groups
+}

--- a/internal/upstreams/flow/label_group_strategy_test.go
+++ b/internal/upstreams/flow/label_group_strategy_test.go
@@ -1,0 +1,111 @@
+package flow_test
+
+import (
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabelGroupStrategyExhaustsGroupBeforeNext(t *testing.T) {
+	chSup := test_utils.CreateChainSupervisor()
+	test_utils.PublishEvent(chSup, "id1", protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	test_utils.PublishEvent(chSup, "id2", protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	test_utils.PublishEvent(chSup, "id3", protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	request, _ := protocol.NewInternalUpstreamJsonRpcRequest("eth_getBalance", nil, chains.ARBITRUM)
+
+	strategy := flow.NewLabelGroupStrategyWithGroups([][]string{{"id1", "id2"}, {"id3"}}, false, chSup)
+
+	// pass-on-error=false: group 0 is fully exhausted before group 1 is reached
+	for _, expected := range []string{"id1", "id2", "id3"} {
+		up, err := strategy.SelectUpstream(request)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, up)
+	}
+	_, err := strategy.SelectUpstream(request)
+	assert.Equal(t, protocol.NoAvailableUpstreamsError(), err)
+}
+
+func TestLabelGroupStrategyDeadGroupFallsThrough(t *testing.T) {
+	chSup := test_utils.CreateChainSupervisor()
+	test_utils.PublishEvent(chSup, "id1", protocol.Unavailable, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	test_utils.PublishEvent(chSup, "id2", protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	request, _ := protocol.NewInternalUpstreamJsonRpcRequest("eth_getBalance", nil, chains.ARBITRUM)
+
+	// pass-on-error=false, but an entirely-dead group 0 still falls through to group 1
+	strategy := flow.NewLabelGroupStrategyWithGroups([][]string{{"id1"}, {"id2"}}, false, chSup)
+
+	up, err := strategy.SelectUpstream(request)
+	assert.NoError(t, err)
+	assert.Equal(t, "id2", up)
+}
+
+func TestLabelGroupStrategyPassOnErrorJumpsGroup(t *testing.T) {
+	chSup := test_utils.CreateChainSupervisor()
+	for _, id := range []string{"id1", "id2", "id3", "id4"} {
+		test_utils.PublishEvent(chSup, id, protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	}
+	request, _ := protocol.NewInternalUpstreamJsonRpcRequest("eth_getBalance", nil, chains.ARBITRUM)
+
+	// pass-on-error=true: each error jumps to the next group, skipping untried upstreams
+	strategy := flow.NewLabelGroupStrategyWithGroups([][]string{{"id1", "id2"}, {"id3", "id4"}}, true, chSup)
+
+	up, err := strategy.SelectUpstream(request)
+	assert.NoError(t, err)
+	assert.Equal(t, "id1", up) // best of group 0
+
+	up, err = strategy.SelectUpstream(request)
+	assert.NoError(t, err)
+	assert.Equal(t, "id3", up) // jumped to group 1, skipping id2
+
+	_, err = strategy.SelectUpstream(request)
+	assert.Equal(t, protocol.NoAvailableUpstreamsError(), err) // no groups left
+}
+
+func TestLabelGroupStrategySelectsUpstreamOnceAcrossGroups(t *testing.T) {
+	chSup := test_utils.CreateChainSupervisor()
+	for _, id := range []string{"id1", "id2", "id3"} {
+		test_utils.PublishEvent(chSup, id, protocol.Available, mapset.NewThreadUnsafeSet[protocol.Cap]())
+	}
+	request, _ := protocol.NewInternalUpstreamJsonRpcRequest("eth_getBalance", nil, chains.ARBITRUM)
+
+	// id1 belongs to both groups but must be selected only once
+	strategy := flow.NewLabelGroupStrategyWithGroups([][]string{{"id1", "id2"}, {"id1", "id3"}}, false, chSup)
+
+	for _, expected := range []string{"id1", "id2", "id3"} {
+		up, err := strategy.SelectUpstream(request)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, up)
+	}
+	_, err := strategy.SelectUpstream(request)
+	assert.Equal(t, protocol.NoAvailableUpstreamsError(), err)
+}
+
+func TestLabelGroupStrategyNoGroups(t *testing.T) {
+	chSup := test_utils.CreateChainSupervisor()
+	request, _ := protocol.NewInternalUpstreamJsonRpcRequest("eth_getBalance", nil, chains.ARBITRUM)
+	strategy := flow.NewLabelGroupStrategyWithGroups(nil, false, chSup)
+
+	_, err := strategy.SelectUpstream(request)
+	assert.Equal(t, protocol.NoAvailableUpstreamsError(), err)
+}
+
+func TestPartitionLabelGroups(t *testing.T) {
+	labels := map[string]mapset.Set[string]{
+		"id1": mapset.NewThreadUnsafeSet("full", "fast"),
+		"id2": mapset.NewThreadUnsafeSet("archive"),
+		"id3": mapset.NewThreadUnsafeSet[string](),
+	}
+	labelsOf := func(id string) mapset.Set[string] { return labels[id] }
+	sorted := []string{"id1", "id2", "id3"}
+
+	withDefault := flow.PartitionLabelGroups(sorted, []string{"full", "archive"}, true, labelsOf)
+	assert.Equal(t, [][]string{{"id1"}, {"id2"}, {"id3"}}, withDefault)
+
+	withoutDefault := flow.PartitionLabelGroups(sorted, []string{"full", "archive"}, false, labelsOf)
+	assert.Equal(t, [][]string{{"id1"}, {"id2"}}, withoutDefault)
+}

--- a/internal/upstreams/interfaces.go
+++ b/internal/upstreams/interfaces.go
@@ -1,6 +1,7 @@
 package upstreams
 
 import (
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -59,6 +60,7 @@ type Upstream interface {
 
 	GetId() string
 	GetChain() chains.Chain
+	GetGroupLabels() mapset.Set[string]
 	GetVendorType() UpstreamVendor
 	GetUpstreamState() protocol.UpstreamState
 	GetConnector(connectorType specs.ApiConnectorType) connectors.ApiConnector

--- a/internal/upstreams/upstream.go
+++ b/internal/upstreams/upstream.go
@@ -41,10 +41,20 @@ type BaseUpstream struct {
 	stateChan        chan protocol.AbstractUpstreamStateEvent
 	upstreamIndexHex string
 	upConfig         *config.Upstream
+	groupLabels      mapset.Set[string]
 	upstreamCtx      *upstreamCtx
 	emitter          event_processors.Emitter
 
 	processorAggregator *event_processors.UpstreamProcessorAggregator
+}
+
+// groupLabelsFromConfig builds the immutable set of config-defined group-labels
+// once at upstream construction so label-balancing lookups are O(1).
+func groupLabelsFromConfig(conf *config.Upstream) mapset.Set[string] {
+	if conf == nil {
+		return mapset.NewThreadUnsafeSet[string]()
+	}
+	return mapset.NewThreadUnsafeSet(conf.GroupLabels...)
 }
 
 var _ Upstream = (*BaseUpstream)(nil)
@@ -85,6 +95,7 @@ func NewBaseUpstream(
 		subManager:       utils.NewSubscriptionManager[protocol.UpstreamEvent](fmt.Sprintf("%s_upstream", conf.Id)),
 		upstreamIndexHex: upstreamIndexHex,
 		upConfig:         conf,
+		groupLabels:      groupLabelsFromConfig(conf),
 		stateChan:        stateChan,
 		emitter:          emitter,
 	}
@@ -146,6 +157,7 @@ func NewBaseUpstreamWithParams(
 		subManager:          utils.NewSubscriptionManager[protocol.UpstreamEvent](fmt.Sprintf("%s_upstream", id)),
 		upstreamIndexHex:    index,
 		upConfig:            upConfig,
+		groupLabels:         groupLabelsFromConfig(upConfig),
 		processorAggregator: processorAggregator,
 		stateChan:           *stateChan,
 		emitter:             *emitter,
@@ -170,6 +182,13 @@ func (u *BaseUpstream) GetId() string {
 
 func (u *BaseUpstream) GetChain() chains.Chain {
 	return u.chain
+}
+
+func (u *BaseUpstream) GetGroupLabels() mapset.Set[string] {
+	if u.groupLabels == nil {
+		return mapset.NewThreadUnsafeSet[string]()
+	}
+	return u.groupLabels
 }
 
 func (u *BaseUpstream) Start() {


### PR DESCRIPTION
# Label-based balancing

## Summary

Adds a second, optional balancing mode on top of the existing per-method rating.

Until now every request to a chain was balanced across **all** of that chain's upstreams
using the score-policy rating (latency, error rate, availability, …). This PR introduces
**priority-group balancing**: operators tag upstreams with `group-labels`, declare an
`order` of those labels, and requests are served from the highest-priority group first,
falling through to lower-priority groups when the current group can't serve. Rating still
decides ordering **within** a group.

Typical use case: prefer cheap `full` nodes, fall back to `archive` nodes only when the
full group can't handle a request.

## Configuration

`label-balancing` is configured as a **global default** under `upstream-config` and can be
**overridden per chain** under `chain-defaults.<chain>` (same pattern as `failsafe-config`).
When neither is set, behavior is unchanged (pure rating).

```yaml
upstream-config:
  # global default — applies to every chain unless overridden per chain
  label-balancing:
    order:                  # group label names, highest priority first
      - full
      - archive
      - fast
    pass-on-error: false    # see semantics below; default false
    include-default: true   # unlabeled upstreams form a final fallback group; default true
  chain-defaults:
    polygon:
      label-balancing:      # per-chain override fully replaces the global block for polygon
        order:
          - archive
          - full
  upstreams:
    - id: up1
      chain: ethereum
      group-labels: [full, fast]
      connectors: [{ type: json-rpc, url: https://full-node.example.com }]
    - id: up2
      chain: ethereum
      group-labels: [archive]
      connectors: [{ type: json-rpc, url: https://archive-node.example.com }]
```

### Fields

| Field | Description |
|---|---|
| `order` | Ordered list of group label names, highest priority first. Required when `label-balancing` is set; entries must be non-empty and unique. |
| `pass-on-error` | Controls retry routing after a retryable **error response** (default `false`). |
| `include-default` | When `true` (default), upstreams carrying none of the `order` labels form a final fallback group tried after all configured groups. When `false`, they are excluded from routing while label-balancing is active. |
| `group-labels` (per upstream) | The priority-group labels this upstream belongs to. Config-defined and independent of the runtime labels produced by label detectors. An upstream may belong to several groups but is selected at most once per request. |

## Algorithm

- Groups are visited in `order`, then the default group (unlabeled upstreams) last.
- Within a group, upstreams keep the usual rating order.
- An upstream is selected **at most once per request**, even if it belongs to several
  groups (guaranteed by the strategy's accumulating `selectedUpstreams` set, which persists
  across failsafe retries/hedges within a request).
- `pass-on-error: false` (default): on a retryable error, retry **within the current group**
  (next-best untried upstream); advance to the next group only once the current group has no
  selectable upstream left.
- `pass-on-error: true`: on a retryable error, **jump straight to the next group**, skipping
  untried upstreams in the current group.
- In both modes, an entirely-dead group (every upstream unavailable / method banned /
  rate-limited) **always** falls through to the next group, regardless of `pass-on-error`.

## Implementation

The feature reuses the existing selection machinery rather than duplicating it:

- **`LabelGroupStrategy`** (`internal/upstreams/flow/label_group_strategy.go`) — a new
  `UpstreamStrategy`. A single instance lives for one request; its `SelectUpstream` walks the
  ordered groups with a cursor and delegates within-group selection to the existing
  `filterUpstreams` (status/method/ws matchers, rate limits, already-tried skipping). The
  `false`/`true` `pass-on-error` modes are the only difference in how the cursor advances.
- **`NewLabelGroupStrategy`** builds the ordered groups itself from the rating registry
  (`registry.GetSortedUpstreams` → `PartitionLabelGroups`), mirroring how `NewRatingStrategy`
  pulls its sorted list from the registry. `createStrategy` stays a one-liner. A
  `NewLabelGroupStrategyWithGroups` constructor keeps the explicit-groups path for tests.
- **`createStrategy`** (`internal/upstreams/flow/execution_flow.go`) builds a
  `LabelGroupStrategy` when label-balancing is configured for the chain, otherwise keeps
  `RatingStrategy`. Quorum and subscribe paths are unaffected; sticky-send composes via the
  existing additional matcher.
- **Config** (`internal/config`) — `LabelBalancingConfig`, `group-labels` on upstreams, the
  global + per-chain fields, a `LabelBalancingFor(chain)` resolver, validation, and an
  `include-default` default of `true`.
- **`Upstream.GetGroupLabels()`** returns a `mapset.Set[string]` built **once** at
  construction, so partitioning does O(1) membership checks instead of re-scanning a slice.

## Tests

- `internal/upstreams/flow/label_group_strategy_test.go` — group exhaustion before advancing,
  dead-group fall-through, `pass-on-error` group-jumping, selected-once across overlapping
  membership, empty-groups, and `PartitionLabelGroups` partitioning (incl. default group).
- `internal/config/label_balancing_test.go` — validation (empty/duplicate `order`),
  `include-default` defaulting, and `LabelBalancingFor` per-chain/global resolution.

## Docs

`docs/nodecore/05-upstream-config.md` gains a `label-balancing` section plus `group-labels`
and per-chain `label-balancing` field entries.

## Notes

- With `pass-on-error: true` and only a **single** group configured, a retryable error has
  nowhere to escalate, so only one upstream is tried per request before failing — the literal
  "jump on error" semantics. This is an unusual config.
