### PR TITLE
Use standard image.repository + image.tag in chart

### DIFF
--- a/chart/nodecore/Chart.yaml
+++ b/chart/nodecore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nodecore
 description: a helm chart for nodecore
 type: application
-version: 1.0.2
+version: 1.1.0
 appVersion: ""
 
 maintainers:

--- a/chart/nodecore/templates/deployment.yaml
+++ b/chart/nodecore/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - name: {{ .Release.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.name }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion | default "latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             {{- range $key, $portSpec := .Values.containerPorts }}

--- a/chart/nodecore/values.schema.json
+++ b/chart/nodecore/values.schema.json
@@ -5,11 +5,16 @@
   "properties": {
     "image": {
       "type": "object",
+      "additionalProperties": false,
       "description": "Container image configuration",
       "properties": {
-        "name": {
+        "repository": {
           "type": "string",
           "description": "Container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag (defaults to the chart appVersion, then \"latest\")"
         },
         "pullPolicy": {
           "type": "string",
@@ -22,7 +27,7 @@
         }
       },
       "required": [
-        "name",
+        "repository",
         "pullPolicy"
       ]
     },

--- a/chart/nodecore/values.yaml
+++ b/chart/nodecore/values.yaml
@@ -1,5 +1,6 @@
 image:
-  name: drpcorg/nodecore
+  repository: drpcorg/nodecore
+  tag: "latest"
   pullPolicy: Always
 
 deployment:


### PR DESCRIPTION
## Description

Alternative to #161. Instead of documenting the chart's `image.name` field, this migrates the chart to the standard Helm `image.repository` + `image.tag` split, which is what the README already documents and what the broader ecosystem expects.

### Why split over a combined `image.name`
- **Ecosystem convention** — Bitnami, the official Helm best-practices guide, and most charts use `repository`/`tag`/`pullPolicy`. The combined `name` is the surprising shape that bit the #161 reporter.
- **CI/CD & GitOps** — `helm upgrade --set image.tag=$GIT_SHA` is the canonical deploy line, and Argo CD Image Updater / Flux image automation / Renovate all have first-class support for a dedicated tag field.
- **Templating** — the tag now falls back to `.Chart.AppVersion`, then `"latest"`.

### Changes
- `values.yaml`: `image.name` → `image.repository` + `image.tag`
- `templates/deployment.yaml`: `image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion | default "latest" }}"`
- `values.schema.json`: `name` → `repository` + `tag`; kept `additionalProperties: false` (the good idea from #161) so a stray `image.name`/`image.tag` fails validation instead of being dropped silently
- `Chart.yaml`: version `1.0.2` → `1.1.0`

The README on `main` already documents `image.repository`/`image.tag`, so no doc change is needed — this realigns the code to the existing docs.

### Validation
- `helm lint` — clean
- defaults render `drpcorg/nodecore:latest`
- `--set image.tag=v1.2.3` renders `drpcorg/nodecore:v1.2.3`
- a stray `--set image.name=...` is now rejected: `at '/image': additional properties 'name' not allowed`

### ⚠️ Breaking change
Existing `values.yaml` files using `image.name` must switch to `image.repository` + `image.tag`. Flagging the version bump — bump to `2.0.0` instead of `1.1.0` if you treat removed values as a major change.