### PR TITLE
Aggregate subs + local newHeads

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/stats"
 	"github.com/drpcorg/nodecore/internal/storages"
 	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/pyroscope"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
@@ -82,6 +83,8 @@ func NewApp(ctx context.Context, appConfig *config.AppConfig) (*App, error) {
 		return nil, fmt.Errorf("unable to load quorum provider keys: %w", err)
 	}
 
+	subEngineRegistry := subengine.NewRegistry(ctx, upstreamSupervisor)
+
 	appCtx := server_ctx.NewApplicationServerContext(
 		upstreamSupervisor,
 		cacheProcessor,
@@ -92,6 +95,7 @@ func NewApp(ctx context.Context, appConfig *config.AppConfig) (*App, error) {
 		statsService,
 		dimensionTracker,
 		quorumRegistry,
+		subEngineRegistry,
 	)
 
 	grpcServer, err := emerald.NewGrpcServer(appCtx)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,7 +83,7 @@ func NewApp(ctx context.Context, appConfig *config.AppConfig) (*App, error) {
 		return nil, fmt.Errorf("unable to load quorum provider keys: %w", err)
 	}
 
-	subEngineRegistry := subengine.NewRegistry(ctx, upstreamSupervisor)
+	subEngineRegistry := subengine.NewRegistry(ctx)
 
 	appCtx := server_ctx.NewApplicationServerContext(
 		upstreamSupervisor,

--- a/internal/protocol/blocks.go
+++ b/internal/protocol/blocks.go
@@ -14,6 +14,7 @@ type Block struct {
 	Slot       uint64
 	Hash       blockchain.HashId
 	ParentHash blockchain.HashId
+	RawData    []byte
 }
 
 func (b Block) Equals(other Block) bool {

--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -361,7 +361,16 @@ func (r ValidUpstreamEvent) eventData() {}
 type Cap int
 
 const (
+	// WsCap means the upstream has a live websocket connector (any chain). Used
+	// to route node-backed subscriptions to a ws-capable upstream.
 	WsCap Cap = iota
+	// NewHeadsCap means the upstream's head is subscription-driven (its head
+	// connector is a websocket), so newHeads can be synthesized locally from the
+	// head stream. EVM-only.
+	NewHeadsCap
+	// LogsCap means NewHeadsCap holds and eth_getLogs is enabled, so logs can be
+	// synthesized locally. EVM-only.
+	LogsCap
 )
 
 type UpstreamState struct {

--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -201,6 +201,7 @@ const (
 // block tag and numeric height) cannot be represented by construction.
 type RequestSelector interface {
 	isRequestSelector()
+	Key() string
 }
 
 type RequestAnySelector struct{}

--- a/internal/protocol/errors.go
+++ b/internal/protocol/errors.go
@@ -153,6 +153,18 @@ func WsTotalFailureError() *ResponseError {
 	}
 }
 
+// WsSubscriberTooSlowError is the terminal error delivered to a subscriber that
+// could not keep up with the shared source's fan-out (its buffer overflowed).
+// It uses the WsTotalFailure code so the client treats it like any other
+// terminal failure and can resubscribe, but carries a distinct message so the
+// cause is visible in logs.
+func WsSubscriberTooSlowError() *ResponseError {
+	return &ResponseError{
+		Message: "subscription dropped: subscriber too slow to keep up",
+		Code:    WsTotalFailure,
+	}
+}
+
 func QuorumUnknownProviderError(providerID string) *ResponseError {
 	return &ResponseError{
 		Message: fmt.Sprintf("quorum signature verification failed: no public key configured for provider %q", providerID),

--- a/internal/protocol/request_selector_key.go
+++ b/internal/protocol/request_selector_key.go
@@ -1,0 +1,66 @@
+package protocol
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Key implementations produce a deterministic, order-independent identity for
+// each RequestSelector. and/or groups sort their children so that logically
+// equal trees collide regardless of ordering. See RequestSelector.Key.
+
+func (RequestAnySelector) Key() string {
+	return "any"
+}
+
+func (s RequestLabelSelector) Key() string {
+	values := append([]string(nil), s.Values...)
+	sort.Strings(values)
+	return fmt.Sprintf("label(%s=%s)", s.Name, strings.Join(values, "|"))
+}
+
+func (s RequestExistsSelector) Key() string {
+	return fmt.Sprintf("exists(%s)", s.Name)
+}
+
+func (s RequestAndSelector) Key() string {
+	return fmt.Sprintf("and(%s)", selectorGroupKey(s.Children))
+}
+
+func (s RequestOrSelector) Key() string {
+	return fmt.Sprintf("or(%s)", selectorGroupKey(s.Children))
+}
+
+func (s RequestNotSelector) Key() string {
+	return fmt.Sprintf("not(%s)", s.Child.Key())
+}
+
+func (s RequestHeightSelector) Key() string {
+	return fmt.Sprintf("height(%d)", s.Height)
+}
+
+func (s RequestBlockTagSelector) Key() string {
+	return fmt.Sprintf("tag(%d)", s.Tag)
+}
+
+func (s RequestSlotHeightSelector) Key() string {
+	return fmt.Sprintf("slot(%d)", s.SlotHeight)
+}
+
+func (s RequestLowerHeightSelector) Key() string {
+	return fmt.Sprintf("lower(%d,%d,%d,%d)", s.Height, s.LowerBoundType, s.TimeOffset, s.HeightDelta)
+}
+
+func (s RequestUnsupportedSelector) Key() string {
+	return fmt.Sprintf("unsupported(%s)", s.Reason)
+}
+
+func selectorGroupKey(children []RequestSelector) string {
+	parts := make([]string, 0, len(children))
+	for _, child := range children {
+		parts = append(parts, child.Key())
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}

--- a/internal/protocol/response.go
+++ b/internal/protocol/response.go
@@ -423,12 +423,13 @@ func NewHttpUpstreamResponseWithError(error *ResponseError) *BaseUpstreamRespons
 }
 
 type WsResponse struct {
-	Id      string
-	SubId   string
-	Message []byte
-	Type    RequestType
-	Error   *ResponseError
-	Event   []byte
+	Id         string
+	SubId      string
+	Message    []byte
+	Type       RequestType
+	Error      *ResponseError
+	Event      []byte
+	UpstreamId string
 }
 
 type JsonRpcWsUpstreamResponse struct {

--- a/internal/protocol/upstream_state_events.go
+++ b/internal/protocol/upstream_state_events.go
@@ -129,10 +129,14 @@ func (u *UnbanMethodUpstreamStateEvent) ProcessEvent(state UpstreamState) Upstre
 }
 
 type SubscribeUpstreamStateEvent struct {
-	State SubscribeConnectorState
+	State         SubscribeConnectorState
+	HeadConnector bool
 }
 
 func (s *SubscribeUpstreamStateEvent) Same(state UpstreamState) bool {
+	if s.HeadConnector {
+		return false
+	}
 	switch s.State {
 	case WsConnected:
 		return state.Caps.Contains(WsCap)
@@ -147,8 +151,17 @@ func (s *SubscribeUpstreamStateEvent) ProcessEvent(state UpstreamState) Upstream
 	switch s.State {
 	case WsConnected:
 		copyCaps.Add(WsCap)
+		// A websocket head connector means the head is subscription-driven, so
+		// newHeads can be synthesized locally; logs additionally needs
+		// eth_getLogs. eth_subscribe presence implies an EVM chain.
+		if s.HeadConnector && state.UpstreamMethods != nil && state.UpstreamMethods.HasMethod("eth_subscribe") {
+			copyCaps.Add(NewHeadsCap)
+			if state.UpstreamMethods.HasMethod("eth_getLogs") {
+				copyCaps.Add(LogsCap)
+			}
+		}
 	case WsDisconnected:
-		copyCaps.Remove(WsCap)
+		copyCaps.Clear()
 	}
 	state.Caps = copyCaps
 	return state

--- a/internal/protocol/upstream_state_events_test.go
+++ b/internal/protocol/upstream_state_events_test.go
@@ -8,11 +8,14 @@ import (
 	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func newUpstreamState() protocol.UpstreamState {
+	methodsMock := mocks.NewMethodsMock()
+	methodsMock.On("HasMethod", mock.Anything).Return(false).Maybe()
 	return protocol.DefaultUpstreamState(
-		mocks.NewMethodsMock(),
+		methodsMock,
 		mapset.NewThreadUnsafeSet[protocol.Cap](),
 		"test-upstream",
 		nil,
@@ -152,6 +155,77 @@ func TestSubscribeUpstreamStateEvent(t *testing.T) {
 		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.SubscribeConnectorState(99)}
 
 		assert.False(t, event.Same(state))
+	})
+
+	t.Run("evm head connector ws connect adds newHeads and logs caps", func(t *testing.T) {
+		methodsMock := mocks.NewMethodsMock()
+		methodsMock.On("HasMethod", "eth_subscribe").Return(true)
+		methodsMock.On("HasMethod", "eth_getLogs").Return(true)
+		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
+		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
+
+		next := event.ProcessEvent(state)
+
+		assert.True(t, next.Caps.Contains(protocol.WsCap))
+		assert.True(t, next.Caps.Contains(protocol.NewHeadsCap))
+		assert.True(t, next.Caps.Contains(protocol.LogsCap))
+	})
+
+	t.Run("evm head connector ws connect without eth_getLogs has no logs cap", func(t *testing.T) {
+		methodsMock := mocks.NewMethodsMock()
+		methodsMock.On("HasMethod", "eth_subscribe").Return(true)
+		methodsMock.On("HasMethod", "eth_getLogs").Return(false)
+		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
+		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
+
+		next := event.ProcessEvent(state)
+
+		assert.True(t, next.Caps.Contains(protocol.NewHeadsCap))
+		assert.False(t, next.Caps.Contains(protocol.LogsCap))
+	})
+
+	// A ws connector used only for requests (head connector is e.g. json-rpc)
+	// must not grant local-sub caps - otherwise newHeads routes to local
+	// synthesis with a polled head and emits nothing.
+	t.Run("non-head ws connect grants only WsCap", func(t *testing.T) {
+		methodsMock := mocks.NewMethodsMock()
+		methodsMock.On("HasMethod", "eth_subscribe").Return(true).Maybe()
+		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
+		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: false}
+
+		next := event.ProcessEvent(state)
+
+		assert.True(t, next.Caps.Contains(protocol.WsCap))
+		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
+		assert.False(t, next.Caps.Contains(protocol.LogsCap))
+	})
+
+	t.Run("non-evm head connector ws connect grants only WsCap", func(t *testing.T) {
+		methodsMock := mocks.NewMethodsMock()
+		methodsMock.On("HasMethod", "eth_subscribe").Return(false)
+		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
+		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
+
+		next := event.ProcessEvent(state)
+
+		assert.True(t, next.Caps.Contains(protocol.WsCap))
+		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
+		assert.False(t, next.Caps.Contains(protocol.LogsCap))
+	})
+
+	t.Run("ws disconnect removes all sub caps", func(t *testing.T) {
+		state := protocol.DefaultUpstreamState(
+			mocks.NewMethodsMock(),
+			mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap),
+			"u", nil, nil,
+		)
+		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsDisconnected}
+
+		next := event.ProcessEvent(state)
+
+		assert.False(t, next.Caps.Contains(protocol.WsCap))
+		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
+		assert.False(t, next.Caps.Contains(protocol.LogsCap))
 	})
 }
 

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -95,6 +95,7 @@ func (s *GrpcBlockchainService) NativeCall(request *dshackle.NativeCallRequest, 
 		s.appCtx.AppConfig,
 		flow.NewSubCtx(),
 		s.appCtx.QuorumRegistry,
+		s.appCtx.SubEngineRegistry,
 	)
 	executionFlow.AddHooks(
 		flow.NewMethodBanHook(s.appCtx.UpstreamSupervisor),
@@ -135,6 +136,10 @@ func (s *GrpcBlockchainService) NativeSubscribe(request *dshackle.NativeSubscrib
 		return status.Error(codes.Unavailable, protocol.NoAvailableUpstreamsError().Message)
 	}
 
+	if !subscribeMethodSupported(chainSupervisor, request.GetMethod()) {
+		return status.Error(codes.Unimplemented, fmt.Sprintf("subscribe %s is not supported for chain %d", request.GetMethod(), request.GetChain()))
+	}
+
 	mappedMethod, mappedPayload, err := mapNativeSubscribeMethod(configuredChain.MethodSpec, chainSupervisor, request.GetMethod(), request.GetPayload())
 	if err != nil {
 		if errors.Is(err, errSubscribeMappingNotSupported) {
@@ -155,6 +160,7 @@ func (s *GrpcBlockchainService) NativeSubscribe(request *dshackle.NativeSubscrib
 		s.appCtx.AppConfig,
 		subCtx,
 		s.appCtx.QuorumRegistry,
+		s.appCtx.SubEngineRegistry,
 	)
 	executionFlow.AddHooks(flow.NewMethodBanHook(s.appCtx.UpstreamSupervisor))
 
@@ -419,6 +425,11 @@ func mapNativeSubscribeMethod(
 
 func supportsNativeSubscribeMethod(methodSpecName string, requestedMethod string) bool {
 	return specs.IsSubscribeMethod(methodSpecName, requestedMethod)
+}
+
+func subscribeMethodSupported(chainSupervisor upstreams.ChainSupervisor, method string) bool {
+	subMethods := chainSupervisor.GetChainState().SubMethods
+	return subMethods != nil && subMethods.ContainsOne(method)
 }
 
 func normalizeNativeSubscribePayload(requestedMethod string, payload []byte) (string, []byte, error) {

--- a/internal/server/emerald/grpc_blockchain_test.go
+++ b/internal/server/emerald/grpc_blockchain_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/nodecore/pkg/dshackle"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
@@ -18,6 +20,33 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// subMethodsChainSupervisor is a ChainSupervisor stub exposing a fixed
+// SubMethods set.
+type subMethodsChainSupervisor struct {
+	upstreams.ChainSupervisor
+	subMethods mapset.Set[string]
+}
+
+func (s subMethodsChainSupervisor) GetChainState() upstreams.ChainSupervisorState {
+	return upstreams.ChainSupervisorState{SubMethods: s.subMethods}
+}
+
+func chainSupWithSubMethods(methods ...string) subMethodsChainSupervisor {
+	return subMethodsChainSupervisor{subMethods: mapset.NewThreadUnsafeSet[string](methods...)}
+}
+
+func TestSubscribeMethodSupported(t *testing.T) {
+	// gRPC validates the requested method against the chain's advertised topics
+	assert.True(t, subscribeMethodSupported(chainSupWithSubMethods("newHeads", "logs"), "newHeads"))
+	assert.True(t, subscribeMethodSupported(chainSupWithSubMethods("newHeads", "logs"), "logs"))
+	// logs not advertised (e.g. no eth_getLogs / no ws head) -> unsupported
+	assert.False(t, subscribeMethodSupported(chainSupWithSubMethods("newHeads"), "logs"))
+	// nothing advertised (e.g. no ws upstream) -> unsupported
+	assert.False(t, subscribeMethodSupported(chainSupWithSubMethods(), "newHeads"))
+	// native (non-EVM) sub methods pass through by name
+	assert.True(t, subscribeMethodSupported(chainSupWithSubMethods("programSubscribe"), "programSubscribe"))
+}
 
 func TestMapNativeSubscribeMethod(t *testing.T) {
 	require.NoError(t, specs.NewMethodSpecLoader().Load())

--- a/internal/server/emerald/sub_chain_status_test.go
+++ b/internal/server/emerald/sub_chain_status_test.go
@@ -233,7 +233,7 @@ func TestSubscribeChainStatus_WaitsForHeadBeforeFirstResponse(t *testing.T) {
 
 	head := protocol.NewBlockWithHeight(100)
 	chainSupervisor.SetState(newChainState(chains.ARBITRUM, head, []string{"eth_call"}))
-	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(head))
+	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(head, "up-1"))
 
 	select {
 	case <-stream.Sent():
@@ -430,7 +430,7 @@ func TestSubscribeChainStatus_SendsIncrementalEventsForStateChanges(t *testing.T
 	nextState := updatedState
 	nextState.HeadData = upstreams.NewChainHeadData(nextHead, "up-1")
 	chainSupervisor.SetState(nextState)
-	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(nextHead))
+	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(nextHead, "up-1"))
 
 	require.Eventually(t, func() bool {
 		return stream.Count() == 3
@@ -492,7 +492,7 @@ func TestSubscribeChainStatus_DoesNotSubscribeSameChainTwice(t *testing.T) {
 	nextHead := protocol.NewBlockWithHeight(322)
 	nextState := newChainState(chains.ARBITRUM, nextHead, []string{"eth_call"})
 	chainSupervisor.SetState(nextState)
-	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(nextHead))
+	chainSupervisor.PublishStateEvent(upstreams.NewHeadWrapper(nextHead, "up-1"))
 
 	require.Eventually(t, func() bool {
 		return stream.Count() == 2

--- a/internal/server/http_server/http_server.go
+++ b/internal/server/http_server/http_server.go
@@ -330,6 +330,7 @@ func handleRequest(
 		appCtx.AppConfig,
 		subCtx,
 		appCtx.QuorumRegistry,
+		appCtx.SubEngineRegistry,
 	)
 	executionFlow.AddHooks(
 		flow.NewMethodBanHook(appCtx.UpstreamSupervisor),

--- a/internal/server/http_server/http_server_test.go
+++ b/internal/server/http_server/http_server_test.go
@@ -127,7 +127,7 @@ func TestHttpServerCantAuthenticate(t *testing.T) {
 	}
 
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -156,7 +156,7 @@ func TestHttpServerCantAuthenticate(t *testing.T) {
 
 func TestHttServerCantParseJsonRpcThenErr(t *testing.T) {
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -182,7 +182,7 @@ func TestHttServerCantParseJsonRpcThenErr(t *testing.T) {
 
 func TestHttpServerPreKeyValidateWithErr(t *testing.T) {
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -209,7 +209,7 @@ func TestHttpServerPreKeyValidateWithErr(t *testing.T) {
 
 func TestHttpServerNotSupportedChainThenErr(t *testing.T) {
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(nil, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -237,7 +237,7 @@ func TestHttpServerNotSupportedChainThenErr(t *testing.T) {
 func TestHttpServerChainSupervisorIsNilThenErr(t *testing.T) {
 	upSup := mocks.NewUpstreamSupervisorMock()
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(upSup, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(upSup, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()
@@ -267,7 +267,7 @@ func TestHttpServerChainSupervisorIsNilThenErr(t *testing.T) {
 func TestHttpServerPostKeyValidateWithErr(t *testing.T) {
 	upSup := mocks.NewUpstreamSupervisorMock()
 	authProc := mocks.NewMockAuthProcessor()
-	appCtx := servernodecore.NewApplicationServerContext(upSup, nil, nil, authProc, nil, nil, nil, nil, nil)
+	appCtx := servernodecore.NewApplicationServerContext(upSup, nil, nil, authProc, nil, nil, nil, nil, nil, nil)
 	server := http_server.NewHttpServer(context.Background(), appCtx)
 	ts := httptest.NewServer(server)
 	defer ts.Close()

--- a/internal/server/server_ctx/server_ctx.go
+++ b/internal/server/server_ctx/server_ctx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/stats"
 	"github.com/drpcorg/nodecore/internal/storages"
 	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 )
 
 type ApplicationServerContext struct {
@@ -22,6 +23,7 @@ type ApplicationServerContext struct {
 	StatsService       stats.StatsService
 	DimensionTracker   dimensions.DimensionTracker
 	QuorumRegistry     *quorum.Registry
+	SubEngineRegistry  *subengine.Registry
 }
 
 func NewApplicationServerContext(
@@ -34,6 +36,7 @@ func NewApplicationServerContext(
 	statsService stats.StatsService,
 	dimensionTracker dimensions.DimensionTracker,
 	quorumRegistry *quorum.Registry,
+	subEngineRegistry *subengine.Registry,
 ) *ApplicationServerContext {
 	return &ApplicationServerContext{
 		UpstreamSupervisor: upstreamSupervisor,
@@ -45,5 +48,6 @@ func NewApplicationServerContext(
 		StatsService:       statsService,
 		DimensionTracker:   dimensionTracker,
 		QuorumRegistry:     quorumRegistry,
+		SubEngineRegistry:  subEngineRegistry,
 	}
 }

--- a/internal/upstreams/blocks/head_test.go
+++ b/internal/upstreams/blocks/head_test.go
@@ -131,6 +131,8 @@ func TestSubHeadSubscribe(t *testing.T) {
 		Height:     uint64(69195275),
 		Hash:       blockchain.NewHashIdFromString("0xdeeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d18"),
 		ParentHash: blockchain.NewHashIdFromString("0x1eeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d11"),
+		// the subscription head retains the full block JSON for local newHeads
+		RawData: protocol.ParseJsonRpcWsMessage(body).Message,
 	}
 
 	assert.True(t, ok)

--- a/internal/upstreams/chain_supervisor.go
+++ b/internal/upstreams/chain_supervisor.go
@@ -181,17 +181,15 @@ func (b *BaseChainSupervisor) processEvents() {
 
 func (b *BaseChainSupervisor) updateHead(upstreamId string, headEvent *protocol.HeadUpstreamEvent) {
 	newState := b.state.Load()
+	var headWrapper *ChainSupervisorStateWrapperEvent
 	if headEvent != nil && !headEvent.Head.IsEmptyByHeight() {
 		updated, head := b.fc.Choose(upstreamId, headEvent)
 		if updated {
 			newState.HeadData = NewChainHeadData(head, upstreamId)
-
 			if !newState.HeadData.IsEmpty() {
-				b.subStateManager.Publish(
-					&ChainSupervisorStateWrapperEvent{
-						[]ChainSupervisorStateWrapper{NewHeadWrapper(newState.HeadData.Head, upstreamId)},
-					},
-				)
+				headWrapper = &ChainSupervisorStateWrapperEvent{
+					[]ChainSupervisorStateWrapper{NewHeadWrapper(newState.HeadData.Head, upstreamId)},
+				}
 			}
 		}
 	} else if headEvent != nil {
@@ -199,6 +197,9 @@ func (b *BaseChainSupervisor) updateHead(upstreamId string, headEvent *protocol.
 	}
 
 	b.state.Store(newState)
+	if headWrapper != nil {
+		b.subStateManager.Publish(headWrapper)
+	}
 	b.calculateHeadLags()
 }
 
@@ -217,11 +218,10 @@ func (b *BaseChainSupervisor) updateState() {
 	newState.SubMethods = b.processSubMethods(newState.Caps)
 
 	eventWrappers := currentState.Compare(newState)
+	b.state.Store(newState)
 	if len(eventWrappers) > 0 {
 		b.subStateManager.Publish(&ChainSupervisorStateWrapperEvent{eventWrappers})
 	}
-
-	b.state.Store(newState)
 	b.calculateFinalizationLags()
 }
 

--- a/internal/upstreams/chain_supervisor.go
+++ b/internal/upstreams/chain_supervisor.go
@@ -59,6 +59,7 @@ func NewBaseChainSupervisor(ctx context.Context, chain chains.Chain, fc choice.F
 			Methods:     methods.NewChainMethods(nil),
 			ChainLabels: make([]AggregatedLabels, 0),
 			SubMethods:  mapset.NewThreadUnsafeSet[string](),
+			Caps:        mapset.NewThreadUnsafeSet[protocol.Cap](),
 		},
 	)
 
@@ -188,7 +189,7 @@ func (b *BaseChainSupervisor) updateHead(upstreamId string, headEvent *protocol.
 			if !newState.HeadData.IsEmpty() {
 				b.subStateManager.Publish(
 					&ChainSupervisorStateWrapperEvent{
-						[]ChainSupervisorStateWrapper{NewHeadWrapper(newState.HeadData.Head)},
+						[]ChainSupervisorStateWrapper{NewHeadWrapper(newState.HeadData.Head, upstreamId)},
 					},
 				)
 			}
@@ -212,7 +213,8 @@ func (b *BaseChainSupervisor) updateState() {
 	newState.Blocks = processUpstreamBlocks(availableUpstreams)
 	newState.LowerBounds = processLowerBounds(availableUpstreams)
 	newState.ChainLabels = processLabels(availableUpstreams)
-	newState.SubMethods = b.processSubMethods(availableUpstreams)
+	newState.Caps = processCaps(availableUpstreams)
+	newState.SubMethods = b.processSubMethods(newState.Caps)
 
 	eventWrappers := currentState.Compare(newState)
 	if len(eventWrappers) > 0 {
@@ -269,14 +271,25 @@ func (b *BaseChainSupervisor) availableUpstreams() []*protocol.UpstreamState {
 	return states
 }
 
-func (b *BaseChainSupervisor) processSubMethods(availableUpstreams []*protocol.UpstreamState) mapset.Set[string] {
-	for _, upState := range availableUpstreams {
-		if upState.Caps.Contains(protocol.WsCap) {
-			return b.subChainMethods.Clone()
+func (b *BaseChainSupervisor) processSubMethods(caps mapset.Set[protocol.Cap]) mapset.Set[string] {
+	if caps == nil || !caps.Contains(protocol.WsCap) {
+		return mapset.NewThreadUnsafeSet[string]()
+	}
+	subMethods := b.subChainMethods.Clone()
+	// EVM advertises concrete topics derived from caps instead of the generic
+	// eth_subscribe method, so SubscribeChainStatus and NativeSubscribe see the
+	// real sub types. A topic is offered only if it can be served locally
+	// (newHeads -> NewHeadsCap, logs -> LogsCap).
+	if subMethods.ContainsOne("eth_subscribe") {
+		subMethods.Remove("eth_subscribe")
+		if caps.Contains(protocol.NewHeadsCap) {
+			subMethods.Add("newHeads")
+		}
+		if caps.Contains(protocol.LogsCap) {
+			subMethods.Add("logs")
 		}
 	}
-
-	return mapset.NewThreadUnsafeSet[string]()
+	return subMethods
 }
 
 func (b *BaseChainSupervisor) processUpstreamStatuses() protocol.AvailabilityStatus {

--- a/internal/upstreams/chain_supervisor_state.go
+++ b/internal/upstreams/chain_supervisor_state.go
@@ -64,6 +64,10 @@ type ChainSupervisorState struct {
 	LowerBounds map[protocol.LowerBoundType]protocol.LowerBoundData
 	ChainLabels []AggregatedLabels
 	SubMethods  mapset.Set[string]
+	// Caps is the union of subscription capabilities across available upstreams
+	// (WsCap, and for EVM NewHeadsCap/LogsCap). The subscription engine reads it
+	// to decide whether a topic can be served locally.
+	Caps mapset.Set[protocol.Cap]
 }
 
 func (c ChainSupervisorState) Compare(new ChainSupervisorState) []ChainSupervisorStateWrapper {
@@ -97,6 +101,17 @@ func (c ChainSupervisorState) Compare(new ChainSupervisorState) []ChainSuperviso
 	}
 
 	return wrappers
+}
+
+func processCaps(availableUpstreams []*protocol.UpstreamState) mapset.Set[protocol.Cap] {
+	caps := mapset.NewThreadUnsafeSet[protocol.Cap]()
+	for _, upState := range availableUpstreams {
+		if upState.Caps == nil {
+			continue
+		}
+		caps = caps.Union(upState.Caps)
+	}
+	return caps
 }
 
 func processLabels(availableUpstreams []*protocol.UpstreamState) []AggregatedLabels {

--- a/internal/upstreams/chain_supervisor_state.go
+++ b/internal/upstreams/chain_supervisor_state.go
@@ -100,7 +100,21 @@ func (c ChainSupervisorState) Compare(new ChainSupervisorState) []ChainSuperviso
 		wrappers = append(wrappers, NewSubMethodsWrapper(new.SubMethods.ToSlice()))
 	}
 
+	// Caps changes (e.g. the last NewHeadsCap upstream disconnecting) must be
+	// observable so locally-synthesized subscriptions can fail over instead of
+	// starving silently.
+	if !capsEqual(c.Caps, new.Caps) {
+		wrappers = append(wrappers, NewCapsWrapper(new.Caps))
+	}
+
 	return wrappers
+}
+
+func capsEqual(a, b mapset.Set[protocol.Cap]) bool {
+	if a == nil || b == nil {
+		return (a == nil || a.Cardinality() == 0) && (b == nil || b.Cardinality() == 0)
+	}
+	return a.Equal(b)
 }
 
 func processCaps(availableUpstreams []*protocol.UpstreamState) mapset.Set[protocol.Cap] {

--- a/internal/upstreams/chain_supervisor_test.go
+++ b/internal/upstreams/chain_supervisor_test.go
@@ -552,14 +552,15 @@ func TestChainSupervisorProcessSubMethods(t *testing.T) {
 	go chainSupervisor.Start()
 
 	sub := chainSupervisor.SubscribeState(t.Name())
-	expectedSubMethods := specs.GetSubMethods(chains.GetMethodSpecNameByChain(chains.ETHEREUM))
+	// EVM advertises cap-derived topics, not the generic eth_subscribe method.
+	expectedSubMethods := mapset.NewThreadUnsafeSet[string]("newHeads", "logs")
 
 	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
 		"id1",
 		protocol.Available,
 		100,
 		methods,
-		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap),
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap),
 	))
 
 	assert.Eventually(t, func() bool {
@@ -592,6 +593,156 @@ func TestChainSupervisorProcessSubMethods(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return chainSupervisor.GetChainState().SubMethods.Cardinality() == 0
+	}, eventuallyWait, eventuallyTick)
+}
+
+func TestChainSupervisorSubMethodsEvmWithoutTopicCapsIsEmpty(t *testing.T) {
+	loadChainSupervisorMethodSpecs(t)
+
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ETHEREUM, fork_choice.NewHeightForkChoice(), nil)
+	methods := mocks.NewMethodsMock()
+	methods.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	// A ws connector is up (WsCap) but it is not the head connector, so neither
+	// NewHeadsCap nor LogsCap is granted - EVM then advertises no sub topics
+	// (the generic eth_subscribe is never exposed).
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap),
+	))
+
+	assert.Eventually(t, func() bool {
+		state := chainSupervisor.GetChainState()
+		return state.SubMethods.Cardinality() == 0 &&
+			state.Caps.Equal(mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap))
+	}, eventuallyWait, eventuallyTick)
+}
+
+func TestChainSupervisorSubMethodsEvmNewHeadsOnly(t *testing.T) {
+	loadChainSupervisorMethodSpecs(t)
+
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ETHEREUM, fork_choice.NewHeightForkChoice(), nil)
+	methods := mocks.NewMethodsMock()
+	methods.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	// Ws head connector but eth_getLogs not enabled -> newHeads only, no logs.
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap),
+	))
+
+	assert.Eventually(t, func() bool {
+		return chainSupervisor.GetChainState().SubMethods.Equal(mapset.NewThreadUnsafeSet[string]("newHeads"))
+	}, eventuallyWait, eventuallyTick)
+}
+
+func TestChainSupervisorSubMethodsEmptyWithoutWsCap(t *testing.T) {
+	loadChainSupervisorMethodSpecs(t)
+
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ETHEREUM, fork_choice.NewHeightForkChoice(), nil)
+	methods := mocks.NewMethodsMock()
+	methods.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	// No ws capability at all -> no sub methods regardless of chain.
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](),
+	))
+
+	assert.Eventually(t, func() bool {
+		state := chainSupervisor.GetChainState()
+		return state.SubMethods.Cardinality() == 0 && state.Caps.Cardinality() == 0
+	}, eventuallyWait, eventuallyTick)
+}
+
+func TestChainSupervisorSubMethodsSolanaUsesNativeMethods(t *testing.T) {
+	loadChainSupervisorMethodSpecs(t)
+
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.SOLANA, fork_choice.NewHeightForkChoice(), nil)
+	methods := mocks.NewMethodsMock()
+	methods.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	// Non-EVM keeps its native sub methods (no eth_subscribe in the spec), gated
+	// only on WsCap - the EVM topic caps are irrelevant here.
+	expected := specs.GetSubMethods(chains.GetMethodSpecNameByChain(chains.SOLANA))
+	require.NotZero(t, expected.Cardinality())
+
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap),
+	))
+
+	assert.Eventually(t, func() bool {
+		return chainSupervisor.GetChainState().SubMethods.Equal(expected)
+	}, eventuallyWait, eventuallyTick)
+}
+
+func TestChainSupervisorCapsAggregatedAcrossUpstreams(t *testing.T) {
+	loadChainSupervisorMethodSpecs(t)
+
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ETHEREUM, fork_choice.NewHeightForkChoice(), nil)
+	methods := mocks.NewMethodsMock()
+	methods.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	// id1 has a ws head connector (full topic caps); id2 only a request ws connector.
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap),
+	))
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id2",
+		protocol.Available,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap),
+	))
+
+	// Chain caps are the union across available upstreams; topics follow.
+	assert.Eventually(t, func() bool {
+		state := chainSupervisor.GetChainState()
+		return state.Caps.Equal(mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap)) &&
+			state.SubMethods.Equal(mapset.NewThreadUnsafeSet[string]("newHeads", "logs"))
+	}, eventuallyWait, eventuallyTick)
+
+	// The only upstream carrying the topic caps becomes unavailable -> caps and
+	// topics recompute from the remaining upstream (request ws only).
+	chainSupervisor.PublishUpstreamEvent(createEventWithCaps(
+		"id1",
+		protocol.Unavailable,
+		100,
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap),
+	))
+
+	assert.Eventually(t, func() bool {
+		state := chainSupervisor.GetChainState()
+		return state.Caps.Equal(mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap)) &&
+			state.SubMethods.Cardinality() == 0
 	}, eventuallyWait, eventuallyTick)
 }
 

--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
@@ -126,7 +126,12 @@ func (e *EvmChainSpecificObject) GetSafeBlock(ctx context.Context) (protocol.Blo
 }
 
 func (e *EvmChainSpecificObject) ParseSubscriptionBlock(blockBytes []byte) (protocol.Block, error) {
-	return e.ParseBlock(blockBytes)
+	block, err := e.ParseBlock(blockBytes)
+	if err != nil {
+		return block, err
+	}
+	block.RawData = append([]byte(nil), blockBytes...)
+	return block, nil
 }
 
 func (e *EvmChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {

--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific_test.go
@@ -76,9 +76,23 @@ func TestEvmParseSubBLock(t *testing.T) {
 		Height:     uint64(69195275),
 		Hash:       blockchain.NewHashIdFromString("0xdeeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d18"),
 		ParentHash: blockchain.NewHashIdFromString("0x1eeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d11"),
+		// the full header JSON is retained so newHeads can be served locally
+		RawData: body,
 	}
 
 	assert.Equal(t, expected, block)
+}
+
+func TestEvmParseBlockHasNoRawData(t *testing.T) {
+	body := []byte(`{
+      "number": "0x41fd60b",
+      "hash": "0xdeeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d18",
+	  "parentHash": "0x1eeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d11"
+    }`)
+
+	block, err := test_utils.NewEvmChainSpecific(nil).ParseBlock(body)
+	assert.Nil(t, err)
+	assert.Nil(t, block.RawData)
 }
 
 func TestEvmGetLatestBlock(t *testing.T) {

--- a/internal/upstreams/flow/execution_flow.go
+++ b/internal/upstreams/flow/execution_flow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/rating"
 	"github.com/drpcorg/nodecore/internal/resilience"
 	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
 	"github.com/drpcorg/nodecore/pkg/utils"
@@ -104,6 +105,7 @@ type BaseExecutionFlow struct {
 	responseChan       chan *protocol.ResponseHolderWrapper
 	cacheProcessor     caches.CacheProcessor
 	subCtx             *SubCtx
+	subEngineRegistry  *subengine.Registry
 	registry           *rating.RatingRegistry
 	appConfig          *config.AppConfig
 	quorumRegistry     *quorum.Registry
@@ -121,6 +123,7 @@ func NewBaseExecutionFlow(
 	appConfig *config.AppConfig,
 	subCtx *SubCtx,
 	quorumRegistry *quorum.Registry,
+	subEngineRegistry *subengine.Registry,
 ) *BaseExecutionFlow {
 	return &BaseExecutionFlow{
 		chain:              chain,
@@ -128,6 +131,7 @@ func NewBaseExecutionFlow(
 		upstreamSupervisor: upstreamSupervisor,
 		responseChan:       make(chan *protocol.ResponseHolderWrapper),
 		subCtx:             subCtx,
+		subEngineRegistry:  subEngineRegistry,
 		registry:           registry,
 		appConfig:          appConfig,
 		quorumRegistry:     quorumRegistry,
@@ -302,7 +306,7 @@ func (e *BaseExecutionFlow) createRequestProcessor(request protocol.RequestHolde
 	var requestProcessor RequestProcessor
 
 	if request.IsSubscribe() {
-		requestProcessor = NewSubscriptionRequestProcessor(e.upstreamSupervisor, e.subCtx)
+		requestProcessor = NewSubscriptionRequestProcessor(e.chain, e.upstreamSupervisor, e.subEngineRegistry.Get(e.chain), e.subCtx)
 	} else if request.SpecMethod().IsLocal() {
 		requestProcessor = NewLocalRequestProcessor(e.chain, e.subCtx)
 		reqObserver.WithRequestKind(protocol.Local)

--- a/internal/upstreams/flow/fanout_request_processor.go
+++ b/internal/upstreams/flow/fanout_request_processor.go
@@ -65,6 +65,9 @@ func (f *FanoutRequestProcessor) ProcessRequest(
 
 	collectedResults := make(map[string]fanoutResult, len(upstreamIDs))
 	for {
+		if err := ctx.Err(); err != nil {
+			return &UnaryResponse{ResponseWrapper: totalFailureWrapper(request, err)}
+		}
 		select {
 		case <-ctx.Done():
 			return &UnaryResponse{ResponseWrapper: totalFailureWrapper(request, ctx.Err())}

--- a/internal/upstreams/flow/sub_aggregation.go
+++ b/internal/upstreams/flow/sub_aggregation.go
@@ -1,0 +1,210 @@
+package flow
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/google/uuid"
+)
+
+// sourceBuilder picks how the shared source for this subscription is produced:
+// locally-synthesized newHeads when the chain has a WS-head-capable upstream, or
+// the default node-backed passthrough otherwise.
+func sourceBuilder(
+	chain chains.Chain,
+	supervisor upstreams.UpstreamSupervisor,
+	request protocol.RequestHolder,
+	strategy UpstreamStrategy,
+) subengine.SourceBuilder {
+	if isNewHeadsRequest(request) && localNewHeadsAvailable(chain, supervisor) {
+		return subengine.NewHeadsSourceBuilder(supervisor, chain)
+	}
+	return newGenericSourceBuilder(supervisor, request, strategy)
+}
+
+// isNewHeadsRequest reports whether request is eth_subscribe("newHeads"). Only
+// EVM chains expose eth_subscribe, so this also implies an EVM chain.
+func isNewHeadsRequest(request protocol.RequestHolder) bool {
+	if request.Method() != "eth_subscribe" {
+		return false
+	}
+	body, err := request.Body()
+	if err != nil {
+		return false
+	}
+	node, err := sonic.Get(body, "params", 0)
+	if err != nil {
+		return false
+	}
+	value, err := node.String()
+	if err != nil {
+		return false
+	}
+	return value == "newHeads"
+}
+
+// localNewHeadsAvailable reports whether the chain can synthesize newHeads
+// locally, i.e. some available upstream has a subscription-driven head
+// (NewHeadsCap). A json-rpc/rest head connector does not get the cap, so such
+// chains correctly fall back to the generic node-backed source.
+func localNewHeadsAvailable(chain chains.Chain, supervisor upstreams.UpstreamSupervisor) bool {
+	chainSup := supervisor.GetChainSupervisor(chain)
+	if chainSup == nil {
+		return false
+	}
+	caps := chainSup.GetChainState().Caps
+	return caps != nil && caps.Contains(protocol.NewHeadsCap)
+}
+
+// subscriptionKey is the aggregation key: subscriptions that share method,
+// params (via RequestHash, which is blake2b over method+params) and selector
+// routing collapse onto a single upstream source.
+func subscriptionKey(request protocol.RequestHolder) string {
+	return fmt.Sprintf("%s|%s|%s", request.Method(), request.RequestHash(), selectorKey(request.Selectors()))
+}
+
+// selectorKey produces a stable string for a selector tree so that identical
+// subscriptions routed the same way collide, while differently-routed ones do
+// not. The encoding is deterministic regardless of selector ordering within
+// and/or groups.
+func selectorKey(selectors []protocol.RequestSelector) string {
+	if len(selectors) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(selectors))
+	for _, selector := range selectors {
+		parts = append(parts, encodeSelector(selector))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func encodeSelector(selector protocol.RequestSelector) string {
+	switch s := selector.(type) {
+	case protocol.RequestAnySelector:
+		return "any"
+	case protocol.RequestLabelSelector:
+		values := append([]string(nil), s.Values...)
+		sort.Strings(values)
+		return fmt.Sprintf("label(%s=%s)", s.Name, strings.Join(values, "|"))
+	case protocol.RequestExistsSelector:
+		return fmt.Sprintf("exists(%s)", s.Name)
+	case protocol.RequestAndSelector:
+		return fmt.Sprintf("and(%s)", encodeSelectorGroup(s.Children))
+	case protocol.RequestOrSelector:
+		return fmt.Sprintf("or(%s)", encodeSelectorGroup(s.Children))
+	case protocol.RequestNotSelector:
+		return fmt.Sprintf("not(%s)", encodeSelector(s.Child))
+	case protocol.RequestHeightSelector:
+		return fmt.Sprintf("height(%d)", s.Height)
+	case protocol.RequestBlockTagSelector:
+		return fmt.Sprintf("tag(%d)", s.Tag)
+	case protocol.RequestSlotHeightSelector:
+		return fmt.Sprintf("slot(%d)", s.SlotHeight)
+	case protocol.RequestLowerHeightSelector:
+		return fmt.Sprintf("lower(%d,%d,%d,%d)", s.Height, s.LowerBoundType, s.TimeOffset, s.HeightDelta)
+	case protocol.RequestUnsupportedSelector:
+		return fmt.Sprintf("unsupported(%s)", s.Reason)
+	default:
+		return fmt.Sprintf("%T", selector)
+	}
+}
+
+func encodeSelectorGroup(children []protocol.RequestSelector) string {
+	parts := make([]string, 0, len(children))
+	for _, child := range children {
+		parts = append(parts, encodeSelector(child))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+// newGenericSourceBuilder builds the default node-backed source: it selects an
+// upstream via the strategy, opens a single ws subscription, and normalizes the
+// upstream stream - swallowing the upstream's own confirmation frame, surfacing
+// errors/disconnects as a terminal frame, and forwarding actual events. Works
+// for any chain family since it is spec-driven (the connector is chosen from
+// the method's api-connector types).
+func newGenericSourceBuilder(
+	supervisor upstreams.UpstreamSupervisor,
+	request protocol.RequestHolder,
+	strategy UpstreamStrategy,
+) subengine.SourceBuilder {
+	return func(srcCtx context.Context) (*subengine.Source, error) {
+		upstreamId, err := strategy.SelectUpstream(request)
+		if err != nil {
+			return nil, err
+		}
+		upstream := supervisor.GetUpstream(upstreamId)
+		if upstream == nil {
+			return nil, protocol.NoAvailableUpstreamsError()
+		}
+		wsConn := getMethodConnector(upstream, request.SpecMethod())
+		if wsConn == nil {
+			return nil, protocol.NoApiConnectorsError(request.Method())
+		}
+
+		subResp, err := wsConn.Subscribe(srcCtx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		var stateChan chan protocol.SubscribeConnectorState
+		statesSub := wsConn.SubscribeStates(fmt.Sprintf("subengine_%s_%s_%s_%d", upstreamId, request.Method(), uuid.NewString(), time.Now().UnixNano()))
+		if statesSub != nil {
+			stateChan = statesSub.Events
+		}
+
+		out := make(chan *protocol.WsResponse, 100)
+		go func() {
+			defer close(out)
+			defer func() {
+				if statesSub != nil {
+					statesSub.Unsubscribe()
+				}
+			}()
+			for {
+				select {
+				case <-srcCtx.Done():
+					return
+				case state, ok := <-stateChan:
+					if ok && state == protocol.WsDisconnected {
+						out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError(), UpstreamId: upstreamId}
+						return
+					}
+				case r, ok := <-subResp.ResponseChan():
+					if !ok {
+						out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError(), UpstreamId: upstreamId}
+						return
+					}
+					if r.Error != nil {
+						r.UpstreamId = upstreamId
+						out <- r
+						return
+					}
+					// Swallow the upstream's own subscription confirmation; each
+					// client allocates its own client-facing subscription id in the
+					// processor, independent of this shared source.
+					if r.SubId == "" {
+						continue
+					}
+					r.UpstreamId = upstreamId
+					out <- r
+				}
+			}
+		}()
+
+		stop := func() {
+			wsConn.Unsubscribe(subResp.OpId())
+		}
+		return &subengine.Source{Events: out, Stop: stop}, nil
+	}
+}

--- a/internal/upstreams/flow/sub_aggregation.go
+++ b/internal/upstreams/flow/sub_aggregation.go
@@ -15,19 +15,28 @@ import (
 	"github.com/google/uuid"
 )
 
-// sourceBuilder picks how the shared source for this subscription is produced:
-// locally-synthesized newHeads when the chain has a WS-head-capable upstream, or
-// the default node-backed passthrough otherwise.
-func sourceBuilder(
+// localNewHeadsKey is the aggregation key for the locally-synthesized newHeads
+// source. The local source taps the chain's single merged-head stream and
+// ignores request selectors, so all local newHeads subscribers must collapse
+// onto one source regardless of their selectors (one head tap per chain).
+const localNewHeadsKey = "local|newHeads"
+
+// resolveSource decides how the shared source for this subscription is produced
+// and returns its aggregation key alongside the builder, keeping the local-vs-
+// generic decision and the key in one place:
+//   - locally-synthesized newHeads (one source per chain) when the chain has a
+//     WS-head-capable upstream, or
+//   - the default node-backed passthrough, keyed by method+params+selectors.
+func resolveSource(
 	chain chains.Chain,
 	supervisor upstreams.UpstreamSupervisor,
 	request protocol.RequestHolder,
 	strategy UpstreamStrategy,
-) subengine.SourceBuilder {
+) (string, subengine.SourceBuilder) {
 	if isNewHeadsRequest(request) && localNewHeadsAvailable(chain, supervisor) {
-		return subengine.NewHeadsSourceBuilder(supervisor, chain)
+		return localNewHeadsKey, subengine.NewHeadsSourceBuilder(supervisor, chain)
 	}
-	return newGenericSourceBuilder(supervisor, request, strategy)
+	return subscriptionKey(request), newGenericSourceBuilder(supervisor, request, strategy)
 }
 
 // isNewHeadsRequest reports whether request is eth_subscribe("newHeads"). Only
@@ -64,67 +73,28 @@ func localNewHeadsAvailable(chain chains.Chain, supervisor upstreams.UpstreamSup
 	return caps != nil && caps.Contains(protocol.NewHeadsCap)
 }
 
-// subscriptionKey is the aggregation key: subscriptions that share method,
+// subscriptionKey is the aggregation key: subscriptions that share method and
 // params (via RequestHash, which is blake2b over method+params) and selector
-// routing collapse onto a single upstream source.
+// routing collapse onto a single upstream source. RequestHash already covers
+// method+params, so the method is not prefixed separately.
 func subscriptionKey(request protocol.RequestHolder) string {
-	return fmt.Sprintf("%s|%s|%s", request.Method(), request.RequestHash(), selectorKey(request.Selectors()))
+	return fmt.Sprintf("%s|%s", request.RequestHash(), selectorKey(request.Selectors()))
 }
 
 // selectorKey produces a stable string for a selector tree so that identical
 // subscriptions routed the same way collide, while differently-routed ones do
-// not. The encoding is deterministic regardless of selector ordering within
-// and/or groups.
+// not. Per-selector encoding is RequestSelector.Key (deterministic regardless
+// of ordering within and/or groups).
 func selectorKey(selectors []protocol.RequestSelector) string {
 	if len(selectors) == 0 {
 		return ""
 	}
 	parts := make([]string, 0, len(selectors))
 	for _, selector := range selectors {
-		parts = append(parts, encodeSelector(selector))
+		parts = append(parts, selector.Key())
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
-}
-
-func encodeSelector(selector protocol.RequestSelector) string {
-	switch s := selector.(type) {
-	case protocol.RequestAnySelector:
-		return "any"
-	case protocol.RequestLabelSelector:
-		values := append([]string(nil), s.Values...)
-		sort.Strings(values)
-		return fmt.Sprintf("label(%s=%s)", s.Name, strings.Join(values, "|"))
-	case protocol.RequestExistsSelector:
-		return fmt.Sprintf("exists(%s)", s.Name)
-	case protocol.RequestAndSelector:
-		return fmt.Sprintf("and(%s)", encodeSelectorGroup(s.Children))
-	case protocol.RequestOrSelector:
-		return fmt.Sprintf("or(%s)", encodeSelectorGroup(s.Children))
-	case protocol.RequestNotSelector:
-		return fmt.Sprintf("not(%s)", encodeSelector(s.Child))
-	case protocol.RequestHeightSelector:
-		return fmt.Sprintf("height(%d)", s.Height)
-	case protocol.RequestBlockTagSelector:
-		return fmt.Sprintf("tag(%d)", s.Tag)
-	case protocol.RequestSlotHeightSelector:
-		return fmt.Sprintf("slot(%d)", s.SlotHeight)
-	case protocol.RequestLowerHeightSelector:
-		return fmt.Sprintf("lower(%d,%d,%d,%d)", s.Height, s.LowerBoundType, s.TimeOffset, s.HeightDelta)
-	case protocol.RequestUnsupportedSelector:
-		return fmt.Sprintf("unsupported(%s)", s.Reason)
-	default:
-		return fmt.Sprintf("%T", selector)
-	}
-}
-
-func encodeSelectorGroup(children []protocol.RequestSelector) string {
-	parts := make([]string, 0, len(children))
-	for _, child := range children {
-		parts = append(parts, encodeSelector(child))
-	}
-	sort.Strings(parts)
-	return strings.Join(parts, "|")
 }
 
 // newGenericSourceBuilder builds the default node-backed source: it selects an

--- a/internal/upstreams/flow/sub_aggregation_internal_test.go
+++ b/internal/upstreams/flow/sub_aggregation_internal_test.go
@@ -1,0 +1,114 @@
+package flow
+
+import (
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubChainSupervisor exposes a fixed ChainSupervisorState for gating tests.
+type stubChainSupervisor struct {
+	state upstreams.ChainSupervisorState
+}
+
+func (s *stubChainSupervisor) Start()                                        {}
+func (s *stubChainSupervisor) GetChain() chains.Chain                        { return chains.ETHEREUM }
+func (s *stubChainSupervisor) GetChainState() upstreams.ChainSupervisorState { return s.state }
+func (s *stubChainSupervisor) GetMethod(string) *specs.Method                { return nil }
+func (s *stubChainSupervisor) GetMethods() []string                          { return nil }
+func (s *stubChainSupervisor) GetUpstreamState(string) *protocol.UpstreamState {
+	return nil
+}
+func (s *stubChainSupervisor) GetSortedUpstreamIds(upstreams.FilterUpstream, upstreams.SortUpstream) []string {
+	return nil
+}
+func (s *stubChainSupervisor) GetUpstreamIds() []string                    { return nil }
+func (s *stubChainSupervisor) PublishUpstreamEvent(protocol.UpstreamEvent) {}
+func (s *stubChainSupervisor) SubscribeState(string) *utils.Subscription[*upstreams.ChainSupervisorStateWrapperEvent] {
+	return nil
+}
+
+var _ upstreams.ChainSupervisor = (*stubChainSupervisor)(nil)
+
+func TestLocalNewHeadsAvailable(t *testing.T) {
+	// nil chain supervisor → not available
+	supNil := mocks.NewUpstreamSupervisorMock()
+	supNil.On("GetChainSupervisor", chains.ETHEREUM).Return(nil)
+	assert.False(t, localNewHeadsAvailable(chains.ETHEREUM, supNil))
+
+	// json-rpc head connector → no NewHeadsCap → falls back to generic
+	supRpc := mocks.NewUpstreamSupervisorMock()
+	supRpc.On("GetChainSupervisor", chains.ETHEREUM).Return(&stubChainSupervisor{
+		state: upstreams.ChainSupervisorState{Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap)},
+	})
+	assert.False(t, localNewHeadsAvailable(chains.ETHEREUM, supRpc))
+
+	// websocket head connector → NewHeadsCap → local synthesis
+	supSub := mocks.NewUpstreamSupervisorMock()
+	supSub.On("GetChainSupervisor", chains.ETHEREUM).Return(&stubChainSupervisor{
+		state: upstreams.ChainSupervisorState{Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap)},
+	})
+	assert.True(t, localNewHeadsAvailable(chains.ETHEREUM, supSub))
+}
+
+func TestSelectorKeyIsOrderIndependent(t *testing.T) {
+	a := []protocol.RequestSelector{
+		protocol.RequestLabelSelector{Name: "region", Values: []string{"eu", "us"}},
+		protocol.RequestExistsSelector{Name: "archive"},
+	}
+	b := []protocol.RequestSelector{
+		protocol.RequestExistsSelector{Name: "archive"},
+		protocol.RequestLabelSelector{Name: "region", Values: []string{"us", "eu"}},
+	}
+	assert.Equal(t, selectorKey(a), selectorKey(b))
+}
+
+func TestSelectorKeyNestedGroupsAreOrderIndependent(t *testing.T) {
+	a := selectorKey([]protocol.RequestSelector{
+		protocol.RequestAndSelector{Children: []protocol.RequestSelector{
+			protocol.RequestExistsSelector{Name: "archive"},
+			protocol.RequestLabelSelector{Name: "region", Values: []string{"eu", "us"}},
+		}},
+	})
+	b := selectorKey([]protocol.RequestSelector{
+		protocol.RequestAndSelector{Children: []protocol.RequestSelector{
+			protocol.RequestLabelSelector{Name: "region", Values: []string{"us", "eu"}},
+			protocol.RequestExistsSelector{Name: "archive"},
+		}},
+	})
+	assert.Equal(t, a, b)
+}
+
+func TestSelectorKeyDistinguishesSelectors(t *testing.T) {
+	a := selectorKey([]protocol.RequestSelector{protocol.RequestLabelSelector{Name: "region", Values: []string{"eu"}}})
+	b := selectorKey([]protocol.RequestSelector{protocol.RequestLabelSelector{Name: "region", Values: []string{"us"}}})
+	assert.NotEqual(t, a, b)
+	assert.Empty(t, selectorKey(nil))
+}
+
+func TestIsNewHeadsRequest(t *testing.T) {
+	newHeads := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}, true, "eth")
+	logs := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["logs",{}]`)}, true, "eth")
+	other := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_call", Params: []byte(`[]`)}, false, "eth")
+
+	assert.True(t, isNewHeadsRequest(newHeads))
+	assert.False(t, isNewHeadsRequest(logs))
+	assert.False(t, isNewHeadsRequest(other))
+}
+
+func TestSubscriptionKeyDependsOnMethodParamsAndSelectors(t *testing.T) {
+	newHeads := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}, true, "eth")
+	logs := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["logs"]`)}, true, "eth")
+	newHeadsAgain := protocol.NewUpstreamJsonRpcRequest("2", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}, true, "eth")
+
+	assert.NotEqual(t, subscriptionKey(newHeads), subscriptionKey(logs))
+	// same method+params (different client id) collapse onto the same source
+	assert.Equal(t, subscriptionKey(newHeads), subscriptionKey(newHeadsAgain))
+}

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -48,7 +48,7 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 		defer close(responses)
 
 		if request.SpecMethod() == nil || request.SpecMethod().Subscription == nil {
-			responses <- failureWrapper(request, errors.New("no subscription info"))
+			responses <- totalFailureWrapper(request, errors.New("no subscription info"))
 			return
 		}
 
@@ -63,22 +63,18 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 		// The shared source emits events only - each client allocates its own
 		// client-facing subscription id below, independent of the single
 		// upstream subscription id.
-		key := subscriptionKey(request)
-		events, unsub, err := s.engine.Subscribe(key, sourceBuilder(s.chain, s.upstreamSupervisor, request, upstreamStrategy))
+		key, builder := resolveSource(s.chain, s.upstreamSupervisor, request, upstreamStrategy)
+		sub, err := s.engine.Subscribe(key, builder)
 		if err != nil {
-			responses <- failureWrapper(request, err)
+			responses <- totalFailureWrapper(request, err)
 			return
 		}
-		defer unsub()
+		defer sub.Unsubscribe()
 
 		subId, err := nextSubscriptionJson(isSolana(s.chain))
 		if err != nil {
 			log.Error().Err(err).Msgf("failed to generate subscription id for %s", request.Method())
-			responses <- &protocol.ResponseHolderWrapper{
-				UpstreamId: NoUpstream,
-				RequestId:  request.Id(),
-				Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
-			}
+			responses <- totalFailureWrapper(request, protocol.WsTotalFailureError())
 			return
 		}
 		s.subCtx.AddSub(protocol.ResultAsString(subId), cancel)
@@ -90,15 +86,14 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 
 		for {
 			select {
-			case r, ok := <-events:
+			case r, ok := <-sub.Events:
 				if !ok {
-					return
-				}
-				if r.Error != nil {
-					responses <- &protocol.ResponseHolderWrapper{
-						UpstreamId: responseUpstreamId(r),
-						RequestId:  request.Id(),
-						Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
+					// The shared source ended. A non-nil cause is a terminal
+					// failure (node disconnect, param reject, slow consumer);
+					// nil means this client detached cleanly. The real cause is
+					// preserved rather than collapsed into a generic error.
+					if cause := sub.Err(); cause != nil {
+						responses <- totalFailureWrapper(request, cause)
 					}
 					return
 				}
@@ -120,14 +115,6 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 	}()
 
 	return &SubscriptionResponse{responses}
-}
-
-func failureWrapper(request protocol.RequestHolder, err error) *protocol.ResponseHolderWrapper {
-	return &protocol.ResponseHolderWrapper{
-		UpstreamId: NoUpstream,
-		RequestId:  request.Id(),
-		Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
-	}
 }
 
 func responseUpstreamId(r *protocol.WsResponse) string {

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -8,22 +8,33 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/chains"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
 type SubscriptionRequestProcessor struct {
+	chain              chains.Chain
 	upstreamSupervisor upstreams.UpstreamSupervisor
+	engine             subengine.Engine
 	subCtx             *SubCtx
 }
 
-func NewSubscriptionRequestProcessor(upstreamSupervisor upstreams.UpstreamSupervisor, subCtx *SubCtx) *SubscriptionRequestProcessor {
-	return &SubscriptionRequestProcessor{upstreamSupervisor: upstreamSupervisor, subCtx: subCtx}
+func NewSubscriptionRequestProcessor(
+	chain chains.Chain,
+	upstreamSupervisor upstreams.UpstreamSupervisor,
+	engine subengine.Engine,
+	subCtx *SubCtx,
+) *SubscriptionRequestProcessor {
+	return &SubscriptionRequestProcessor{
+		chain:              chain,
+		upstreamSupervisor: upstreamSupervisor,
+		engine:             engine,
+		subCtx:             subCtx,
+	}
 }
 
 func (s *SubscriptionRequestProcessor) ProcessRequest(
@@ -35,118 +46,73 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 
 	go func() {
 		defer close(responses)
-		var response *protocol.ResponseHolderWrapper
 
 		if request.SpecMethod() == nil || request.SpecMethod().Subscription == nil {
-			response = &protocol.ResponseHolderWrapper{
-				UpstreamId: NoUpstream,
-				RequestId:  request.Id(),
-				Response:   protocol.NewTotalFailureFromErr(request.Id(), errors.New("no subscription info"), request.RequestType()),
-			}
-			responses <- response
+			responses <- failureWrapper(request, errors.New("no subscription info"))
 			return
 		}
 
 		method := request.SpecMethod().Subscription.Method
 
-		//TODO: it might be a good idea to select an upstream with a ws (or other sub) head connector
-		// and receive updates from it in order to reduce client's costs
-		// otherwise choose any upstream with a sub capability
-		upstreamId, err := upstreamStrategy.SelectUpstream(request)
-		if err != nil {
-			response = &protocol.ResponseHolderWrapper{
-				UpstreamId: NoUpstream,
-				RequestId:  request.Id(),
-				Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
-			}
-			responses <- response
-			return
-		}
-
-		upstream := s.upstreamSupervisor.GetUpstream(upstreamId)
-
-		// however there could be other connectors as well
-		// like http connector to support SSE
-		wsConn := getMethodConnector(upstream, request.SpecMethod())
-		if wsConn == nil {
-			response = &protocol.ResponseHolderWrapper{
-				UpstreamId: NoUpstream,
-				RequestId:  request.Id(),
-				Response:   protocol.NewTotalFailure(request, protocol.NoApiConnectorsError(request.Method())),
-			}
-			responses <- response
-			return
-		}
-
 		execCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		var stateChan chan protocol.SubscribeConnectorState
-		connectorStatesSub := wsConn.SubscribeStates(
-			fmt.Sprintf("%s_%s_request_%s_%d", upstream.GetId(), request.Method(), uuid.NewString(), time.Now().UnixNano()),
-		)
-		if connectorStatesSub != nil {
-			stateChan = connectorStatesSub.Events
-			defer connectorStatesSub.Unsubscribe()
-		}
-
-		subResp, err := wsConn.Subscribe(execCtx, request)
+		// All subscriptions route through the per-chain aggregation engine so
+		// identical (method+params+selector) subscriptions share a single
+		// upstream source instead of opening one node subscription per client.
+		// The shared source emits events only - each client allocates its own
+		// client-facing subscription id below, independent of the single
+		// upstream subscription id.
+		key := subscriptionKey(request)
+		events, unsub, err := s.engine.Subscribe(key, sourceBuilder(s.chain, s.upstreamSupervisor, request, upstreamStrategy))
 		if err != nil {
-			response = &protocol.ResponseHolderWrapper{
-				UpstreamId: NoUpstream,
-				RequestId:  request.Id(),
-				Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
-			}
-			responses <- response
+			responses <- failureWrapper(request, err)
 			return
 		}
-		var currentSubId json.RawMessage
+		defer unsub()
+
+		subId, err := nextSubscriptionJson(isSolana(s.chain))
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to generate subscription id for %s", request.Method())
+			responses <- &protocol.ResponseHolderWrapper{
+				UpstreamId: NoUpstream,
+				RequestId:  request.Id(),
+				Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
+			}
+			return
+		}
+		s.subCtx.AddSub(protocol.ResultAsString(subId), cancel)
+		responses <- &protocol.ResponseHolderWrapper{
+			UpstreamId: NoUpstream,
+			RequestId:  request.Id(),
+			Response:   protocol.NewSubscriptionMessageEventResponse(request.Id(), subId),
+		}
 
 		for {
 			select {
-			case state, ok := <-stateChan:
-				if ok {
-					if state == protocol.WsDisconnected {
-						responses <- &protocol.ResponseHolderWrapper{
-							UpstreamId: upstreamId,
-							RequestId:  request.Id(),
-							Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
-						}
-						return
-					}
-				}
-			case r, ok := <-subResp.ResponseChan():
+			case r, ok := <-events:
 				if !ok {
 					return
 				}
-				var subResponse protocol.ResponseHolder
-				if r.SubId == "" {
-					subId, err := nextSubscriptionJson(isSolana(upstream.GetChain()))
-					if err != nil {
-						log.Error().Err(err).Msgf("failed to generate subscription id for %s", request.Method())
-						responses <- &protocol.ResponseHolderWrapper{
-							UpstreamId: upstreamId,
-							RequestId:  request.Id(),
-							Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
-						}
-						return
+				if r.Error != nil {
+					responses <- &protocol.ResponseHolderWrapper{
+						UpstreamId: responseUpstreamId(r),
+						RequestId:  request.Id(),
+						Response:   protocol.NewTotalFailureFromErr(request.Id(), protocol.WsTotalFailureError(), request.RequestType()),
 					}
-					currentSubId = subId
-					s.subCtx.AddSub(protocol.ResultAsString(subId), cancel)
-					subResponse = protocol.NewSubscriptionMessageEventResponse(request.Id(), subId)
-				} else {
-					if s.subCtx.IsSubscriptionResultOnly() {
-						subResponse = protocol.NewSubscriptionResultEventResponse(request.Id(), r.Message)
-					} else {
-						subResponse = protocol.NewSubscriptionMethodResultResponse(request.Id(), method, r.Message, currentSubId)
-					}
+					return
 				}
-				wrapper := &protocol.ResponseHolderWrapper{
-					UpstreamId: upstreamId,
+				var subResponse protocol.ResponseHolder
+				if s.subCtx.IsSubscriptionResultOnly() {
+					subResponse = protocol.NewSubscriptionResultEventResponse(request.Id(), r.Message)
+				} else {
+					subResponse = protocol.NewSubscriptionMethodResultResponse(request.Id(), method, r.Message, subId)
+				}
+				responses <- &protocol.ResponseHolderWrapper{
+					UpstreamId: responseUpstreamId(r),
 					RequestId:  request.Id(),
 					Response:   subResponse,
 				}
-				responses <- wrapper
 			case <-execCtx.Done():
 				return
 			}
@@ -154,6 +120,21 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 	}()
 
 	return &SubscriptionResponse{responses}
+}
+
+func failureWrapper(request protocol.RequestHolder, err error) *protocol.ResponseHolderWrapper {
+	return &protocol.ResponseHolderWrapper{
+		UpstreamId: NoUpstream,
+		RequestId:  request.Id(),
+		Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
+	}
+}
+
+func responseUpstreamId(r *protocol.WsResponse) string {
+	if r.UpstreamId != "" {
+		return r.UpstreamId
+	}
+	return NoUpstream
 }
 
 func isSolana(chain chains.Chain) bool {

--- a/internal/upstreams/flow/sub_processor_test.go
+++ b/internal/upstreams/flow/sub_processor_test.go
@@ -34,7 +34,7 @@ func newSubProcessor(upSupervisor *mocks.UpstreamSupervisorMock, subCtx *flow.Su
 	// No local-newHeads availability, so these tests exercise the generic
 	// node-backed path; tests that want local synthesis override this.
 	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
-	engine := subengine.NewRegistry(context.Background(), upSupervisor).Get(chains.ETHEREUM)
+	engine := subengine.NewRegistry(context.Background()).Get(chains.ETHEREUM)
 	return flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, subCtx)
 }
 
@@ -202,7 +202,7 @@ func TestSubscriptionRequestProcessorTwoSubscribersShareOneUpstreamSub(t *testin
 	// No local-newHeads availability → both clients use the generic path.
 	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
 	// One shared engine backs both client processors.
-	engine := subengine.NewRegistry(ctx, upSupervisor).Get(chains.ETHEREUM)
+	engine := subengine.NewRegistry(ctx).Get(chains.ETHEREUM)
 	p1 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
 	p2 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
 

--- a/internal/upstreams/flow/sub_processor_test.go
+++ b/internal/upstreams/flow/sub_processor_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/flow"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
+	"github.com/drpcorg/nodecore/pkg/chains"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
 	"github.com/drpcorg/nodecore/pkg/test_utils"
 	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
@@ -22,12 +24,26 @@ func testEthSubscribeRequest() protocol.RequestHolder {
 	return protocol.NewUpstreamJsonRpcRequest("223", body, false, "eth")
 }
 
+func testEthSubscribeRequestWithId(id string) protocol.RequestHolder {
+	_ = specs.NewMethodSpecLoader().Load()
+	body := protocol.JsonRpcRequestBody{Id: []byte(id), Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}
+	return protocol.NewUpstreamJsonRpcRequest(id, body, false, "eth")
+}
+
+func newSubProcessor(upSupervisor *mocks.UpstreamSupervisorMock, subCtx *flow.SubCtx) *flow.SubscriptionRequestProcessor {
+	// No local-newHeads availability, so these tests exercise the generic
+	// node-backed path; tests that want local synthesis override this.
+	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
+	engine := subengine.NewRegistry(context.Background(), upSupervisor).Get(chains.ETHEREUM)
+	return flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, subCtx)
+}
+
 func TestSubscriptionRequestProcessorAndCantSelectUpstreamThenError(t *testing.T) {
 	upSupervisor := mocks.NewUpstreamSupervisorMock()
 	strategy := mocks.NewMockStrategy()
 	request := testEthSubscribeRequest()
 	err := errors.New("selection error")
-	processor := flow.NewSubscriptionRequestProcessor(upSupervisor, flow.NewSubCtx())
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
 
 	strategy.On("SelectUpstream", request).Return("", err)
 
@@ -54,14 +70,11 @@ func TestSubscriptionRequestProcessorAndCantSubscribeThenError(t *testing.T) {
 	request := testEthSubscribeRequest()
 	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
 	err := errors.New("sub error")
-	processor := flow.NewSubscriptionRequestProcessor(upSupervisor, flow.NewSubCtx())
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
 
 	strategy.On("SelectUpstream", request).Return("id", nil)
 	upSupervisor.On("GetUpstream", "id").Return(upstream)
 	apiConnector.On("Subscribe", mock.Anything, request).Return(nil, err)
-	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
-
-	processor.ProcessRequest(context.Background(), strategy, request)
 
 	response := processor.ProcessRequest(context.Background(), strategy, request)
 
@@ -80,34 +93,61 @@ func TestSubscriptionRequestProcessorAndCantSubscribeThenError(t *testing.T) {
 	assert.Equal(t, protocol.ResponseErrorWithData(500, "internal server error: sub error", nil), errorWrapper.Response.GetError())
 }
 
-func TestSubscriptionRequestProcessorAndCancelCtxThenNothing(t *testing.T) {
+// On subscribe the engine seeds a synthetic confirmation, so the first frame a
+// client receives is always its subscription-id ack.
+func TestSubscriptionRequestProcessorEmitsSubIdAck(t *testing.T) {
 	upSupervisor := mocks.NewUpstreamSupervisorMock()
 	strategy := mocks.NewMockStrategy()
 	apiConnector := mocks.NewWsConnectorMock()
 	request := testEthSubscribeRequest()
 	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	processor := flow.NewSubscriptionRequestProcessor(upSupervisor, flow.NewSubCtx())
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
 	respChan := make(chan *protocol.WsResponse)
 
 	strategy.On("SelectUpstream", request).Return("id", nil)
 	upSupervisor.On("GetUpstream", "id").Return(upstream)
 	apiConnector.On("Subscribe", mock.Anything, request).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil)
 	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
 
-	response := processor.ProcessRequest(ctx, strategy, request)
-
-	assert.IsType(t, &flow.SubscriptionResponse{}, response)
+	response := processor.ProcessRequest(context.Background(), strategy, request)
 
 	subRespWrappers := response.(*flow.SubscriptionResponse).ResponseWrappers
+	ackWrapper := <-subRespWrappers
+
+	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ackWrapper.Response)
+	assert.False(t, ackWrapper.Response.HasError())
+	assert.Equal(t, "223", ackWrapper.RequestId)
+	assert.Equal(t, flow.NoUpstream, ackWrapper.UpstreamId)
+}
+
+func TestSubscriptionRequestProcessorAndCancelCtxThenChannelCloses(t *testing.T) {
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+	apiConnector := mocks.NewWsConnectorMock()
+	request := testEthSubscribeRequest()
+	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
+	respChan := make(chan *protocol.WsResponse)
+
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+	apiConnector.On("Subscribe", mock.Anything, request).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil)
+	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
+
+	response := processor.ProcessRequest(ctx, strategy, request)
+	subRespWrappers := response.(*flow.SubscriptionResponse).ResponseWrappers
+
 	cancel()
-	responseWrapper := <-subRespWrappers
+	// Drain until the response channel is closed; cancellation must terminate
+	// the processor goroutine.
+	for range subRespWrappers {
+	}
 
 	strategy.AssertExpectations(t)
 	upSupervisor.AssertExpectations(t)
-	apiConnector.AssertExpectations(t)
-
-	assert.Nil(t, responseWrapper)
 }
 
 func TestSubscriptionRequestProcessorAndSubscribeThenReceiveEvent(t *testing.T) {
@@ -117,35 +157,121 @@ func TestSubscriptionRequestProcessorAndSubscribeThenReceiveEvent(t *testing.T) 
 	request := testEthSubscribeRequest()
 	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
 	ctx := context.Background()
-	processor := flow.NewSubscriptionRequestProcessor(upSupervisor, flow.NewSubCtx())
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
 	respChan := make(chan *protocol.WsResponse)
 	event := []byte("event")
 	go func() {
-		respChan <- &protocol.WsResponse{Event: event, SubId: "id"}
+		respChan <- &protocol.WsResponse{Message: event, SubId: "upstream-sub"}
 	}()
 
 	strategy.On("SelectUpstream", request).Return("id", nil)
 	upSupervisor.On("GetUpstream", "id").Return(upstream)
 	apiConnector.On("Subscribe", mock.Anything, request).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil)
 	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
 
 	response := processor.ProcessRequest(ctx, strategy, request)
 
 	assert.IsType(t, &flow.SubscriptionResponse{}, response)
 
 	subRespWrappers := response.(*flow.SubscriptionResponse).ResponseWrappers
+	<-subRespWrappers // subscription-id ack
 	responseWrapper := <-subRespWrappers
 
 	strategy.AssertExpectations(t)
 	upSupervisor.AssertExpectations(t)
-	apiConnector.AssertExpectations(t)
 
 	assert.IsType(t, &protocol.SubscriptionMethodResultResponse{}, responseWrapper.Response)
-	assert.Equal(t, []byte(nil), responseWrapper.Response.ResponseResult())
+	assert.Equal(t, event, responseWrapper.Response.ResponseResult())
 	assert.False(t, responseWrapper.Response.HasError())
 	assert.False(t, responseWrapper.Response.HasStream())
 	assert.Equal(t, "223", responseWrapper.RequestId)
 	assert.Equal(t, "id", responseWrapper.UpstreamId)
+}
+
+// Two clients subscribing to the same (method+params) share one upstream
+// subscription but each receives its own distinct subscription-id ack, and both
+// receive the fanned-out event.
+func TestSubscriptionRequestProcessorTwoSubscribersShareOneUpstreamSub(t *testing.T) {
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+	apiConnector := mocks.NewWsConnectorMock()
+	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
+	ctx := context.Background()
+
+	// No local-newHeads availability → both clients use the generic path.
+	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
+	// One shared engine backs both client processors.
+	engine := subengine.NewRegistry(ctx, upSupervisor).Get(chains.ETHEREUM)
+	p1 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
+	p2 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
+
+	req1 := testEthSubscribeRequestWithId("c1")
+	req2 := testEthSubscribeRequestWithId("c2")
+	respChan := make(chan *protocol.WsResponse, 4)
+
+	// The upstream subscription must be built exactly once, regardless of the
+	// number of clients.
+	strategy.On("SelectUpstream", mock.Anything).Return("id", nil).Once()
+	upSupervisor.On("GetUpstream", "id").Return(upstream).Once()
+	apiConnector.On("Subscribe", mock.Anything, mock.Anything).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil).Once()
+	apiConnector.On("SubscribeStates", mock.Anything).Return(nil).Once()
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
+
+	// First client subscribes and builds the shared source.
+	resp1 := p1.ProcessRequest(ctx, strategy, req1).(*flow.SubscriptionResponse).ResponseWrappers
+	ack1 := <-resp1
+	// Second client reuses the shared source.
+	resp2 := p2.ProcessRequest(ctx, strategy, req2).(*flow.SubscriptionResponse).ResponseWrappers
+	ack2 := <-resp2
+
+	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ack1.Response)
+	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ack2.Response)
+	subId1 := ack1.Response.ResponseResult()
+	subId2 := ack2.Response.ResponseResult()
+	assert.NotEmpty(t, subId1)
+	assert.NotEmpty(t, subId2)
+	assert.NotEqual(t, subId1, subId2, "each client must get its own subscription id")
+
+	// A single upstream event fans out to both clients.
+	respChan <- &protocol.WsResponse{SubId: "upstream-sub", Message: []byte("e")}
+	event1 := <-resp1
+	event2 := <-resp2
+	assert.Equal(t, []byte("e"), event1.Response.ResponseResult())
+	assert.Equal(t, []byte("e"), event2.Response.ResponseResult())
+
+	strategy.AssertExpectations(t)
+	upSupervisor.AssertExpectations(t)
+	apiConnector.AssertExpectations(t)
+}
+
+// When the shared upstream subscription drops (channel closes), the engine
+// propagates a terminal error and the processor surfaces it as a total failure
+// to the client (no durable reconnect).
+func TestSubscriptionRequestProcessorPropagatesUpstreamDisconnect(t *testing.T) {
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+	apiConnector := mocks.NewWsConnectorMock()
+	request := testEthSubscribeRequest()
+	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx())
+	respChan := make(chan *protocol.WsResponse)
+
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+	apiConnector.On("Subscribe", mock.Anything, request).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil)
+	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
+
+	subRespWrappers := processor.ProcessRequest(context.Background(), strategy, request).(*flow.SubscriptionResponse).ResponseWrappers
+	<-subRespWrappers // subscription-id ack
+
+	// Upstream subscription drops.
+	close(respChan)
+
+	terminal := <-subRespWrappers
+	assert.True(t, terminal.Response.HasError())
+	assert.Equal(t, protocol.WsTotalFailureError(), terminal.Response.GetError())
 }
 
 func TestSubscriptionRequestProcessorAndSubscribeThenReceiveResultOnlyEvent(t *testing.T) {
@@ -155,29 +281,29 @@ func TestSubscriptionRequestProcessorAndSubscribeThenReceiveResultOnlyEvent(t *t
 	request := testEthSubscribeRequest()
 	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
 	ctx := context.Background()
-	processor := flow.NewSubscriptionRequestProcessor(upSupervisor, flow.NewSubCtx().WithSubscriptionResultOnly(true))
+	processor := newSubProcessor(upSupervisor, flow.NewSubCtx().WithSubscriptionResultOnly(true))
 	respChan := make(chan *protocol.WsResponse)
-	event := []byte(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"id","result":{"foo":"bar"}}}`)
 	result := []byte(`{"foo":"bar"}`)
 	go func() {
-		respChan <- &protocol.WsResponse{Event: event, Message: result, SubId: "id"}
+		respChan <- &protocol.WsResponse{Message: result, SubId: "upstream-sub"}
 	}()
 
 	strategy.On("SelectUpstream", request).Return("id", nil)
 	upSupervisor.On("GetUpstream", "id").Return(upstream)
 	apiConnector.On("Subscribe", mock.Anything, request).Return(protocol.NewJsonRpcWsUpstreamResponse(respChan, "op-1"), nil)
 	apiConnector.On("SubscribeStates", mock.Anything).Return(nil)
+	apiConnector.On("Unsubscribe", mock.Anything).Return().Maybe()
 
 	response := processor.ProcessRequest(ctx, strategy, request)
 
 	assert.IsType(t, &flow.SubscriptionResponse{}, response)
 
 	subRespWrappers := response.(*flow.SubscriptionResponse).ResponseWrappers
+	<-subRespWrappers // subscription-id ack (skipped by gRPC since it is not an event frame)
 	responseWrapper := <-subRespWrappers
 
 	strategy.AssertExpectations(t)
 	upSupervisor.AssertExpectations(t)
-	apiConnector.AssertExpectations(t)
 
 	subscriptionResponse, ok := responseWrapper.Response.(protocol.SubscriptionResponseHolder)
 	assert.True(t, ok)

--- a/internal/upstreams/flow/subengine/engine.go
+++ b/internal/upstreams/flow/subengine/engine.go
@@ -4,27 +4,40 @@
 // instead of opening one node subscription per client.
 //
 // The engine is producer-agnostic: callers pass a SourceBuilder that knows how
-// to start the underlying source (a generic node-backed ws subscription, or -
-// in later stages - locally synthesized newHeads/logs). The engine owns
-// ref-counting, fan-out and lifecycle (teardown after the last client leaves).
+// to start the underlying source (a generic node-backed ws subscription, or
+// locally synthesized newHeads/logs).
+//
+// Design: each aggregation key is owned by a single goroutine (a sourceActor).
+// That goroutine holds ALL of the key's mutable state - subscribers, ref count,
+// teardown timer, terminal cause - as ordinary local variables, and is the only
+// thing that ever touches them. There are therefore no mutexes: concurrency is
+// resolved by channel sends to the actor, not by locking shared state. The
+// process-wide key -> actor map is the lock-free utils.CMap.
+//
+// Terminal state is delivered out of band: a subscriber learns the source ended
+// only by its Events channel being closed, after which Subscription.Err returns
+// the cause. The channel never carries an in-band error frame, so a terminal
+// signal can never be lost to a full buffer or missed by a late subscriber.
 package subengine
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
-	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/rs/zerolog/log"
 )
 
 // defaultTeardownDelay mirrors dshackle's refCount(1, 60s): the shared source is
 // kept alive for this long after the last subscriber leaves, so a quick
 // resubscribe reuses it instead of re-opening a node subscription.
 const defaultTeardownDelay = 10 * time.Second
+
+// subscriberBufferSize bounds how far a single subscriber may lag behind the
+// shared source before it is disconnected (see the fan-out in run).
+const subscriberBufferSize = 100
 
 // Source is a started, normalized subscription stream that the engine fans out.
 // Events carries upstream messages plus, on disconnect/error, a terminal
@@ -39,153 +52,253 @@ type Source struct {
 // engine when the source is torn down.
 type SourceBuilder func(srcCtx context.Context) (*Source, error)
 
-type sharedSource struct {
-	sm       *utils.SubscriptionManager[*protocol.WsResponse]
-	stop     func()
-	refs     int
-	seq      int
-	teardown *time.Timer
-	closed   bool
-}
-
 // Engine aggregates subscriptions for a single chain. Consumers depend on this
 // interface; the concrete implementation is baseEngine.
 type Engine interface {
 	// Subscribe attaches a subscriber to the shared source identified by key,
 	// building it via build on the first subscriber. See baseEngine.Subscribe.
-	Subscribe(key string, build SourceBuilder) (<-chan *protocol.WsResponse, func(), error)
+	Subscribe(key string, build SourceBuilder) (*Subscription, error)
+}
+
+// subscriber is a single client's view of a shared source, owned entirely by the
+// source's actor goroutine.
+type subscriber struct {
+	id  int
+	ch  chan *protocol.WsResponse // data events; the actor closes it to signal terminal
+	err *protocol.ResponseError   // set by the actor before close(ch); read by the client after
+}
+
+// subscribeCmd asks the actor to attach a new subscriber and reply with its
+// Subscription.
+type subscribeCmd struct {
+	reply chan *Subscription
+}
+
+// sourceActor is the handle other goroutines use to talk to a key's owning
+// goroutine. All of its fields are immutable after creation except buildErr,
+// which is written once before done is closed and read only after done.
+type sourceActor struct {
+	key         string
+	subscribe   chan subscribeCmd
+	unsubscribe chan *subscriber
+	done        chan struct{} // closed when the actor stops accepting subscribers
+	buildErr    error         // write-once before close(done); valid to read after <-done
+}
+
+// Subscription is a client's handle to a shared source.
+type Subscription struct {
+	Events <-chan *protocol.WsResponse
+
+	actor *sourceActor
+	sub   *subscriber
+}
+
+// Unsubscribe detaches this subscriber from the shared source. It is a guarded
+// send to the owning actor; the actor treats a repeated or unknown detach as a
+// no-op, so it is safe to call more than once.
+func (s *Subscription) Unsubscribe() {
+	select {
+	case s.actor.unsubscribe <- s.sub:
+	case <-s.actor.done: // actor already gone - nothing to detach from
+	}
+}
+
+// Err returns the terminal cause after Events has been closed. It returns nil
+// for a clean detach and a *protocol.ResponseError when the source died or this
+// subscriber was disconnected for lagging. Reading is safe without a lock: the
+// actor writes sub.err before closing the channel, and the client reads it only
+// after observing the close (which establishes the happens-before edge).
+func (s *Subscription) Err() *protocol.ResponseError {
+	return s.sub.err
 }
 
 // baseEngine is the default Engine implementation.
 type baseEngine struct {
 	ctx           context.Context
 	chain         chains.Chain
-	sup           upstreams.UpstreamSupervisor
 	teardownDelay time.Duration
 
-	mu      sync.Mutex
-	sources map[string]*sharedSource
+	sources *utils.CMap[string, *sourceActor]
 }
 
 var _ Engine = (*baseEngine)(nil)
 
-func NewEngine(ctx context.Context, chain chains.Chain, sup upstreams.UpstreamSupervisor) Engine {
+func NewEngine(ctx context.Context, chain chains.Chain) Engine {
 	return &baseEngine{
 		ctx:           ctx,
 		chain:         chain,
-		sup:           sup,
 		teardownDelay: defaultTeardownDelay,
-		sources:       make(map[string]*sharedSource),
+		sources:       utils.NewCMap[string, *sourceActor](),
 	}
 }
 
 // Subscribe attaches a new subscriber to the shared source identified by key,
-// building the source via build on the first subscriber. It returns the
-// subscriber's event channel, an unsubscribe func to detach, and a build error
-// if the source could not be started.
+// building the source via build on the first subscriber. It returns a
+// Subscription whose Events channel carries data events and is closed on
+// termination (the cause is then available via Subscription.Err), or a build
+// error if the source could not be started.
 //
-// The channel carries subscription events and, on disconnect/error, a terminal
-// *protocol.WsResponse with Error set. It never carries subscription
-// confirmations: the upstream's own confirmation is swallowed by the source
-// builder, and each subscriber allocates its own client-facing subscription id
-// in the caller (see SubscriptionRequestProcessor).
-func (e *baseEngine) Subscribe(key string, build SourceBuilder) (<-chan *protocol.WsResponse, func(), error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	s, ok := e.sources[key]
-	var pumpEvents <-chan *protocol.WsResponse
-	if !ok {
-		srcCtx, cancel := context.WithCancel(e.ctx)
-		src, err := build(srcCtx)
-		if err != nil {
-			cancel()
-			return nil, nil, err
+// The event channel never carries subscription confirmations: the upstream's
+// own confirmation is swallowed by the source builder, and each subscriber
+// allocates its own client-facing subscription id in the caller (see
+// SubscriptionRequestProcessor).
+func (e *baseEngine) Subscribe(key string, build SourceBuilder) (*Subscription, error) {
+	for {
+		a := e.getOrCreate(key, build)
+		reply := make(chan *Subscription, 1)
+		select {
+		case a.subscribe <- subscribeCmd{reply: reply}:
+			return <-reply, nil
+		case <-a.done:
+			// The actor stopped accepting subscribers. If the build failed, the
+			// error is definitive - return it (never spin retrying). Otherwise
+			// the source was torn down or terminated, and this new caller should
+			// transparently build a fresh one.
+			if a.buildErr != nil {
+				return nil, a.buildErr
+			}
 		}
-		var stopOnce sync.Once
-		s = &sharedSource{
-			sm: utils.NewSubscriptionManager[*protocol.WsResponse](fmt.Sprintf("subengine_%s_%s", e.chain, key)),
-			stop: func() {
-				stopOnce.Do(func() {
-					src.Stop()
-					cancel()
-				})
-			},
-		}
-		e.sources[key] = s
-		pumpEvents = src.Events
 	}
-
-	if s.teardown != nil {
-		s.teardown.Stop()
-		s.teardown = nil
-	}
-	s.refs++
-	s.seq++
-	sub := s.sm.SubscribeWithSize(fmt.Sprintf("sub-%d", s.seq), 100)
-
-	// Start pumping only once the first subscriber is attached, so a fast
-	// source cannot publish (and drop) events before anyone is listening.
-	if pumpEvents != nil {
-		go e.pump(key, s, pumpEvents)
-	}
-
-	var once sync.Once
-	unsub := func() {
-		once.Do(func() {
-			sub.Unsubscribe()
-			e.detach(key)
-		})
-	}
-	return sub.Events, unsub, nil
 }
 
-// pump forwards every source event to the source's subscribers and, when the
-// source ends, removes it from the engine and releases it.
-func (e *baseEngine) pump(key string, s *sharedSource, events <-chan *protocol.WsResponse) {
-	for ev := range events {
-		s.sm.Publish(ev)
+func (e *baseEngine) getOrCreate(key string, build SourceBuilder) *sourceActor {
+	if a, ok := e.sources.Load(key); ok {
+		return a
 	}
-	e.mu.Lock()
-	if !s.closed {
-		s.closed = true
-		if s.teardown != nil {
-			s.teardown.Stop()
-			s.teardown = nil
-		}
-		if cur, ok := e.sources[key]; ok && cur == s {
-			delete(e.sources, key)
-		}
+	a := &sourceActor{
+		key:         key,
+		subscribe:   make(chan subscribeCmd),
+		unsubscribe: make(chan *subscriber),
+		done:        make(chan struct{}),
 	}
-	e.mu.Unlock()
-	s.stop()
+	if actual, loaded := e.sources.LoadOrStore(key, a); loaded {
+		return actual // lost the create race; our actor was never started
+	}
+	go e.run(a, build)
+	return a
 }
 
-// detach decrements the ref count and, when it reaches zero, schedules teardown
-// after teardownDelay.
-func (e *baseEngine) detach(key string) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	s, ok := e.sources[key]
-	if !ok {
+func (e *baseEngine) newSubscription(a *sourceActor, sub *subscriber) *Subscription {
+	return &Subscription{Events: sub.ch, actor: a, sub: sub}
+}
+
+// run is the actor goroutine: it builds the source once, then owns all of the
+// key's state inside a single select loop until the source ends.
+func (e *baseEngine) run(a *sourceActor, build SourceBuilder) {
+	srcCtx, cancel := context.WithCancel(e.ctx)
+	src, err := build(srcCtx)
+	if err != nil {
+		a.buildErr = err
+		e.sources.CompareAndDelete(a.key, a)
+		close(a.done)
+		cancel()
 		return
 	}
-	s.refs--
-	if s.refs <= 0 && !s.closed && s.teardown == nil {
-		s.teardown = time.AfterFunc(e.teardownDelay, func() { e.teardownSource(key, s) })
-	}
-}
 
-func (e *baseEngine) teardownSource(key string, s *sharedSource) {
-	e.mu.Lock()
-	if s.closed || s.refs > 0 {
-		e.mu.Unlock()
-		return
+	subs := make(map[int]*subscriber)
+	var seq, refs int
+	var teardown *time.Timer
+	var teardownC <-chan time.Time // nil unless armed; a nil channel never fires
+
+	var srcEvents <-chan *protocol.WsResponse
+
+	// arm starts the teardown grace timer: once
+	// the last subscriber has left, the source is kept alive for teardownDelay so
+	// a quick resubscribe can reuse it. When the timer fires, the <-teardownC case
+	// tears the source down. teardownC mirrors the timer's channel so the select
+	// can wait on it; while disarmed it is nil and that select case never fires.
+	arm := func() {
+		teardown = time.NewTimer(e.teardownDelay)
+		teardownC = teardown.C
 	}
-	s.closed = true
-	if cur, ok := e.sources[key]; ok && cur == s {
-		delete(e.sources, key)
+	// disarm cancels a running grace timer - called when a subscriber attaches, so
+	// a source with live subscribers is never torn down. Safe to call when no
+	// timer is armed (no-op).
+	disarm := func() {
+		if teardown != nil {
+			teardown.Stop()
+			teardown, teardownC = nil, nil
+		}
 	}
-	e.mu.Unlock()
-	s.stop()
+
+	// terminate closes every subscriber out of band (cause first, then close so
+	// the client reads it), removes the source, and releases it. After it runs
+	// the actor returns and no longer accepts subscribers.
+	terminate := func(cause *protocol.ResponseError) {
+		if cause == nil {
+			cause = protocol.WsTotalFailureError()
+		}
+		for _, s := range subs {
+			s.err = cause
+			close(s.ch)
+		}
+		e.sources.CompareAndDelete(a.key, a)
+		close(a.done)
+		cancel()
+		src.Stop()
+	}
+
+	for {
+		select {
+		case <-e.ctx.Done():
+			terminate(protocol.WsTotalFailureError())
+			return
+
+		case ev, ok := <-srcEvents:
+			if !ok {
+				terminate(nil)
+				return
+			}
+			if ev.Error != nil {
+				terminate(ev.Error)
+				return
+			}
+			for id, s := range subs {
+				select {
+				case s.ch <- ev:
+				default:
+					// Slow consumer: disconnect it (no silent data gaps) rather
+					// than dropping the event. Its later Unsubscribe is a no-op.
+					s.err = protocol.WsSubscriberTooSlowError()
+					close(s.ch)
+					delete(subs, id)
+					refs--
+					log.Warn().Msgf("disconnected lagging subscriber %s/sub-%d: buffer of %d full", a.key, id, subscriberBufferSize)
+				}
+			}
+			if refs == 0 && teardownC == nil {
+				// Arm the grace timer only if it isn't already running. Events keep
+				// arriving with no audience during the teardown window; re-arming on
+				// each one would reset the window indefinitely and a source on an
+				// active chain (event interval < teardownDelay) would never tear down.
+				arm()
+			}
+
+		case cmd := <-a.subscribe:
+			disarm() // a resubscribe within the teardown window revives the source
+			if srcEvents == nil {
+				srcEvents = src.Events // first listener: start draining the source
+			}
+			seq++
+			refs++
+			s := &subscriber{id: seq, ch: make(chan *protocol.WsResponse, subscriberBufferSize)}
+			subs[s.id] = s
+			cmd.reply <- e.newSubscription(a, s)
+
+		case s := <-a.unsubscribe:
+			if _, ok := subs[s.id]; ok {
+				delete(subs, s.id)
+				refs--
+				if refs == 0 && teardownC == nil {
+					arm()
+				}
+			}
+
+		case <-teardownC:
+			if refs == 0 {
+				terminate(nil)
+				return
+			}
+		}
+	}
 }

--- a/internal/upstreams/flow/subengine/engine.go
+++ b/internal/upstreams/flow/subengine/engine.go
@@ -1,0 +1,191 @@
+// Package subengine implements a per-chain subscription aggregation engine. It
+// dedups subscriptions by a caller-provided key so that identical client
+// subscriptions share a single upstream source and fan out from one channel,
+// instead of opening one node subscription per client.
+//
+// The engine is producer-agnostic: callers pass a SourceBuilder that knows how
+// to start the underlying source (a generic node-backed ws subscription, or -
+// in later stages - locally synthesized newHeads/logs). The engine owns
+// ref-counting, fan-out and lifecycle (teardown after the last client leaves).
+package subengine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/utils"
+)
+
+// defaultTeardownDelay mirrors dshackle's refCount(1, 60s): the shared source is
+// kept alive for this long after the last subscriber leaves, so a quick
+// resubscribe reuses it instead of re-opening a node subscription.
+const defaultTeardownDelay = 10 * time.Second
+
+// Source is a started, normalized subscription stream that the engine fans out.
+// Events carries upstream messages plus, on disconnect/error, a terminal
+// *protocol.WsResponse with Error set; the channel is closed when the source
+// ends. Stop releases the underlying resources (node unsubscribe, goroutines).
+type Source struct {
+	Events <-chan *protocol.WsResponse
+	Stop   func()
+}
+
+// SourceBuilder starts a Source bound to srcCtx. srcCtx is cancelled by the
+// engine when the source is torn down.
+type SourceBuilder func(srcCtx context.Context) (*Source, error)
+
+type sharedSource struct {
+	sm       *utils.SubscriptionManager[*protocol.WsResponse]
+	stop     func()
+	refs     int
+	seq      int
+	teardown *time.Timer
+	closed   bool
+}
+
+// Engine aggregates subscriptions for a single chain. Consumers depend on this
+// interface; the concrete implementation is baseEngine.
+type Engine interface {
+	// Subscribe attaches a subscriber to the shared source identified by key,
+	// building it via build on the first subscriber. See baseEngine.Subscribe.
+	Subscribe(key string, build SourceBuilder) (<-chan *protocol.WsResponse, func(), error)
+}
+
+// baseEngine is the default Engine implementation.
+type baseEngine struct {
+	ctx           context.Context
+	chain         chains.Chain
+	sup           upstreams.UpstreamSupervisor
+	teardownDelay time.Duration
+
+	mu      sync.Mutex
+	sources map[string]*sharedSource
+}
+
+var _ Engine = (*baseEngine)(nil)
+
+func NewEngine(ctx context.Context, chain chains.Chain, sup upstreams.UpstreamSupervisor) Engine {
+	return &baseEngine{
+		ctx:           ctx,
+		chain:         chain,
+		sup:           sup,
+		teardownDelay: defaultTeardownDelay,
+		sources:       make(map[string]*sharedSource),
+	}
+}
+
+// Subscribe attaches a new subscriber to the shared source identified by key,
+// building the source via build on the first subscriber. It returns the
+// subscriber's event channel, an unsubscribe func to detach, and a build error
+// if the source could not be started.
+//
+// The channel carries subscription events and, on disconnect/error, a terminal
+// *protocol.WsResponse with Error set. It never carries subscription
+// confirmations: the upstream's own confirmation is swallowed by the source
+// builder, and each subscriber allocates its own client-facing subscription id
+// in the caller (see SubscriptionRequestProcessor).
+func (e *baseEngine) Subscribe(key string, build SourceBuilder) (<-chan *protocol.WsResponse, func(), error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	s, ok := e.sources[key]
+	var pumpEvents <-chan *protocol.WsResponse
+	if !ok {
+		srcCtx, cancel := context.WithCancel(e.ctx)
+		src, err := build(srcCtx)
+		if err != nil {
+			cancel()
+			return nil, nil, err
+		}
+		var stopOnce sync.Once
+		s = &sharedSource{
+			sm: utils.NewSubscriptionManager[*protocol.WsResponse](fmt.Sprintf("subengine_%s_%s", e.chain, key)),
+			stop: func() {
+				stopOnce.Do(func() {
+					src.Stop()
+					cancel()
+				})
+			},
+		}
+		e.sources[key] = s
+		pumpEvents = src.Events
+	}
+
+	if s.teardown != nil {
+		s.teardown.Stop()
+		s.teardown = nil
+	}
+	s.refs++
+	s.seq++
+	sub := s.sm.SubscribeWithSize(fmt.Sprintf("sub-%d", s.seq), 100)
+
+	// Start pumping only once the first subscriber is attached, so a fast
+	// source cannot publish (and drop) events before anyone is listening.
+	if pumpEvents != nil {
+		go e.pump(key, s, pumpEvents)
+	}
+
+	var once sync.Once
+	unsub := func() {
+		once.Do(func() {
+			sub.Unsubscribe()
+			e.detach(key)
+		})
+	}
+	return sub.Events, unsub, nil
+}
+
+// pump forwards every source event to the source's subscribers and, when the
+// source ends, removes it from the engine and releases it.
+func (e *baseEngine) pump(key string, s *sharedSource, events <-chan *protocol.WsResponse) {
+	for ev := range events {
+		s.sm.Publish(ev)
+	}
+	e.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		if s.teardown != nil {
+			s.teardown.Stop()
+			s.teardown = nil
+		}
+		if cur, ok := e.sources[key]; ok && cur == s {
+			delete(e.sources, key)
+		}
+	}
+	e.mu.Unlock()
+	s.stop()
+}
+
+// detach decrements the ref count and, when it reaches zero, schedules teardown
+// after teardownDelay.
+func (e *baseEngine) detach(key string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	s, ok := e.sources[key]
+	if !ok {
+		return
+	}
+	s.refs--
+	if s.refs <= 0 && !s.closed && s.teardown == nil {
+		s.teardown = time.AfterFunc(e.teardownDelay, func() { e.teardownSource(key, s) })
+	}
+}
+
+func (e *baseEngine) teardownSource(key string, s *sharedSource) {
+	e.mu.Lock()
+	if s.closed || s.refs > 0 {
+		e.mu.Unlock()
+		return
+	}
+	s.closed = true
+	if cur, ok := e.sources[key]; ok && cur == s {
+		delete(e.sources, key)
+	}
+	e.mu.Unlock()
+	s.stop()
+}

--- a/internal/upstreams/flow/subengine/engine_test.go
+++ b/internal/upstreams/flow/subengine/engine_test.go
@@ -1,0 +1,152 @@
+package subengine
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEngine(delay time.Duration) *baseEngine {
+	return &baseEngine{
+		ctx:           context.Background(),
+		chain:         chains.ETHEREUM,
+		teardownDelay: delay,
+		sources:       make(map[string]*sharedSource),
+	}
+}
+
+// Two subscribers sharing a key must reuse one source (build called once) and
+// both receive the same fanned-out events.
+func TestEngineSharesSourceAcrossSubscribers(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	var builds int32
+	events := make(chan *protocol.WsResponse, 8)
+	build := func(_ context.Context) (*Source, error) {
+		atomic.AddInt32(&builds, 1)
+		return &Source{Events: events, Stop: func() {}}, nil
+	}
+
+	ch1, unsub1, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	ch2, unsub2, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+
+	// the shared event fans out to every subscriber
+	events <- &protocol.WsResponse{SubId: "x", Message: []byte("e")}
+	assert.Equal(t, []byte("e"), (<-ch1).Message)
+	assert.Equal(t, []byte("e"), (<-ch2).Message)
+
+	unsub1()
+	unsub2()
+}
+
+func TestEngineDistinctKeysBuildSeparately(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	var builds int32
+	build := func(_ context.Context) (*Source, error) {
+		atomic.AddInt32(&builds, 1)
+		return &Source{Events: make(chan *protocol.WsResponse), Stop: func() {}}, nil
+	}
+
+	_, _, err := e.Subscribe("k1", build)
+	require.NoError(t, err)
+	_, _, err = e.Subscribe("k2", build)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
+}
+
+func TestEngineBuildErrorIsReturned(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	_, _, err := e.Subscribe("k", func(_ context.Context) (*Source, error) {
+		return nil, assert.AnError
+	})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// After the last subscriber leaves the source is torn down once teardownDelay
+// elapses.
+func TestEngineTeardownAfterLastUnsub(t *testing.T) {
+	e := newTestEngine(30 * time.Millisecond)
+	stopped := make(chan struct{})
+	events := make(chan *protocol.WsResponse)
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() { close(events); close(stopped) }}, nil
+	}
+
+	_, unsub, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	unsub()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("source was not torn down after the last subscriber left")
+	}
+}
+
+// A resubscribe within the teardown window reuses the source rather than
+// rebuilding it.
+func TestEngineResubscribeWithinWindowReusesSource(t *testing.T) {
+	e := newTestEngine(time.Second)
+	var builds int32
+	events := make(chan *protocol.WsResponse, 8)
+	build := func(_ context.Context) (*Source, error) {
+		atomic.AddInt32(&builds, 1)
+		return &Source{Events: events, Stop: func() {}}, nil
+	}
+
+	_, unsub1, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	unsub1()
+	_, unsub2, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	defer unsub2()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
+}
+
+// A terminal frame from the source is fanned out to clients and removes the
+// source so the next subscribe rebuilds it.
+func TestEngineTerminalErrorRemovesSource(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	built := make(chan chan *protocol.WsResponse, 4)
+	build := func(_ context.Context) (*Source, error) {
+		ev := make(chan *protocol.WsResponse, 4)
+		built <- ev
+		return &Source{Events: ev, Stop: func() {}}, nil
+	}
+
+	ch1, _, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	ev1 := <-built
+
+	ev1 <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
+	close(ev1)
+
+	terminal := <-ch1
+	require.NotNil(t, terminal.Error)
+
+	require.Eventually(t, func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		_, ok := e.sources["k"]
+		return !ok
+	}, time.Second, 5*time.Millisecond)
+
+	_, _, err = e.Subscribe("k", build)
+	require.NoError(t, err)
+	select {
+	case <-built: // a second build happened
+	case <-time.After(time.Second):
+		t.Fatal("source was not rebuilt after a terminal error")
+	}
+}

--- a/internal/upstreams/flow/subengine/engine_test.go
+++ b/internal/upstreams/flow/subengine/engine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,12 +18,12 @@ func newTestEngine(delay time.Duration) *baseEngine {
 		ctx:           context.Background(),
 		chain:         chains.ETHEREUM,
 		teardownDelay: delay,
-		sources:       make(map[string]*sharedSource),
+		sources:       utils.NewCMap[string, *sourceActor](),
 	}
 }
 
-// Two subscribers sharing a key must reuse one source (build called once) and
-// both receive the same fanned-out events.
+// Two subscribers sharing a key reuse one source (build called once) and both
+// receive the same fanned-out events.
 func TestEngineSharesSourceAcrossSubscribers(t *testing.T) {
 	e := newTestEngine(time.Minute)
 	var builds int32
@@ -32,20 +33,41 @@ func TestEngineSharesSourceAcrossSubscribers(t *testing.T) {
 		return &Source{Events: events, Stop: func() {}}, nil
 	}
 
-	ch1, unsub1, err := e.Subscribe("k", build)
+	sub1, err := e.Subscribe("k", build)
 	require.NoError(t, err)
-	ch2, unsub2, err := e.Subscribe("k", build)
+	sub2, err := e.Subscribe("k", build)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
 
-	// the shared event fans out to every subscriber
 	events <- &protocol.WsResponse{SubId: "x", Message: []byte("e")}
-	assert.Equal(t, []byte("e"), (<-ch1).Message)
-	assert.Equal(t, []byte("e"), (<-ch2).Message)
+	assert.Equal(t, []byte("e"), (<-sub1.Events).Message)
+	assert.Equal(t, []byte("e"), (<-sub2.Events).Message)
 
-	unsub1()
-	unsub2()
+	sub1.Unsubscribe()
+	sub2.Unsubscribe()
+}
+
+// The source must not consume events before the first subscriber attaches: an
+// event already queued by the source at build time (e.g. the newHeads seed) is
+// delivered to the first subscriber, not dropped to an empty subscriber set.
+func TestEngineDoesNotDropEventsBeforeFirstSubscriber(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	events := make(chan *protocol.WsResponse, 4)
+	events <- &protocol.WsResponse{Message: []byte("seed")} // queued before anyone subscribes
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() {}}, nil
+	}
+
+	sub, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+
+	select {
+	case got := <-sub.Events:
+		assert.Equal(t, []byte("seed"), got.Message)
+	case <-time.After(time.Second):
+		t.Fatal("first subscriber missed an event the source had already queued")
+	}
 }
 
 func TestEngineDistinctKeysBuildSeparately(t *testing.T) {
@@ -56,20 +78,30 @@ func TestEngineDistinctKeysBuildSeparately(t *testing.T) {
 		return &Source{Events: make(chan *protocol.WsResponse), Stop: func() {}}, nil
 	}
 
-	_, _, err := e.Subscribe("k1", build)
+	_, err := e.Subscribe("k1", build)
 	require.NoError(t, err)
-	_, _, err = e.Subscribe("k2", build)
+	_, err = e.Subscribe("k2", build)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
 }
 
-func TestEngineBuildErrorIsReturned(t *testing.T) {
+// A build failure is returned to the caller and never retried into a spin.
+func TestEngineBuildErrorIsReturnedNotRetried(t *testing.T) {
 	e := newTestEngine(time.Minute)
-	_, _, err := e.Subscribe("k", func(_ context.Context) (*Source, error) {
+	var builds int32
+	_, err := e.Subscribe("k", func(_ context.Context) (*Source, error) {
+		atomic.AddInt32(&builds, 1)
 		return nil, assert.AnError
 	})
 	assert.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&builds), "build must run exactly once")
+
+	// A failed build must not leave an actor behind.
+	require.Eventually(t, func() bool {
+		_, ok := e.sources.Load("k")
+		return !ok
+	}, time.Second, 5*time.Millisecond)
 }
 
 // After the last subscriber leaves the source is torn down once teardownDelay
@@ -77,20 +109,57 @@ func TestEngineBuildErrorIsReturned(t *testing.T) {
 func TestEngineTeardownAfterLastUnsub(t *testing.T) {
 	e := newTestEngine(30 * time.Millisecond)
 	stopped := make(chan struct{})
-	events := make(chan *protocol.WsResponse)
 	build := func(_ context.Context) (*Source, error) {
-		return &Source{Events: events, Stop: func() { close(events); close(stopped) }}, nil
+		return &Source{Events: make(chan *protocol.WsResponse), Stop: func() { close(stopped) }}, nil
 	}
 
-	_, unsub, err := e.Subscribe("k", build)
+	sub, err := e.Subscribe("k", build)
 	require.NoError(t, err)
-	unsub()
+	sub.Unsubscribe()
 
 	select {
 	case <-stopped:
 	case <-time.After(time.Second):
 		t.Fatal("source was not torn down after the last subscriber left")
 	}
+}
+
+// Events arriving after the last subscriber leaves must not keep re-arming the
+// teardown timer: a source on an active chain (event interval < teardownDelay)
+// must still tear down once the grace window elapses.
+func TestEngineTeardownDespiteOngoingEvents(t *testing.T) {
+	e := newTestEngine(50 * time.Millisecond)
+	events := make(chan *protocol.WsResponse)
+	stopped := make(chan struct{})
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() { close(stopped) }}, nil
+	}
+
+	sub, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	sub.Unsubscribe()
+
+	// Keep emitting faster than teardownDelay; these have no audience.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case events <- &protocol.WsResponse{Message: []byte("e")}:
+			case <-stopped:
+				return
+			case <-time.After(time.Second):
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("source did not tear down while events kept flowing after the last unsub")
+	}
+	<-done
 }
 
 // A resubscribe within the teardown window reuses the source rather than
@@ -104,49 +173,132 @@ func TestEngineResubscribeWithinWindowReusesSource(t *testing.T) {
 		return &Source{Events: events, Stop: func() {}}, nil
 	}
 
-	_, unsub1, err := e.Subscribe("k", build)
+	sub1, err := e.Subscribe("k", build)
 	require.NoError(t, err)
-	unsub1()
-	_, unsub2, err := e.Subscribe("k", build)
+	sub1.Unsubscribe()
+	sub2, err := e.Subscribe("k", build)
 	require.NoError(t, err)
-	defer unsub2()
+	defer sub2.Unsubscribe()
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&builds))
 }
 
-// A terminal frame from the source is fanned out to clients and removes the
-// source so the next subscribe rebuilds it.
-func TestEngineTerminalErrorRemovesSource(t *testing.T) {
+// A terminal frame from the source closes every subscriber channel (out of
+// band), exposes the cause via Err, removes the source, and lets the next
+// Subscribe rebuild it.
+func TestEngineTerminalClosesAndRemovesSource(t *testing.T) {
 	e := newTestEngine(time.Minute)
+	var builds int32
 	built := make(chan chan *protocol.WsResponse, 4)
 	build := func(_ context.Context) (*Source, error) {
+		atomic.AddInt32(&builds, 1)
 		ev := make(chan *protocol.WsResponse, 4)
 		built <- ev
 		return &Source{Events: ev, Stop: func() {}}, nil
 	}
 
-	ch1, _, err := e.Subscribe("k", build)
+	sub1, err := e.Subscribe("k", build)
 	require.NoError(t, err)
 	ev1 := <-built
 
-	ev1 <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
-	close(ev1)
+	cause := &protocol.ResponseError{Code: 42, Message: "node said no"}
+	ev1 <- &protocol.WsResponse{Error: cause}
 
-	terminal := <-ch1
-	require.NotNil(t, terminal.Error)
+	_, ok := <-sub1.Events // closed, not an in-band frame
+	require.False(t, ok)
+	require.Equal(t, cause, sub1.Err())
 
 	require.Eventually(t, func() bool {
-		e.mu.Lock()
-		defer e.mu.Unlock()
-		_, ok := e.sources["k"]
+		_, ok := e.sources.Load("k")
 		return !ok
 	}, time.Second, 5*time.Millisecond)
 
-	_, _, err = e.Subscribe("k", build)
+	_, err = e.Subscribe("k", build)
 	require.NoError(t, err)
 	select {
-	case <-built: // a second build happened
+	case <-built:
+		assert.Equal(t, int32(2), atomic.LoadInt32(&builds))
 	case <-time.After(time.Second):
 		t.Fatal("source was not rebuilt after a terminal error")
 	}
+}
+
+// A terminal must never be lost to a full buffer: a subscriber that never drains
+// is disconnected with a terminal error instead of silently dropping events.
+func TestEngineSlowConsumerDisconnectedDespiteFullBuffer(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	events := make(chan *protocol.WsResponse)
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() {}}, nil
+	}
+	sub, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+
+	for i := 0; i < subscriberBufferSize+5; i++ {
+		events <- &protocol.WsResponse{Message: []byte("e")}
+	}
+
+	require.Eventually(t, func() bool { return sub.Err() != nil }, time.Second, 5*time.Millisecond)
+	for range sub.Events { // drain to the close
+	}
+	assert.Equal(t, protocol.WsSubscriberTooSlowError().Code, sub.Err().Code)
+}
+
+// A fast subscriber keeps receiving even when a peer on the same source is
+// disconnected for lagging.
+func TestEngineSlowConsumerDoesNotAffectFastPeer(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	events := make(chan *protocol.WsResponse)
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() {}}, nil
+	}
+	slow, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+	fast, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+
+	var got int64
+	go func() {
+		for range fast.Events {
+			atomic.AddInt64(&got, 1)
+		}
+	}()
+
+	for i := 0; i < subscriberBufferSize*3; i++ {
+		events <- &protocol.WsResponse{Message: []byte("e")}
+	}
+
+	require.Eventually(t, func() bool { return slow.Err() != nil }, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&got) > int64(subscriberBufferSize) }, time.Second, 5*time.Millisecond)
+	fast.Unsubscribe()
+}
+
+// A slow build for one key does not block subscribes for other keys (each key
+// has its own goroutine; no shared lock spans build).
+func TestEngineBuildDoesNotBlockOtherKeys(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	release := make(chan struct{})
+	slowBuild := func(_ context.Context) (*Source, error) {
+		<-release
+		return &Source{Events: make(chan *protocol.WsResponse), Stop: func() {}}, nil
+	}
+	fastBuild := func(_ context.Context) (*Source, error) {
+		return &Source{Events: make(chan *protocol.WsResponse), Stop: func() {}}, nil
+	}
+
+	go func() { _, _ = e.Subscribe("slow", slowBuild) }()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.Subscribe("fast", fastBuild)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("subscribe for an unrelated key blocked on an in-flight build")
+	}
+	close(release)
 }

--- a/internal/upstreams/flow/subengine/heads.go
+++ b/internal/upstreams/flow/subengine/heads.go
@@ -1,0 +1,65 @@
+package subengine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/google/uuid"
+)
+
+// NewHeadsSourceBuilder builds a locally-synthesized newHeads source: instead of
+// opening eth_subscribe("newHeads") on a node, it taps the chain's merged head
+// stream (fork-choice winner) and emits each new block's full header JSON.
+//
+// Only blocks carrying RawData are emitted - that JSON is populated solely by a
+// subscription-driven head (EVM ParseSubscriptionBlock). Polled heads have no
+// RawData and are skipped; callers gate this builder on WS-head availability so
+// that does not happen in practice.
+func NewHeadsSourceBuilder(sup upstreams.UpstreamSupervisor, chain chains.Chain) SourceBuilder {
+	return func(srcCtx context.Context) (*Source, error) {
+		chainSup := sup.GetChainSupervisor(chain)
+		if chainSup == nil {
+			return nil, protocol.NoAvailableUpstreamsError()
+		}
+
+		sub := chainSup.SubscribeState(fmt.Sprintf("subengine_newheads_%s_%s_%d", chain, uuid.NewString(), time.Now().UnixNano()))
+		out := make(chan *protocol.WsResponse, 100)
+
+		go func() {
+			defer close(out)
+			defer sub.Unsubscribe()
+
+			// Seed with the current head so the first subscriber gets an
+			// immediate event instead of waiting for the next block.
+			if cur := chainSup.GetChainState().HeadData; !cur.IsEmpty() && len(cur.Head.RawData) > 0 {
+				out <- &protocol.WsResponse{Message: cur.Head.RawData, UpstreamId: cur.UpstreamId}
+			}
+
+			for {
+				select {
+				case <-srcCtx.Done():
+					return
+				case event, ok := <-sub.Events:
+					if !ok {
+						return
+					}
+					for _, wrapper := range event.Wrappers {
+						head, ok := wrapper.(*upstreams.HeadWrapper)
+						if !ok || len(head.Head.RawData) == 0 {
+							continue
+						}
+						out <- &protocol.WsResponse{Message: head.Head.RawData, UpstreamId: head.UpstreamId}
+					}
+				}
+			}
+		}()
+
+		// Teardown is driven by srcCtx cancellation (the goroutine unsubscribes
+		// from the chain state and closes out on return).
+		return &Source{Events: out, Stop: func() {}}, nil
+	}
+}

--- a/internal/upstreams/flow/subengine/heads.go
+++ b/internal/upstreams/flow/subengine/heads.go
@@ -3,7 +3,6 @@ package subengine
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams"
@@ -13,12 +12,17 @@ import (
 
 // NewHeadsSourceBuilder builds a locally-synthesized newHeads source: instead of
 // opening eth_subscribe("newHeads") on a node, it taps the chain's merged head
-// stream (fork-choice winner) and emits each new block's full header JSON.
+// stream (fork-choice winner) and forwards subscription blocks.
 //
-// Only blocks carrying RawData are emitted - that JSON is populated solely by a
-// subscription-driven head (EVM ParseSubscriptionBlock). Polled heads have no
-// RawData and are skipped; callers gate this builder on WS-head availability so
-// that does not happen in practice.
+// A head produced from a ws newHeads notification carries that notification's
+// header JSON in RawData (set only by ParseSubscriptionBlock) - which is exactly
+// the newHeads payload, so it is forwarded verbatim. Heads without RawData
+// (polled blocks, or a subscription head's poll fallback) are not subscription
+// notifications and are skipped.
+//
+// The source degrades - emits a terminal frame so clients resubscribe onto the
+// generic node-backed path - when the chain loses NewHeadsCap (the last ws-head
+// upstream left), detected by re-reading the chain state on each state event.
 func NewHeadsSourceBuilder(sup upstreams.UpstreamSupervisor, chain chains.Chain) SourceBuilder {
 	return func(srcCtx context.Context) (*Source, error) {
 		chainSup := sup.GetChainSupervisor(chain)
@@ -26,17 +30,21 @@ func NewHeadsSourceBuilder(sup upstreams.UpstreamSupervisor, chain chains.Chain)
 			return nil, protocol.NoAvailableUpstreamsError()
 		}
 
-		sub := chainSup.SubscribeState(fmt.Sprintf("subengine_newheads_%s_%s_%d", chain, uuid.NewString(), time.Now().UnixNano()))
+		sub := chainSup.SubscribeState(fmt.Sprintf("subengine_newheads_%s_%s", chain, uuid.NewString()))
 		out := make(chan *protocol.WsResponse, 100)
 
 		go func() {
 			defer close(out)
 			defer sub.Unsubscribe()
 
-			// Seed with the current head so the first subscriber gets an
-			// immediate event instead of waiting for the next block.
-			if cur := chainSup.GetChainState().HeadData; !cur.IsEmpty() && len(cur.Head.RawData) > 0 {
-				out <- &protocol.WsResponse{Message: cur.Head.RawData, UpstreamId: cur.UpstreamId}
+			newHeadsLost := func() bool {
+				caps := chainSup.GetChainState().Caps
+				return caps == nil || !caps.Contains(protocol.NewHeadsCap)
+			}
+
+			if newHeadsLost() {
+				out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
+				return
 			}
 
 			for {
@@ -47,10 +55,14 @@ func NewHeadsSourceBuilder(sup upstreams.UpstreamSupervisor, chain chains.Chain)
 					if !ok {
 						return
 					}
+					if newHeadsLost() {
+						out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
+						return
+					}
 					for _, wrapper := range event.Wrappers {
 						head, ok := wrapper.(*upstreams.HeadWrapper)
 						if !ok || len(head.Head.RawData) == 0 {
-							continue
+							continue // not a subscription block - nothing to forward
 						}
 						out <- &protocol.WsResponse{Message: head.Head.RawData, UpstreamId: head.UpstreamId}
 					}

--- a/internal/upstreams/flow/subengine/heads_test.go
+++ b/internal/upstreams/flow/subengine/heads_test.go
@@ -1,0 +1,101 @@
+package subengine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeChainSupervisor is a minimal ChainSupervisor whose head stream the test
+// drives directly.
+type fakeChainSupervisor struct {
+	sm    *utils.SubscriptionManager[*upstreams.ChainSupervisorStateWrapperEvent]
+	state upstreams.ChainSupervisorState
+}
+
+func newFakeChainSupervisor() *fakeChainSupervisor {
+	return &fakeChainSupervisor{sm: utils.NewSubscriptionManager[*upstreams.ChainSupervisorStateWrapperEvent]("fake")}
+}
+
+func (s *fakeChainSupervisor) publishHead(block protocol.Block, upstreamId string) {
+	s.sm.Publish(&upstreams.ChainSupervisorStateWrapperEvent{
+		Wrappers: []upstreams.ChainSupervisorStateWrapper{upstreams.NewHeadWrapper(block, upstreamId)},
+	})
+}
+
+func (s *fakeChainSupervisor) Start()                                          {}
+func (s *fakeChainSupervisor) GetChain() chains.Chain                          { return chains.ETHEREUM }
+func (s *fakeChainSupervisor) GetChainState() upstreams.ChainSupervisorState   { return s.state }
+func (s *fakeChainSupervisor) GetMethod(string) *specs.Method                  { return nil }
+func (s *fakeChainSupervisor) GetMethods() []string                            { return nil }
+func (s *fakeChainSupervisor) GetUpstreamState(string) *protocol.UpstreamState { return nil }
+func (s *fakeChainSupervisor) GetSortedUpstreamIds(upstreams.FilterUpstream, upstreams.SortUpstream) []string {
+	return nil
+}
+func (s *fakeChainSupervisor) GetUpstreamIds() []string                    { return nil }
+func (s *fakeChainSupervisor) PublishUpstreamEvent(protocol.UpstreamEvent) {}
+func (s *fakeChainSupervisor) SubscribeState(name string) *utils.Subscription[*upstreams.ChainSupervisorStateWrapperEvent] {
+	return s.sm.Subscribe(name)
+}
+
+var _ upstreams.ChainSupervisor = (*fakeChainSupervisor)(nil)
+
+// The head source forwards each head's RawData, stamps the producing upstream,
+// and skips heads without RawData (polled blocks).
+func TestNewHeadsSourceForwardsRawDataAndSkipsEmpty(t *testing.T) {
+	chainSup := newFakeChainSupervisor()
+	sup := mocks.NewUpstreamSupervisorMock()
+	sup.On("GetChainSupervisor", chains.ETHEREUM).Return(chainSup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	src, err := NewHeadsSourceBuilder(sup, chains.ETHEREUM)(ctx)
+	require.NoError(t, err)
+	defer src.Stop()
+
+	chainSup.publishHead(protocol.Block{Height: 1, RawData: []byte(`{"number":"0x1"}`)}, "up1")
+	first := <-src.Events
+	assert.Equal(t, []byte(`{"number":"0x1"}`), first.Message)
+	assert.Equal(t, "up1", first.UpstreamId)
+
+	// a polled head (no RawData) is skipped; the next head with RawData arrives
+	chainSup.publishHead(protocol.Block{Height: 2}, "up2")
+	chainSup.publishHead(protocol.Block{Height: 3, RawData: []byte(`{"number":"0x3"}`)}, "up1")
+	second := <-src.Events
+	assert.Equal(t, []byte(`{"number":"0x3"}`), second.Message)
+}
+
+// The first subscriber is seeded with the current head if it carries RawData.
+func TestNewHeadsSourceSeedsCurrentHead(t *testing.T) {
+	chainSup := newFakeChainSupervisor()
+	chainSup.state = upstreams.ChainSupervisorState{
+		HeadData: upstreams.NewChainHeadData(protocol.Block{Height: 10, RawData: []byte(`{"number":"0xa"}`)}, "up1"),
+	}
+	sup := mocks.NewUpstreamSupervisorMock()
+	sup.On("GetChainSupervisor", chains.ETHEREUM).Return(chainSup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	src, err := NewHeadsSourceBuilder(sup, chains.ETHEREUM)(ctx)
+	require.NoError(t, err)
+	defer src.Stop()
+
+	select {
+	case seeded := <-src.Events:
+		assert.Equal(t, []byte(`{"number":"0xa"}`), seeded.Message)
+		assert.Equal(t, "up1", seeded.UpstreamId)
+	case <-time.After(time.Second):
+		t.Fatal("expected the current head to be seeded")
+	}
+}

--- a/internal/upstreams/flow/subengine/heads_test.go
+++ b/internal/upstreams/flow/subengine/heads_test.go
@@ -2,9 +2,11 @@ package subengine
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -16,14 +18,22 @@ import (
 )
 
 // fakeChainSupervisor is a minimal ChainSupervisor whose head stream the test
-// drives directly.
+// drives directly. Like the real supervisor it stores state before publishing,
+// so GetChainState is authoritative when an event is observed.
 type fakeChainSupervisor struct {
 	sm    *utils.SubscriptionManager[*upstreams.ChainSupervisorStateWrapperEvent]
+	mu    sync.Mutex
 	state upstreams.ChainSupervisorState
 }
 
 func newFakeChainSupervisor() *fakeChainSupervisor {
 	return &fakeChainSupervisor{sm: utils.NewSubscriptionManager[*upstreams.ChainSupervisorStateWrapperEvent]("fake")}
+}
+
+func (s *fakeChainSupervisor) setCaps(caps mapset.Set[protocol.Cap]) {
+	s.mu.Lock()
+	s.state.Caps = caps
+	s.mu.Unlock()
 }
 
 func (s *fakeChainSupervisor) publishHead(block protocol.Block, upstreamId string) {
@@ -32,9 +42,20 @@ func (s *fakeChainSupervisor) publishHead(block protocol.Block, upstreamId strin
 	})
 }
 
-func (s *fakeChainSupervisor) Start()                                          {}
-func (s *fakeChainSupervisor) GetChain() chains.Chain                          { return chains.ETHEREUM }
-func (s *fakeChainSupervisor) GetChainState() upstreams.ChainSupervisorState   { return s.state }
+func (s *fakeChainSupervisor) publishCaps(caps mapset.Set[protocol.Cap]) {
+	s.setCaps(caps) // store before publishing, mirroring the real supervisor
+	s.sm.Publish(&upstreams.ChainSupervisorStateWrapperEvent{
+		Wrappers: []upstreams.ChainSupervisorStateWrapper{upstreams.NewCapsWrapper(caps)},
+	})
+}
+
+func (s *fakeChainSupervisor) Start()                 {}
+func (s *fakeChainSupervisor) GetChain() chains.Chain { return chains.ETHEREUM }
+func (s *fakeChainSupervisor) GetChainState() upstreams.ChainSupervisorState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
 func (s *fakeChainSupervisor) GetMethod(string) *specs.Method                  { return nil }
 func (s *fakeChainSupervisor) GetMethods() []string                            { return nil }
 func (s *fakeChainSupervisor) GetUpstreamState(string) *protocol.UpstreamState { return nil }
@@ -49,10 +70,12 @@ func (s *fakeChainSupervisor) SubscribeState(name string) *utils.Subscription[*u
 
 var _ upstreams.ChainSupervisor = (*fakeChainSupervisor)(nil)
 
-// The head source forwards each head's RawData, stamps the producing upstream,
-// and skips heads without RawData (polled blocks).
-func TestNewHeadsSourceForwardsRawDataAndSkipsEmpty(t *testing.T) {
+// A subscription block (RawData = the ws newHeads header) is forwarded verbatim
+// and stamped with the producing upstream; a head without RawData (a polled
+// block) is not a subscription notification and is skipped.
+func TestNewHeadsSourceForwardsSubscriptionBlocks(t *testing.T) {
 	chainSup := newFakeChainSupervisor()
+	chainSup.setCaps(mapset.NewThreadUnsafeSet(protocol.WsCap, protocol.NewHeadsCap))
 	sup := mocks.NewUpstreamSupervisorMock()
 	sup.On("GetChainSupervisor", chains.ETHEREUM).Return(chainSup)
 
@@ -63,24 +86,57 @@ func TestNewHeadsSourceForwardsRawDataAndSkipsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	defer src.Stop()
 
-	chainSup.publishHead(protocol.Block{Height: 1, RawData: []byte(`{"number":"0x1"}`)}, "up1")
+	header := []byte(`{"number":"0x1","hash":"0xaa"}`)
+	chainSup.publishHead(protocol.Block{Height: 1, RawData: header}, "up1")
 	first := <-src.Events
-	assert.Equal(t, []byte(`{"number":"0x1"}`), first.Message)
 	assert.Equal(t, "up1", first.UpstreamId)
+	assert.Equal(t, header, first.Message) // forwarded verbatim
 
-	// a polled head (no RawData) is skipped; the next head with RawData arrives
+	// a polled head (no RawData) is skipped; the next subscription block arrives
 	chainSup.publishHead(protocol.Block{Height: 2}, "up2")
-	chainSup.publishHead(protocol.Block{Height: 3, RawData: []byte(`{"number":"0x3"}`)}, "up1")
+	next := []byte(`{"number":"0x3"}`)
+	chainSup.publishHead(protocol.Block{Height: 3, RawData: next}, "up1")
 	second := <-src.Events
-	assert.Equal(t, []byte(`{"number":"0x3"}`), second.Message)
+	assert.Equal(t, next, second.Message)
 }
 
-// The first subscriber is seeded with the current head if it carries RawData.
-func TestNewHeadsSourceSeedsCurrentHead(t *testing.T) {
+// When NewHeadsCap disappears from the chain (the last ws-head upstream left),
+// the source emits a terminal frame so clients can fail over.
+func TestNewHeadsSourceTerminatesOnCapLoss(t *testing.T) {
 	chainSup := newFakeChainSupervisor()
-	chainSup.state = upstreams.ChainSupervisorState{
-		HeadData: upstreams.NewChainHeadData(protocol.Block{Height: 10, RawData: []byte(`{"number":"0xa"}`)}, "up1"),
+	chainSup.setCaps(mapset.NewThreadUnsafeSet(protocol.WsCap, protocol.NewHeadsCap))
+	sup := mocks.NewUpstreamSupervisorMock()
+	sup.On("GetChainSupervisor", chains.ETHEREUM).Return(chainSup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	src, err := NewHeadsSourceBuilder(sup, chains.ETHEREUM)(ctx)
+	require.NoError(t, err)
+	defer src.Stop()
+
+	// Drive a head first so the source is provably past its startup snapshot and
+	// in the event loop, then drop NewHeadsCap: the loss is observed via the
+	// state event and degrades the source.
+	chainSup.publishHead(protocol.Block{Height: 1, RawData: []byte(`{"number":"0x1"}`)}, "up1")
+	<-src.Events
+
+	chainSup.publishCaps(mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap))
+
+	select {
+	case terminal := <-src.Events:
+		require.NotNil(t, terminal.Error)
+	case <-time.After(time.Second):
+		t.Fatal("expected a terminal frame on NewHeadsCap loss")
 	}
+}
+
+// Caps changes arrive only as deltas; if NewHeadsCap is already gone when the
+// source starts (no CapsWrapper will ever come), it degrades from the initial
+// state snapshot instead of stalling silently.
+func TestNewHeadsSourceTerminatesWhenCapAbsentAtStart(t *testing.T) {
+	chainSup := newFakeChainSupervisor()
+	chainSup.setCaps(mapset.NewThreadUnsafeSet(protocol.WsCap)) // no NewHeadsCap
 	sup := mocks.NewUpstreamSupervisorMock()
 	sup.On("GetChainSupervisor", chains.ETHEREUM).Return(chainSup)
 
@@ -92,10 +148,9 @@ func TestNewHeadsSourceSeedsCurrentHead(t *testing.T) {
 	defer src.Stop()
 
 	select {
-	case seeded := <-src.Events:
-		assert.Equal(t, []byte(`{"number":"0xa"}`), seeded.Message)
-		assert.Equal(t, "up1", seeded.UpstreamId)
+	case terminal := <-src.Events:
+		require.NotNil(t, terminal.Error)
 	case <-time.After(time.Second):
-		t.Fatal("expected the current head to be seeded")
+		t.Fatal("expected an immediate terminal frame when NewHeadsCap is absent at start")
 	}
 }

--- a/internal/upstreams/flow/subengine/registry.go
+++ b/internal/upstreams/flow/subengine/registry.go
@@ -3,7 +3,6 @@ package subengine
 import (
 	"context"
 
-	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/nodecore/pkg/utils"
 )
@@ -13,14 +12,12 @@ import (
 // subscription opened over either transport aggregates into the same source.
 type Registry struct {
 	ctx     context.Context
-	sup     upstreams.UpstreamSupervisor
 	engines *utils.CMap[chains.Chain, Engine]
 }
 
-func NewRegistry(ctx context.Context, sup upstreams.UpstreamSupervisor) *Registry {
+func NewRegistry(ctx context.Context) *Registry {
 	return &Registry{
 		ctx:     ctx,
-		sup:     sup,
 		engines: utils.NewCMap[chains.Chain, Engine](),
 	}
 }
@@ -33,6 +30,6 @@ func (r *Registry) Get(chain chains.Chain) Engine {
 	if engine, ok := r.engines.Load(chain); ok {
 		return engine
 	}
-	engine, _ := r.engines.LoadOrStore(chain, NewEngine(r.ctx, chain, r.sup))
+	engine, _ := r.engines.LoadOrStore(chain, NewEngine(r.ctx, chain))
 	return engine
 }

--- a/internal/upstreams/flow/subengine/registry.go
+++ b/internal/upstreams/flow/subengine/registry.go
@@ -1,0 +1,38 @@
+package subengine
+
+import (
+	"context"
+
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/utils"
+)
+
+// Registry holds one Engine per chain, created lazily on first use. It is
+// process-wide and shared by both the HTTP/WS and gRPC entry points so that a
+// subscription opened over either transport aggregates into the same source.
+type Registry struct {
+	ctx     context.Context
+	sup     upstreams.UpstreamSupervisor
+	engines *utils.CMap[chains.Chain, Engine]
+}
+
+func NewRegistry(ctx context.Context, sup upstreams.UpstreamSupervisor) *Registry {
+	return &Registry{
+		ctx:     ctx,
+		sup:     sup,
+		engines: utils.NewCMap[chains.Chain, Engine](),
+	}
+}
+
+// Get returns the engine for chain, creating it on first access. The Load fast
+// path avoids constructing a throwaway engine on the common hit; LoadOrStore
+// keeps creation atomic on the first-time race (a discarded engine holds no
+// resources - sources are only started on Subscribe).
+func (r *Registry) Get(chain chains.Chain) Engine {
+	if engine, ok := r.engines.Load(chain); ok {
+		return engine
+	}
+	engine, _ := r.engines.LoadOrStore(chain, NewEngine(r.ctx, chain, r.sup))
+	return engine
+}

--- a/internal/upstreams/flow/subengine/registry_test.go
+++ b/internal/upstreams/flow/subengine/registry_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRegistryGetIsLazyAndPerChain(t *testing.T) {
-	r := NewRegistry(context.Background(), nil)
+	r := NewRegistry(context.Background())
 
 	eth := r.Get(chains.ETHEREUM)
 	require.NotNil(t, eth)

--- a/internal/upstreams/flow/subengine/registry_test.go
+++ b/internal/upstreams/flow/subengine/registry_test.go
@@ -1,0 +1,25 @@
+package subengine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryGetIsLazyAndPerChain(t *testing.T) {
+	r := NewRegistry(context.Background(), nil)
+
+	eth := r.Get(chains.ETHEREUM)
+	require.NotNil(t, eth)
+
+	// Same chain returns the same engine instance (lazy, cached).
+	assert.True(t, eth == r.Get(chains.ETHEREUM), "expected the same engine per chain")
+
+	// A different chain gets its own engine.
+	arb := r.Get(chains.ARBITRUM)
+	require.NotNil(t, arb)
+	assert.False(t, eth == arb, "expected a distinct engine per chain")
+}

--- a/internal/upstreams/state_wrappers.go
+++ b/internal/upstreams/state_wrappers.go
@@ -79,12 +79,14 @@ func NewLowerBoundsWrapper(lowerBounds []protocol.LowerBoundData) *LowerBoundsWr
 func (s *LowerBoundsWrapper) chainSupervisorEventWrapper() {}
 
 type HeadWrapper struct {
-	Head protocol.Block
+	Head       protocol.Block
+	UpstreamId string
 }
 
-func NewHeadWrapper(head protocol.Block) *HeadWrapper {
+func NewHeadWrapper(head protocol.Block, upstreamId string) *HeadWrapper {
 	return &HeadWrapper{
-		Head: head,
+		Head:       head,
+		UpstreamId: upstreamId,
 	}
 }
 

--- a/internal/upstreams/state_wrappers.go
+++ b/internal/upstreams/state_wrappers.go
@@ -1,6 +1,9 @@
 package upstreams
 
-import "github.com/drpcorg/nodecore/internal/protocol"
+import (
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+)
 
 type ChainSupervisorStateWrapperEvent struct {
 	Wrappers []ChainSupervisorStateWrapper
@@ -77,6 +80,16 @@ func NewLowerBoundsWrapper(lowerBounds []protocol.LowerBoundData) *LowerBoundsWr
 }
 
 func (s *LowerBoundsWrapper) chainSupervisorEventWrapper() {}
+
+type CapsWrapper struct {
+	Caps mapset.Set[protocol.Cap]
+}
+
+func NewCapsWrapper(caps mapset.Set[protocol.Cap]) *CapsWrapper {
+	return &CapsWrapper{Caps: caps}
+}
+
+func (s *CapsWrapper) chainSupervisorEventWrapper() {}
 
 type HeadWrapper struct {
 	Head       protocol.Block

--- a/internal/upstreams/upstream.go
+++ b/internal/upstreams/upstream.go
@@ -305,6 +305,7 @@ func (u *BaseUpstream) newUpstreamMethods(bannedMethods mapset.Set[string]) meth
 }
 
 func (u *BaseUpstream) startConnectors(ctx context.Context) {
+	headConnectorType := u.upConfig.GetHeadApiConnectorType()
 	for _, connector := range u.apiConnectors {
 		connector.Start()
 		go func(conn connectors.ApiConnector) {
@@ -314,13 +315,14 @@ func (u *BaseUpstream) startConnectors(ctx context.Context) {
 			}
 			defer stateSubscription.Unsubscribe()
 
+			isHeadConnector := conn.GetType() == headConnectorType
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case event, okEvent := <-stateSubscription.Events:
 					if okEvent {
-						u.emitter(&protocol.SubscribeUpstreamStateEvent{State: event})
+						u.emitter(&protocol.SubscribeUpstreamStateEvent{State: event, HeadConnector: isHeadConnector})
 					}
 				}
 			}

--- a/internal/upstreams/ws/ws_processor.go
+++ b/internal/upstreams/ws/ws_processor.go
@@ -23,6 +23,13 @@ type WsProcessor interface {
 
 const rpcTimeout = 1 * time.Minute
 
+// wsWriteTimeout bounds how long an outbound frame may wait to be written to the
+// socket (enqueue + write). It does NOT bound the subscription stream itself -
+// that lives on the caller's context. Without it, a stuck or long-reconnecting
+// connection would block the writer indefinitely, which for subscriptions would
+// pin the aggregation engine's per-key build and starve unrelated subscribers.
+const wsWriteTimeout = 30 * time.Second
+
 type BaseWsProcessor struct {
 	lifecycle *utils.BaseLifecycle
 
@@ -186,7 +193,12 @@ func (b *BaseWsProcessor) sendWsRequest(ctx context.Context, upstreamRequest pro
 	req := b.requestRegistry.Register(ctx, upstreamRequest, frame.RequestId, frame.SubType, b.wsProtocol.DoOnCloseFunc(b.writeRequest))
 	b.requestRegistry.Start(req)
 
-	err = b.writeRequest(ctx, frame.Body)
+	// Bound only the write; the subscription stream stays on the caller's ctx
+	// (registered above). resultErrChan is buffered, so the writer goroutine
+	// never blocks if this returns early on timeout.
+	writeCtx, cancel := context.WithTimeout(ctx, wsWriteTimeout)
+	defer cancel()
+	err = b.writeRequest(writeCtx, frame.Body)
 	if err != nil {
 		b.requestRegistry.Abort(frame.RequestId)
 		return nil, "", err

--- a/pkg/utils/atomic.go
+++ b/pkg/utils/atomic.go
@@ -81,3 +81,7 @@ func (mp *CMap[K, V]) Delete(key K) {
 func (mp *CMap[K, V]) CompareAndSwap(key K, old V, new V) bool {
 	return mp.mp.CompareAndSwap(key, old, new)
 }
+
+func (mp *CMap[K, V]) CompareAndDelete(key K, old V) bool {
+	return mp.mp.CompareAndDelete(key, old)
+}


### PR DESCRIPTION
# Subscription aggregation engine + local newHeads

## Why

Today every WebSocket subscription is a blind per-client passthrough: `SubscriptionRequestProcessor`
picks one upstream and sends a real subscribe (`eth_subscribe`, `programSubscribe`, …) to that node
for **each** client. Because the per-upstream WS registry keys on the upstream-returned `subId`
(unique per `Subscribe` call), there is **no cross-client deduplication** — N identical client
subscriptions open N node subscriptions, on every chain.

This PR introduces a per-chain **subscription aggregation engine** (modeled on dshackle's
`EthereumEgressSubscription`) that:

- dedups **all** node-backed subscriptions by `(method + params + selector)` so identical client
  subscriptions share **one** node subscription and fan out from a single channel;
- **synthesizes EVM `newHeads` locally** from nodecore's existing merged-head stream — no node
  subscription at all;
- routes in the flow layer, so **HTTP and gRPC both benefit** automatically.

This is stages 1–2 of the rework. Logs, reorgs and `drpc_pendingTransactions` are intentionally left
for follow-up PRs to keep this one reviewable.

## What's in this PR

**Engine — new package `internal/upstreams/flow/subengine`:**
- `engine.go` — `Engine` interface (concrete `baseEngine`): a ref-counted shared source per
  aggregation key, fan-out via `utils.SubscriptionManager`, teardown shortly after the last
  subscriber leaves, and terminal-error propagation.
- `registry.go` — process-wide per-chain `Registry` (lazy, `utils.CMap`), shared by HTTP and gRPC.
- `heads.go` — `NewHeadsSourceBuilder`: taps `ChainSupervisor.SubscribeState` and emits each new
  block's full header JSON as a `newHeads` notification (no node sub).

**Flow routing (`internal/upstreams/flow`):**
- `sub_processor.go` — all `IsSubscribe()` requests now delegate to the engine. Each client
  generates its own subscription id eagerly; events from the shared source are framed per client.
- `sub_aggregation.go` — the aggregation key (`method | RequestHash | selectorKey`), a deterministic
  `selectorKey`, the generic node-backed source builder (selects an upstream, opens one ws sub,
  swallows the upstream confirmation, surfaces disconnect as a terminal frame), and `newHeads`
  routing (`isNewHeadsRequest` + `localNewHeadsAvailable`).
- `execution_flow.go` — resolves the per-chain engine and injects it.

**Granular subscription capabilities (`internal/protocol`, `internal/upstreams`):**
- `protocol.Cap` gains `NewHeadsCap` / `LogsCap` (EVM) alongside `WsCap` (all chains). They're
  granted in `SubscribeUpstreamStateEvent` only for a **websocket head connector** (so a json-rpc
  head connector with a request-only ws connector does **not** get them) and when the methods expose
  `eth_subscribe` / `eth_getLogs`.
- `ChainSupervisorState.Caps` aggregates caps across available upstreams; `SubMethods` now advertises
  cap-derived topics (`newHeads`, `logs`) for EVM instead of the generic `eth_subscribe`.
- `protocol.Block.RawData` retains the raw header JSON, populated only by EVM
  `ParseSubscriptionBlock`; `HeadWrapper` carries the producing `UpstreamId`.

**gRPC (`internal/server/emerald`):**
- `NativeSubscribe` validates the requested topic against the chain's advertised `SubMethods`
  (`subscribeMethodSupported`) and rejects unsupported topics with `codes.Unimplemented`.

## Behavior

- **Aggregation is per-chain**: one node subscription per `(method+params+selector)` for the whole
  chain, fanned out to all clients.
- **newHeads/logs, two modes**:
  - **HTTP** — local synthesis when the chain has a ws head connector (`NewHeadsCap`), otherwise
    falls back to a real node passthrough.
  - **gRPC** — dshackle-strict, local-only: `newHeads`/`logs` are served only when locally
    synthesizable, otherwise `Unimplemented` (never passed through to a node).
- **No durable reconnect**: on upstream disconnect/error the engine propagates a terminal error to
  all attached clients and tears the shared source down; the client decides whether to resubscribe.
