### PR TITLE
Local logs subscription

### DIFF
--- a/docs/nodecore/08-prometheus-metrics.md
+++ b/docs/nodecore/08-prometheus-metrics.md
@@ -12,6 +12,7 @@ This document describes all Prometheus metrics exposed by nodecore on the `metri
 - [Cache Metrics](#cache-metrics)
 - [WebSocket Metrics](#websocket-metrics)
 - [Subscription Utilities Metrics](#subscription-utilities-metrics)
+- [Logs Subscription Metrics](#logs-subscription-metrics)
 
 ---
 
@@ -468,3 +469,40 @@ These metrics track internal subscription manager performance (used for event pr
 **Source:** `pkg/utils/subscriptions.go`
 
 **Use Case:** Identify potential backpressure or slow consumers in internal event systems.
+
+---
+
+## Logs Subscription Metrics
+
+Metrics for the locally-synthesized EVM `logs` subscription source (one shared `eth_getLogs` per block, fanned out to all subscribers). A non-zero value on either counter means subscribers may have silently missed log events.
+
+### `nodecore_logs_source_blocks_skipped_total`
+
+**Type:** Counter
+
+**Description:** The total number of blocks whose logs could not be served and were skipped. The block's logs are silently missing from every `logs` subscriber on that chain.
+
+**Labels:**
+
+- `chain` - The blockchain network (e.g., ethereum)
+- `reason` - Why the block was skipped: `build` (failed to build the `eth_getLogs` request), `no_upstream` (no upstream at the block height / strategy exhausted), `parse` (failed to parse the `eth_getLogs` result), `upstream_error` (every attempt returned an upstream error)
+
+**Source:** `internal/upstreams/flow/logs_source.go`
+
+**Use Case:** Alert on gaps in delivered `logs`; a sustained `no_upstream` rate indicates insufficient upstream coverage at the chain head.
+
+---
+
+### `nodecore_logs_source_reorg_clamped_total`
+
+**Type:** Counter
+
+**Description:** The total number of reorgs whose orphaned suffix reached deeper than the history window, so the oldest orphaned blocks were never re-emitted with `removed:true`.
+
+**Labels:**
+
+- `chain` - The blockchain network (e.g., ethereum)
+
+**Source:** `internal/upstreams/flow/subengine/blockupdates.go`
+
+**Use Case:** Detect deep reorgs that exceed the reconciliation window, where some `removed` events are silently dropped.

--- a/internal/protocol/response.go
+++ b/internal/protocol/response.go
@@ -430,6 +430,13 @@ type WsResponse struct {
 	Error      *ResponseError
 	Event      []byte
 	UpstreamId string
+	// ParsedEvent is an optional, source-attached pre-parsed view of Message,
+	ParsedEvent ParsedEvent
+}
+
+// ParsedEvent is the pre-parsed view of a WsResponse Message. See WsResponse.ParsedEvent.
+type ParsedEvent interface {
+	Raw() []byte
 }
 
 type JsonRpcWsUpstreamResponse struct {

--- a/internal/upstreams/flow/execution_flow.go
+++ b/internal/upstreams/flow/execution_flow.go
@@ -306,7 +306,7 @@ func (e *BaseExecutionFlow) createRequestProcessor(request protocol.RequestHolde
 	var requestProcessor RequestProcessor
 
 	if request.IsSubscribe() {
-		requestProcessor = NewSubscriptionRequestProcessor(e.chain, e.upstreamSupervisor, e.subEngineRegistry.Get(e.chain), e.subCtx)
+		requestProcessor = NewSubscriptionRequestProcessor(e.chain, e.upstreamSupervisor, e.subEngineRegistry.Get(e.chain), e.subCtx, e.registry)
 	} else if request.SpecMethod().IsLocal() {
 		requestProcessor = NewLocalRequestProcessor(e.chain, e.subCtx)
 		reqObserver.WithRequestKind(protocol.Local)

--- a/internal/upstreams/flow/log_filter.go
+++ b/internal/upstreams/flow/log_filter.go
@@ -1,0 +1,143 @@
+package flow
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+)
+
+// SubFilter decides, per client, whether a fanned-out event should be delivered
+// to that client. A shared local source (e.g. the chain's single all-logs
+// stream) carries every event for all of its subscribers; each client's
+// SubFilter drops the ones it did not subscribe to. resolveSource returns nil
+// for sources that need no per-client filtering (newHeads, generic passthrough).
+type SubFilter interface {
+	Matches(message []byte) bool
+}
+
+// topicFilter is one position of an eth logs topic filter: any (the request had
+// null at this position) matches anything; otherwise the log's topic at this
+// position must be one of set.
+type topicFilter struct {
+	any bool
+	set map[string]struct{}
+}
+
+// logFilter is a parsed eth_subscribe("logs", {...}) filter. The shared all-logs
+// source carries every log of every block; each client applies its own logFilter
+// in the processor so it sees only the logs it subscribed to. All hex values are
+// compared lowercased.
+type logFilter struct {
+	addresses map[string]struct{} // empty => match any address
+	topics    []topicFilter       // positional; empty => match any topics
+}
+
+var _ SubFilter = (*logFilter)(nil)
+
+// rawLogFilter mirrors the eth logs filter object. address is a string or an
+// array of strings; each topics entry is null, a string, or an array of strings.
+type rawLogFilter struct {
+	Address json.RawMessage   `json:"address"`
+	Topics  []json.RawMessage `json:"topics"`
+}
+
+// parseLogFilter extracts the filter object (params[1]) from an
+// eth_subscribe("logs", {...}) request. A missing object (`["logs"]`) yields a
+// match-everything filter; a malformed object returns an error so the caller can
+// fall back to the generic node-backed path.
+func parseLogFilter(request protocol.RequestHolder) (*logFilter, error) {
+	body, err := request.Body()
+	if err != nil {
+		return nil, err
+	}
+	filter := &logFilter{addresses: map[string]struct{}{}}
+
+	node, err := sonic.Get(body, "params", 1)
+	if err != nil {
+		return filter, nil // no filter object - match everything
+	}
+	raw, err := node.Raw()
+	if err != nil {
+		return filter, nil
+	}
+	var rf rawLogFilter
+	if err := sonic.UnmarshalString(raw, &rf); err != nil {
+		return nil, err
+	}
+
+	for _, addr := range parseStringOrArray(rf.Address) {
+		filter.addresses[strings.ToLower(addr)] = struct{}{}
+	}
+	for _, topic := range rf.Topics {
+		tf := topicFilter{set: map[string]struct{}{}}
+		trimmed := strings.TrimSpace(string(topic))
+		if len(topic) == 0 || trimmed == "null" {
+			tf.any = true
+		} else if vals := parseStringOrArray(topic); len(vals) > 0 {
+			for _, v := range vals {
+				tf.set[strings.ToLower(v)] = struct{}{}
+			}
+		} else {
+			tf.any = true
+		}
+		filter.topics = append(filter.topics, tf)
+	}
+	return filter, nil
+}
+
+// parseStringOrArray decodes a JSON value that is either a single string or an
+// array of strings into a slice (nil for null/empty/other).
+func parseStringOrArray(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var single string
+	if err := sonic.Unmarshal(raw, &single); err == nil {
+		return []string{single}
+	}
+	var many []string
+	if err := sonic.Unmarshal(raw, &many); err == nil {
+		return many
+	}
+	return nil
+}
+
+// Matches reports whether a raw eth log object satisfies the filter. A log with
+// fewer topics than the filter requires does not match (standard eth semantics).
+func (f *logFilter) Matches(logRaw []byte) bool {
+	if f == nil {
+		return true
+	}
+	if len(f.addresses) > 0 {
+		addrNode, err := sonic.Get(logRaw, "address")
+		if err != nil {
+			return false
+		}
+		addr, err := addrNode.String()
+		if err != nil {
+			return false
+		}
+		if _, ok := f.addresses[strings.ToLower(addr)]; !ok {
+			return false
+		}
+	}
+	for i, tf := range f.topics {
+		if tf.any {
+			continue
+		}
+		topicNode, err := sonic.Get(logRaw, "topics", i)
+		if err != nil {
+			return false // log has fewer topics than the filter requires
+		}
+		topic, err := topicNode.String()
+		if err != nil {
+			return false
+		}
+		if _, ok := tf.set[strings.ToLower(topic)]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/upstreams/flow/log_filter.go
+++ b/internal/upstreams/flow/log_filter.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -13,8 +14,35 @@ import (
 // stream) carries every event for all of its subscribers; each client's
 // SubFilter drops the ones it did not subscribe to. resolveSource returns nil
 // for sources that need no per-client filtering (newHeads, generic passthrough).
+//
+// It receives the source-attached protocol.ParsedEvent (parsed once per event in
+// the source) so it can match without re-parsing the raw JSON for every
+// subscriber.
 type SubFilter interface {
-	Matches(message []byte) bool
+	Matches(event protocol.ParsedEvent) bool
+}
+
+type parsedLog struct {
+	raw     json.RawMessage
+	address string
+	topics  []string
+}
+
+var _ protocol.ParsedEvent = (*parsedLog)(nil)
+
+func (p *parsedLog) Raw() []byte { return p.raw }
+
+func parseLogEvent(raw json.RawMessage) *parsedLog {
+	var rl struct {
+		Address string   `json:"address"`
+		Topics  []string `json:"topics"`
+	}
+	_ = sonic.Unmarshal(raw, &rl) // best-effort; missing fields stay zero
+	pl := &parsedLog{raw: raw, address: strings.ToLower(rl.Address), topics: make([]string, len(rl.Topics))}
+	for i, t := range rl.Topics {
+		pl.topics[i] = strings.ToLower(t)
+	}
+	return pl
 }
 
 // topicFilter is one position of an eth logs topic filter: any (the request had
@@ -67,7 +95,15 @@ func parseLogFilter(request protocol.RequestHolder) (*logFilter, error) {
 		return nil, err
 	}
 
-	for _, addr := range parseStringOrArray(rf.Address) {
+	// A present-but-malformed address would otherwise leave the address set empty
+	// and silently match EVERY address (the firehose). Reject it so the caller
+	// falls back to the generic node-backed path, where the node validates the
+	// filter itself.
+	addrs, ok := parseStringOrArray(rf.Address)
+	if !ok {
+		return nil, errors.New("malformed address in logs filter")
+	}
+	for _, addr := range addrs {
 		filter.addresses[strings.ToLower(addr)] = struct{}{}
 	}
 	for _, topic := range rf.Topics {
@@ -75,7 +111,7 @@ func parseLogFilter(request protocol.RequestHolder) (*logFilter, error) {
 		trimmed := strings.TrimSpace(string(topic))
 		if len(topic) == 0 || trimmed == "null" {
 			tf.any = true
-		} else if vals := parseStringOrArray(topic); len(vals) > 0 {
+		} else if vals, ok := parseStringOrArray(topic); ok && len(vals) > 0 {
 			for _, v := range vals {
 				tf.set[strings.ToLower(v)] = struct{}{}
 			}
@@ -88,38 +124,42 @@ func parseLogFilter(request protocol.RequestHolder) (*logFilter, error) {
 }
 
 // parseStringOrArray decodes a JSON value that is either a single string or an
-// array of strings into a slice (nil for null/empty/other).
-func parseStringOrArray(raw json.RawMessage) []string {
+// array of strings into a slice. The bool distinguishes a usable value (absent,
+// or a well-formed string/array - ok=true) from a malformed one (present but
+// neither a string nor an array of strings - ok=false), so the caller can fall
+// back rather than silently widening the match.
+func parseStringOrArray(raw json.RawMessage) ([]string, bool) {
 	if len(raw) == 0 {
-		return nil
+		return nil, true // absent
 	}
 	var single string
 	if err := sonic.Unmarshal(raw, &single); err == nil {
-		return []string{single}
+		return []string{single}, true
 	}
 	var many []string
 	if err := sonic.Unmarshal(raw, &many); err == nil {
-		return many
+		return many, true
 	}
-	return nil
+	return nil, false // malformed
 }
 
-// Matches reports whether a raw eth log object satisfies the filter. A log with
-// fewer topics than the filter requires does not match (standard eth semantics).
-func (f *logFilter) Matches(logRaw []byte) bool {
+// Matches reports whether the parsed eth log satisfies the filter. It reads the
+// pre-parsed view (parsed once in the source) instead of re-walking the raw JSON
+// per subscriber. A log with fewer topics than the filter requires does not match
+// (standard eth semantics).
+func (f *logFilter) Matches(event protocol.ParsedEvent) bool {
 	if f == nil {
 		return true
 	}
+	if event == nil {
+		return false // contract violation: a logs source must attach a ParsedEvent
+	}
+	pl, ok := event.(*parsedLog)
+	if !ok {
+		pl = parseLogEvent(event.Raw()) // defensive: unknown parsed type; never hit for logs
+	}
 	if len(f.addresses) > 0 {
-		addrNode, err := sonic.Get(logRaw, "address")
-		if err != nil {
-			return false
-		}
-		addr, err := addrNode.String()
-		if err != nil {
-			return false
-		}
-		if _, ok := f.addresses[strings.ToLower(addr)]; !ok {
+		if _, ok := f.addresses[pl.address]; !ok {
 			return false
 		}
 	}
@@ -127,15 +167,10 @@ func (f *logFilter) Matches(logRaw []byte) bool {
 		if tf.any {
 			continue
 		}
-		topicNode, err := sonic.Get(logRaw, "topics", i)
-		if err != nil {
+		if i >= len(pl.topics) {
 			return false // log has fewer topics than the filter requires
 		}
-		topic, err := topicNode.String()
-		if err != nil {
-			return false
-		}
-		if _, ok := tf.set[strings.ToLower(topic)]; !ok {
+		if _, ok := tf.set[pl.topics[i]]; !ok {
 			return false
 		}
 	}

--- a/internal/upstreams/flow/logs_source.go
+++ b/internal/upstreams/flow/logs_source.go
@@ -1,0 +1,217 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/rating"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// logsCacheSize is how many recent blocks' logs are kept so a reorg DROP can
+	// re-emit them with removed:true.
+	logsCacheSize = 32
+	// logsBufferSize is the per-subscriber fan-out buffer for the logs source: a
+	// single busy block can yield thousands of logs, so it is far larger than the
+	// engine default. A client that cannot drain a block's worth of logs in time
+	// is disconnected as too slow (no silent gaps).
+	logsBufferSize = 4096
+	// logsFetchAttempts bounds the per-block walk down the rating list when an
+	// upstream errors on eth_getLogs before the block is skipped.
+	logsFetchAttempts = 3
+)
+
+// newLogsSourceBuilder builds the chain's single shared "all logs" source: for
+// each new block it issues one eth_getLogs{blockHash} (no address/topic filter)
+// and emits every log as its own event; per-client address/topic filtering
+// happens in the processor. Upstream selection is by the block's HEIGHT (any
+// available upstream at >= that height), not by the head producer, so a producer
+// that has since gone away does not break log delivery.
+//
+// Reorgs are handled via the block-update stream (see subengine.StreamBlockUpdates):
+// a dropped block's cached logs are re-emitted with removed:true. The source
+// terminates (so clients fail over to the generic node-backed path) when the
+// chain loses LogsCap.
+func newLogsSourceBuilder(
+	supervisor upstreams.UpstreamSupervisor,
+	chain chains.Chain,
+	registry *rating.RatingRegistry,
+) subengine.SourceBuilder {
+	return func(srcCtx context.Context) (*subengine.Source, error) {
+		chainSup := supervisor.GetChainSupervisor(chain)
+		if chainSup == nil {
+			return nil, protocol.NoAvailableUpstreamsError()
+		}
+
+		logsLost := func() bool {
+			caps := chainSup.GetChainState().Caps
+			return caps == nil || !caps.Contains(protocol.LogsCap)
+		}
+
+		out := make(chan *protocol.WsResponse, logsBufferSize)
+		updates := make(chan subengine.BlockUpdate, 64)
+
+		go subengine.StreamBlockUpdates(srcCtx, chainSup, updates)
+
+		go func() {
+			defer close(out)
+			cache := newLogCache(logsCacheSize)
+
+			if logsLost() {
+				out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
+				return
+			}
+
+			for {
+				select {
+				case <-srcCtx.Done():
+					return
+				case update, ok := <-updates:
+					if !ok {
+						return
+					}
+					if logsLost() {
+						out <- &protocol.WsResponse{Error: protocol.WsTotalFailureError()}
+						return
+					}
+					switch update.Kind {
+					case subengine.BlockNew:
+						logs, upstreamId := fetchBlockLogs(srcCtx, supervisor, chain, chainSup, registry, update.Block)
+						if logs == nil {
+							continue // fetch failed/skipped (logged); not terminal
+						}
+						cache.put(update.Block.Hash.ToHex(), logs)
+						for _, raw := range logs {
+							select {
+							case out <- &protocol.WsResponse{Message: raw, UpstreamId: upstreamId}:
+							case <-srcCtx.Done():
+								return
+							}
+						}
+					case subengine.BlockDrop:
+						cached, ok := cache.get(update.Block.Hash.ToHex())
+						if !ok {
+							continue // never cached this block's logs - nothing to revert
+						}
+						for _, raw := range cached {
+							select {
+							case out <- &protocol.WsResponse{Message: setRemovedTrue(raw)}:
+							case <-srcCtx.Done():
+								return
+							}
+						}
+					}
+				}
+			}
+		}()
+
+		// Teardown is driven by srcCtx cancellation: both goroutines unwind and
+		// out is closed by the consumer goroutine.
+		return &subengine.Source{Events: out, Stop: func() {}, Buffer: logsBufferSize}, nil
+	}
+}
+
+// fetchBlockLogs returns the raw log objects of block, fetched via eth_getLogs on
+// an upstream chosen by height, plus the serving upstream id. It returns (nil,"")
+// when the block cannot be served (no upstream at the height, or every attempt
+// errored); the source treats that as a skipped block, not a terminal failure.
+func fetchBlockLogs(
+	ctx context.Context,
+	supervisor upstreams.UpstreamSupervisor,
+	chain chains.Chain,
+	chainSup upstreams.ChainSupervisor,
+	registry *rating.RatingRegistry,
+	block protocol.Block,
+) ([]json.RawMessage, string) {
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(
+		"eth_getLogs",
+		[]any{map[string]string{"blockHash": block.Hash.ToHexWithPrefix()}},
+		chain,
+	)
+	if err != nil {
+		log.Warn().Err(err).Msgf("subengine: failed to build eth_getLogs for block %d on %s", block.Height, chain)
+		return nil, ""
+	}
+
+	// Select any available, best-rated upstream whose head is at >= the block's
+	// height. A fresh strategy per block carries the height matcher; repeated
+	// SelectUpstream calls walk down the rating list (selectedUpstreams dedup).
+	strategy := NewRatingStrategy(chain, "eth_getLogs", []Matcher{NewHeightMatcher(int64(block.Height))}, chainSup, registry)
+
+	for attempt := 0; attempt < logsFetchAttempts; attempt++ {
+		resp, err := selectAndSend(ctx, supervisor, request, strategy)
+		if err != nil {
+			return nil, "" // strategy exhausted / no upstream at this height
+		}
+		if resp.Response.HasError() {
+			continue // try the next-best upstream
+		}
+		var arr []json.RawMessage
+		if err := sonic.Unmarshal(resp.Response.ResponseResult(), &arr); err != nil {
+			log.Warn().Err(err).Msgf("subengine: failed to parse eth_getLogs result for block %d on %s", block.Height, chain)
+			return nil, ""
+		}
+		logs := make([]json.RawMessage, 0, len(arr))
+		for _, l := range arr {
+			logs = append(logs, append(json.RawMessage(nil), l...)) // copy: connector buffers may be pooled
+		}
+		return logs, resp.UpstreamId
+	}
+	return nil, ""
+}
+
+// setRemovedTrue returns a copy of an eth log object with "removed" set to true,
+// for re-emitting a reorged-out block's logs. On any parse/marshal error it
+// returns the input unchanged.
+func setRemovedTrue(raw json.RawMessage) []byte {
+	node, err := sonic.Get(raw)
+	if err != nil {
+		return raw
+	}
+	if _, err := node.Set("removed", ast.NewBool(true)); err != nil {
+		return raw
+	}
+	b, err := node.MarshalJSON()
+	if err != nil {
+		return raw
+	}
+	return b
+}
+
+// logCache is a single-goroutine FIFO of recent blocks' logs, keyed by block
+// hash, used to re-emit removals on a reorg.
+type logCache struct {
+	capacity int
+	order    []string
+	items    map[string][]json.RawMessage
+}
+
+func newLogCache(capacity int) *logCache {
+	return &logCache{capacity: capacity, items: make(map[string][]json.RawMessage, capacity)}
+}
+
+func (c *logCache) put(hash string, logs []json.RawMessage) {
+	if _, ok := c.items[hash]; ok {
+		c.items[hash] = logs
+		return
+	}
+	if len(c.order) >= c.capacity {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.items, oldest)
+	}
+	c.order = append(c.order, hash)
+	c.items[hash] = logs
+}
+
+func (c *logCache) get(hash string) ([]json.RawMessage, bool) {
+	logs, ok := c.items[hash]
+	return logs, ok
+}

--- a/internal/upstreams/flow/logs_source.go
+++ b/internal/upstreams/flow/logs_source.go
@@ -6,13 +6,32 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/bytedance/sonic/ast"
+	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/rating"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
+
+// logsBlocksSkippedMetric counts blocks whose logs could not be served and were
+// therefore skipped (the client silently misses that block's logs). A non-zero
+// rate means subscribers may have gaps; the reason label says why.
+var logsBlocksSkippedMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: config.AppName,
+		Subsystem: "logs_source",
+		Name:      "blocks_skipped_total",
+		Help:      "The total number of blocks whose logs could not be served and were skipped, by reason",
+	},
+	[]string{"chain", "reason"},
+)
+
+func init() {
+	prometheus.MustRegister(logsBlocksSkippedMetric)
+}
 
 const (
 	// logsCacheSize is how many recent blocks' logs are kept so a reorg DROP can
@@ -87,22 +106,36 @@ func newLogsSourceBuilder(
 						if logs == nil {
 							continue // fetch failed/skipped (logged); not terminal
 						}
-						cache.put(update.Block.Hash.ToHex(), logs)
-						for _, raw := range logs {
+						// Parse each log's filterable fields once here; every client's
+						// SubFilter then reads the shared parsed view instead of
+						// re-parsing the raw JSON per subscriber.
+						parsed := make([]*parsedLog, len(logs))
+						for i, raw := range logs {
+							parsed[i] = parseLogEvent(raw)
+						}
+						cache.put(update.Block.Hash.ToHex(), parsed)
+						for _, pl := range parsed {
 							select {
-							case out <- &protocol.WsResponse{Message: raw, UpstreamId: upstreamId}:
+							case out <- &protocol.WsResponse{Message: pl.raw, UpstreamId: upstreamId, ParsedEvent: pl}:
 							case <-srcCtx.Done():
 								return
 							}
 						}
 					case subengine.BlockDrop:
+						// Client contract: this source is shared and cache-only
+						// (logsCacheSize blocks), so a client that subscribed after a
+						// block was emitted but before it reorgs receives removed:true
+						// for logs it never received as added. Clients MUST tolerate
+						// unmatched/spurious removed events (standard eth-log semantics).
 						cached, ok := cache.get(update.Block.Hash.ToHex())
 						if !ok {
 							continue // never cached this block's logs - nothing to revert
 						}
-						for _, raw := range cached {
+						// Reuse the cached parsed view: the removed flag does not affect
+						// address/topic matching, so per-client filters still apply.
+						for _, pl := range cached {
 							select {
-							case out <- &protocol.WsResponse{Message: setRemovedTrue(raw)}:
+							case out <- &protocol.WsResponse{Message: setRemovedTrue(pl.raw), ParsedEvent: pl}:
 							case <-srcCtx.Done():
 								return
 							}
@@ -137,6 +170,7 @@ func fetchBlockLogs(
 	)
 	if err != nil {
 		log.Warn().Err(err).Msgf("subengine: failed to build eth_getLogs for block %d on %s", block.Height, chain)
+		logsBlocksSkippedMetric.WithLabelValues(chain.String(), "build").Inc()
 		return nil, ""
 	}
 
@@ -148,7 +182,11 @@ func fetchBlockLogs(
 	for attempt := 0; attempt < logsFetchAttempts; attempt++ {
 		resp, err := selectAndSend(ctx, supervisor, request, strategy)
 		if err != nil {
-			return nil, "" // strategy exhausted / no upstream at this height
+			// No upstream at this height (or the strategy is exhausted): the block's
+			// logs are skipped, so the client silently misses them. Surface it.
+			log.Warn().Err(err).Msgf("subengine: no upstream to serve eth_getLogs for block %d on %s; skipping block's logs", block.Height, chain)
+			logsBlocksSkippedMetric.WithLabelValues(chain.String(), "no_upstream").Inc()
+			return nil, ""
 		}
 		if resp.Response.HasError() {
 			continue // try the next-best upstream
@@ -156,6 +194,7 @@ func fetchBlockLogs(
 		var arr []json.RawMessage
 		if err := sonic.Unmarshal(resp.Response.ResponseResult(), &arr); err != nil {
 			log.Warn().Err(err).Msgf("subengine: failed to parse eth_getLogs result for block %d on %s", block.Height, chain)
+			logsBlocksSkippedMetric.WithLabelValues(chain.String(), "parse").Inc()
 			return nil, ""
 		}
 		logs := make([]json.RawMessage, 0, len(arr))
@@ -164,40 +203,49 @@ func fetchBlockLogs(
 		}
 		return logs, resp.UpstreamId
 	}
+	// Every attempt returned an upstream error: the block's logs are skipped.
+	log.Warn().Msgf("subengine: eth_getLogs errored on all %d attempts for block %d on %s; skipping block's logs", logsFetchAttempts, block.Height, chain)
+	logsBlocksSkippedMetric.WithLabelValues(chain.String(), "upstream_error").Inc()
 	return nil, ""
 }
 
 // setRemovedTrue returns a copy of an eth log object with "removed" set to true,
 // for re-emitting a reorged-out block's logs. On any parse/marshal error it
-// returns the input unchanged.
+// returns the input unchanged and warns: a malformed cached log would otherwise
+// be re-emitted with its original "removed" value, so the client would treat a
+// reorged-out log as still valid without any signal.
 func setRemovedTrue(raw json.RawMessage) []byte {
 	node, err := sonic.Get(raw)
 	if err != nil {
+		log.Warn().Err(err).Msg("subengine: failed to parse cached log for reorg removal; re-emitting unchanged")
 		return raw
 	}
 	if _, err := node.Set("removed", ast.NewBool(true)); err != nil {
+		log.Warn().Err(err).Msg("subengine: failed to set removed:true on cached log; re-emitting unchanged")
 		return raw
 	}
 	b, err := node.MarshalJSON()
 	if err != nil {
+		log.Warn().Err(err).Msg("subengine: failed to marshal cached log for reorg removal; re-emitting unchanged")
 		return raw
 	}
 	return b
 }
 
-// logCache is a single-goroutine FIFO of recent blocks' logs, keyed by block
-// hash, used to re-emit removals on a reorg.
+// logCache is a single-goroutine FIFO of recent blocks' parsed logs, keyed by
+// block hash, used to re-emit removals on a reorg. It stores the parsed view
+// (which also carries the raw bytes) so a DROP reuses it without re-parsing.
 type logCache struct {
 	capacity int
 	order    []string
-	items    map[string][]json.RawMessage
+	items    map[string][]*parsedLog
 }
 
 func newLogCache(capacity int) *logCache {
-	return &logCache{capacity: capacity, items: make(map[string][]json.RawMessage, capacity)}
+	return &logCache{capacity: capacity, items: make(map[string][]*parsedLog, capacity)}
 }
 
-func (c *logCache) put(hash string, logs []json.RawMessage) {
+func (c *logCache) put(hash string, logs []*parsedLog) {
 	if _, ok := c.items[hash]; ok {
 		c.items[hash] = logs
 		return
@@ -211,7 +259,7 @@ func (c *logCache) put(hash string, logs []json.RawMessage) {
 	c.items[hash] = logs
 }
 
-func (c *logCache) get(hash string) ([]json.RawMessage, bool) {
+func (c *logCache) get(hash string) ([]*parsedLog, bool) {
 	logs, ok := c.items[hash]
 	return logs, ok
 }

--- a/internal/upstreams/flow/logs_source_internal_test.go
+++ b/internal/upstreams/flow/logs_source_internal_test.go
@@ -1,0 +1,361 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/config"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/rating"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func logsTestUpConfig() *config.Upstream {
+	return &config.Upstream{
+		Id:           "id",
+		PollInterval: 10 * time.Millisecond,
+		Options:      &chains.Options{InternalTimeout: 5 * time.Second},
+	}
+}
+
+func logsMethodsMock() *mocks.MethodsMock {
+	m := mocks.NewMethodsMock()
+	m.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("eth_getLogs"))
+	m.On("HasMethod", "eth_getLogs").Return(true)
+	m.On("HasMethod", mock.Anything).Return(false).Maybe()
+	return m
+}
+
+// publishLogsUpstream registers an Available upstream at the given head height
+// whose advertised methods include eth_getLogs.
+func publishLogsUpstream(chSup interface {
+	PublishUpstreamEvent(protocol.UpstreamEvent)
+}, id string, height uint64) {
+	chSup.PublishUpstreamEvent(test_utils.CreateEvent(
+		id,
+		protocol.Available,
+		protocol.Block{Height: height, Hash: blockchain.NewHashIdFromString("00")},
+		logsMethodsMock(),
+	))
+	time.Sleep(10 * time.Millisecond)
+}
+
+func newLogsTestRegistry(upSup *mocks.UpstreamSupervisorMock) *rating.RatingRegistry {
+	return rating.NewRatingRegistry(upSup, nil, &config.ScorePolicyConfig{
+		CalculationFunctionName: config.DefaultLatencyPolicyFuncName,
+		CalculationInterval:     time.Minute,
+	})
+}
+
+// fetchBlockLogs must pick an upstream whose head is at >= the block height (not
+// the head producer): a too-low upstream is never queried.
+func TestFetchBlockLogsSelectsByHeightAndParses(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	chSup := test_utils.CreateChainSupervisor() // ARBITRUM
+	publishLogsUpstream(chSup, "high", 100)
+	publishLogsUpstream(chSup, "low", 50)
+
+	connHigh := mocks.NewConnectorMock()
+	connLow := mocks.NewConnectorMock()
+	upHigh := test_utils.TestEvmUpstream(connHigh, logsTestUpConfig(), logsMethodsMock(), nil)
+	upLow := test_utils.TestEvmUpstream(connLow, logsTestUpConfig(), logsMethodsMock(), nil)
+
+	upSup := mocks.NewUpstreamSupervisorMock()
+	upSup.On("GetChainSupervisor", chains.ARBITRUM).Return(chSup)
+	upSup.On("GetUpstream", "high").Return(upHigh).Maybe()
+	upSup.On("GetUpstream", "low").Return(upLow).Maybe()
+
+	logsJSON := []byte(`[{"address":"0xabc","topics":["0x1"],"removed":false}]`)
+	connHigh.On("SendRequest", mock.Anything, mock.Anything).Return(protocol.NewSimpleHttpUpstreamResponse("1", logsJSON, protocol.JsonRpc))
+
+	block := protocol.Block{Height: 100, Hash: blockchain.NewHashIdFromString("aa")}
+	logs, upstreamId := fetchBlockLogs(context.Background(), upSup, chains.ARBITRUM, chSup, newLogsTestRegistry(upSup), block)
+
+	require.Len(t, logs, 1)
+	assert.Equal(t, "id", upstreamId) // BaseUpstream id from TestEvmUpstream
+	connLow.AssertNotCalled(t, "SendRequest", mock.Anything, mock.Anything)
+}
+
+// A block with no upstream at its height is skipped (nil), not a terminal error.
+func TestFetchBlockLogsNoUpstreamAtHeight(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	chSup := test_utils.CreateChainSupervisor()
+	publishLogsUpstream(chSup, "low", 50)
+
+	conn := mocks.NewConnectorMock()
+	up := test_utils.TestEvmUpstream(conn, logsTestUpConfig(), logsMethodsMock(), nil)
+	upSup := mocks.NewUpstreamSupervisorMock()
+	upSup.On("GetChainSupervisor", chains.ARBITRUM).Return(chSup)
+	upSup.On("GetUpstream", "low").Return(up).Maybe()
+
+	block := protocol.Block{Height: 100, Hash: blockchain.NewHashIdFromString("aa")}
+	logs, upstreamId := fetchBlockLogs(context.Background(), upSup, chains.ARBITRUM, chSup, newLogsTestRegistry(upSup), block)
+
+	assert.Nil(t, logs)
+	assert.Empty(t, upstreamId)
+	conn.AssertNotCalled(t, "SendRequest", mock.Anything, mock.Anything)
+}
+
+// An upstream that errors on eth_getLogs causes the block to be skipped (nil)
+// after the bounded walk-down, not a terminal failure.
+func TestFetchBlockLogsErrorSkipsBlock(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	chSup := test_utils.CreateChainSupervisor()
+	publishLogsUpstream(chSup, "high", 100)
+
+	conn := mocks.NewConnectorMock()
+	up := test_utils.TestEvmUpstream(conn, logsTestUpConfig(), logsMethodsMock(), nil)
+	upSup := mocks.NewUpstreamSupervisorMock()
+	upSup.On("GetChainSupervisor", chains.ARBITRUM).Return(chSup)
+	upSup.On("GetUpstream", "high").Return(up).Maybe()
+
+	conn.On("SendRequest", mock.Anything, mock.Anything).
+		Return(protocol.NewTotalFailureFromErr("1", assert.AnError, protocol.JsonRpc))
+
+	block := protocol.Block{Height: 100, Hash: blockchain.NewHashIdFromString("aa")}
+	logs, _ := fetchBlockLogs(context.Background(), upSup, chains.ARBITRUM, chSup, newLogsTestRegistry(upSup), block)
+
+	assert.Nil(t, logs)
+}
+
+func TestSetRemovedTrue(t *testing.T) {
+	out := setRemovedTrue([]byte(`{"address":"0xabc","removed":false,"topics":["0x1"]}`))
+	var parsed map[string]any
+	require.NoError(t, sonic.Unmarshal(out, &parsed))
+	assert.Equal(t, true, parsed["removed"])
+	assert.Equal(t, "0xabc", parsed["address"])
+	assert.Len(t, parsed["topics"], 1)
+
+	// adds the field when absent
+	out = setRemovedTrue([]byte(`{"address":"0xabc"}`))
+	require.NoError(t, sonic.Unmarshal(out, &parsed))
+	assert.Equal(t, true, parsed["removed"])
+
+	// invalid json is returned unchanged
+	bad := []byte(`not json`)
+	assert.Equal(t, bad, setRemovedTrue(bad))
+}
+
+// --- newLogsSourceBuilder (end-to-end source goroutine) ------------------
+
+func logsCaps() mapset.Set[protocol.Cap] {
+	return mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap)
+}
+
+// registerLogsUpstream publishes a StateUpstreamEvent so the chain supervisor
+// knows the upstream's caps + methods + availability. State events set caps but
+// do NOT drive the head stream - heads are advanced via publishHead.
+func registerLogsUpstream(chSup upstreams.ChainSupervisor, id string, caps mapset.Set[protocol.Cap]) {
+	state := protocol.DefaultUpstreamState(logsMethodsMock(), caps, "idx", nil, nil)
+	state.Status = protocol.Available
+	chSup.PublishUpstreamEvent(protocol.UpstreamEvent{
+		Id:        id,
+		EventType: &protocol.StateUpstreamEvent{State: &state},
+	})
+	time.Sleep(30 * time.Millisecond)
+}
+
+// publishHead advances an upstream's head via a HeadUpstreamEvent, which is what
+// triggers a HeadWrapper on the state stream (and refreshes the per-upstream head
+// snapshot read by the height matcher).
+func publishHead(chSup upstreams.ChainSupervisor, id string, height uint64, hash, parent string) {
+	chSup.PublishUpstreamEvent(protocol.UpstreamEvent{
+		Id: id,
+		EventType: &protocol.HeadUpstreamEvent{
+			Status: protocol.Available,
+			Head: protocol.Block{
+				Height:     height,
+				Hash:       blockchain.NewHashIdFromString(hash),
+				ParentHash: blockchain.NewHashIdFromString(parent),
+			},
+		},
+	})
+	time.Sleep(30 * time.Millisecond)
+}
+
+func readWsResponse(t *testing.T, ch <-chan *protocol.WsResponse) *protocol.WsResponse {
+	t.Helper()
+	select {
+	case r, ok := <-ch:
+		require.True(t, ok, "source channel closed unexpectedly")
+		return r
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for a source event")
+		return nil
+	}
+}
+
+func assertRemoved(t *testing.T, r *protocol.WsResponse, want bool) {
+	t.Helper()
+	require.NotNil(t, r)
+	require.Nil(t, r.Error, "unexpected terminal frame")
+	var m map[string]any
+	require.NoError(t, sonic.Unmarshal(r.Message, &m))
+	removed, _ := m["removed"].(bool)
+	assert.Equal(t, want, removed)
+}
+
+func logsSourceTestSetup(t *testing.T, sendResult protocol.ResponseHolder) (upstreams.ChainSupervisor, *mocks.UpstreamSupervisorMock, *rating.RatingRegistry) {
+	t.Helper()
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	chSup := test_utils.CreateChainSupervisor() // ARBITRUM
+	conn := mocks.NewConnectorMock()
+	if sendResult != nil {
+		conn.On("SendRequest", mock.Anything, mock.Anything).Return(sendResult)
+	}
+	up := test_utils.TestEvmUpstream(conn, logsTestUpConfig(), logsMethodsMock(), nil)
+	upSup := mocks.NewUpstreamSupervisorMock()
+	upSup.On("GetChainSupervisor", chains.ARBITRUM).Return(chSup)
+	upSup.On("GetUpstream", mock.Anything).Return(up).Maybe()
+	return chSup, upSup, newLogsTestRegistry(upSup)
+}
+
+// A new canonical block makes the source fetch its logs and fan each one out as a
+// separate event with removed:false. Source.Buffer is the enlarged logs buffer.
+func TestLogsSourceEmitsPerLog(t *testing.T) {
+	twoLogs := protocol.NewSimpleHttpUpstreamResponse("1",
+		[]byte(`[{"address":"0xa","topics":["0x1"],"removed":false},{"address":"0xb","topics":["0x2"],"removed":false}]`),
+		protocol.JsonRpc)
+	chSup, upSup, registry := logsSourceTestSetup(t, twoLogs)
+	registerLogsUpstream(chSup, "up1", logsCaps()) // caps before build
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	src, err := newLogsSourceBuilder(upSup, chains.ARBITRUM, registry)(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, logsBufferSize, src.Buffer)
+
+	time.Sleep(50 * time.Millisecond) // let StreamBlockUpdates subscribe
+	publishHead(chSup, "up1", 100, "a0", "99")
+
+	assertRemoved(t, readWsResponse(t, src.Events), false)
+	assertRemoved(t, readWsResponse(t, src.Events), false)
+}
+
+// A reorg drops the orphaned block's cached logs with removed:true, then emits
+// the new block's logs with removed:false.
+func TestLogsSourceReorgReemitsRemoved(t *testing.T) {
+	oneLog := protocol.NewSimpleHttpUpstreamResponse("1",
+		[]byte(`[{"address":"0xa","topics":["0x1"],"removed":false}]`), protocol.JsonRpc)
+	chSup, upSup, registry := logsSourceTestSetup(t, oneLog)
+	registerLogsUpstream(chSup, "up1", logsCaps())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	src, err := newLogsSourceBuilder(upSup, chains.ARBITRUM, registry)(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	publishHead(chSup, "up1", 100, "a0", "99")
+	assertRemoved(t, readWsResponse(t, src.Events), false) // block 100 logs
+
+	// Height 101 builds on a different 100 (parent "bad") -> reorg: drop 100, new 101.
+	publishHead(chSup, "up1", 101, "a1", "de")
+	assertRemoved(t, readWsResponse(t, src.Events), true)  // block 100 re-emitted as removed
+	assertRemoved(t, readWsResponse(t, src.Events), false) // block 101 logs
+}
+
+// With no LogsCap on the chain, the source emits a terminal frame immediately so
+// clients fall back to the generic node-backed path.
+func TestLogsSourceTerminatesWhenLogsCapAbsentAtStart(t *testing.T) {
+	chSup, upSup, registry := logsSourceTestSetup(t, nil)
+	_ = chSup // no upstream published -> no LogsCap
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	src, err := newLogsSourceBuilder(upSup, chains.ARBITRUM, registry)(ctx)
+	require.NoError(t, err)
+
+	r := readWsResponse(t, src.Events)
+	require.NotNil(t, r.Error, "expected a terminal error frame when LogsCap is absent")
+}
+
+// Losing LogsCap mid-stream terminates the source on the next head update.
+func TestLogsSourceTerminatesWhenLogsCapLost(t *testing.T) {
+	oneLog := protocol.NewSimpleHttpUpstreamResponse("1",
+		[]byte(`[{"address":"0xa","topics":["0x1"],"removed":false}]`), protocol.JsonRpc)
+	chSup, upSup, registry := logsSourceTestSetup(t, oneLog)
+	registerLogsUpstream(chSup, "up1", logsCaps())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	src, err := newLogsSourceBuilder(upSup, chains.ARBITRUM, registry)(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	publishHead(chSup, "up1", 100, "a0", "99")
+	assertRemoved(t, readWsResponse(t, src.Events), false)
+
+	// up1 stops advertising LogsCap; the next head update terminates the source.
+	registerLogsUpstream(chSup, "up1", mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap))
+	publishHead(chSup, "up1", 101, "a1", "a0")
+	r := readWsResponse(t, src.Events)
+	require.NotNil(t, r.Error, "expected a terminal frame after LogsCap is lost")
+}
+
+// An eth_getLogs failure for one block skips it without terminating the source;
+// the next block's logs are still delivered.
+func TestLogsSourceSkipsBlockOnGetLogsError(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	chSup := test_utils.CreateChainSupervisor()
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.Anything).
+		Return(protocol.NewTotalFailureFromErr("1", assert.AnError, protocol.JsonRpc)).Once()
+	conn.On("SendRequest", mock.Anything, mock.Anything).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(`[{"address":"0xa","topics":["0x1"],"removed":false}]`), protocol.JsonRpc))
+	up := test_utils.TestEvmUpstream(conn, logsTestUpConfig(), logsMethodsMock(), nil)
+	upSup := mocks.NewUpstreamSupervisorMock()
+	upSup.On("GetChainSupervisor", chains.ARBITRUM).Return(chSup)
+	upSup.On("GetUpstream", mock.Anything).Return(up).Maybe()
+	registry := newLogsTestRegistry(upSup)
+
+	registerLogsUpstream(chSup, "up1", logsCaps())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	src, err := newLogsSourceBuilder(upSup, chains.ARBITRUM, registry)(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	publishHead(chSup, "up1", 100, "a0", "99") // getLogs errors -> skipped
+	publishHead(chSup, "up1", 101, "a1", "a0") // getLogs ok -> emitted
+
+	// The only event is block 101's log (block 100 produced none) and the source is alive.
+	assertRemoved(t, readWsResponse(t, src.Events), false)
+}
+
+func TestLogCacheFIFO(t *testing.T) {
+	c := newLogCache(2)
+	c.put("a", []json.RawMessage{[]byte(`1`)})
+	c.put("b", []json.RawMessage{[]byte(`2`)})
+	c.put("c", []json.RawMessage{[]byte(`3`)}) // evicts "a"
+
+	_, ok := c.get("a")
+	assert.False(t, ok, "oldest entry should be evicted")
+	got, ok := c.get("b")
+	assert.True(t, ok)
+	assert.Equal(t, json.RawMessage(`2`), got[0])
+	_, ok = c.get("c")
+	assert.True(t, ok)
+
+	// overwriting an existing key does not grow/evict
+	c.put("b", []json.RawMessage{[]byte(`22`)})
+	got, _ = c.get("b")
+	assert.Equal(t, json.RawMessage(`22`), got[0])
+	_, ok = c.get("c")
+	assert.True(t, ok, "overwrite must not evict another entry")
+}

--- a/internal/upstreams/flow/logs_source_internal_test.go
+++ b/internal/upstreams/flow/logs_source_internal_test.go
@@ -340,22 +340,22 @@ func TestLogsSourceSkipsBlockOnGetLogsError(t *testing.T) {
 
 func TestLogCacheFIFO(t *testing.T) {
 	c := newLogCache(2)
-	c.put("a", []json.RawMessage{[]byte(`1`)})
-	c.put("b", []json.RawMessage{[]byte(`2`)})
-	c.put("c", []json.RawMessage{[]byte(`3`)}) // evicts "a"
+	c.put("a", []*parsedLog{{raw: []byte(`1`)}})
+	c.put("b", []*parsedLog{{raw: []byte(`2`)}})
+	c.put("c", []*parsedLog{{raw: []byte(`3`)}}) // evicts "a"
 
 	_, ok := c.get("a")
 	assert.False(t, ok, "oldest entry should be evicted")
 	got, ok := c.get("b")
 	assert.True(t, ok)
-	assert.Equal(t, json.RawMessage(`2`), got[0])
+	assert.Equal(t, json.RawMessage(`2`), got[0].raw)
 	_, ok = c.get("c")
 	assert.True(t, ok)
 
 	// overwriting an existing key does not grow/evict
-	c.put("b", []json.RawMessage{[]byte(`22`)})
+	c.put("b", []*parsedLog{{raw: []byte(`22`)}})
 	got, _ = c.get("b")
-	assert.Equal(t, json.RawMessage(`22`), got[0])
+	assert.Equal(t, json.RawMessage(`22`), got[0].raw)
 	_, ok = c.get("c")
 	assert.True(t, ok, "overwrite must not evict another entry")
 }

--- a/internal/upstreams/flow/request_processor.go
+++ b/internal/upstreams/flow/request_processor.go
@@ -179,6 +179,29 @@ func executeUnaryRequest(
 	return result, err
 }
 
+// selectAndSend selects a single upstream via the strategy and sends the request
+// to it directly, WITHOUT the failsafe executor (no retry/hedge policies). It is
+// the lightweight counterpart to executeUnaryRequest for callers that just need a
+// one-shot request to a strategy-chosen upstream - e.g. the local logs source
+// fetching eth_getLogs from any upstream at the block's height. Repeated calls
+// with the same strategy walk down its rating list (selectedUpstreams dedup).
+func selectAndSend(
+	ctx context.Context,
+	upstreamSupervisor upstreams.UpstreamSupervisor,
+	request protocol.RequestHolder,
+	strategy UpstreamStrategy,
+) (*protocol.ResponseHolderWrapper, error) {
+	upstreamId, err := strategy.SelectUpstream(request)
+	if err != nil {
+		return nil, err
+	}
+	upstream := upstreamSupervisor.GetUpstream(upstreamId)
+	if upstream == nil {
+		return nil, protocol.NoAvailableUpstreamsError()
+	}
+	return sendUnaryRequest(ctx, upstream, request, request.ParseParams(ctx))
+}
+
 func getMethodConnector(upstream upstreams.Upstream, method *specs.Method) connectors.ApiConnector {
 	for _, connector := range method.GetApiConnectorTypes() {
 		if upConnector := upstream.GetConnector(connector); upConnector != nil {

--- a/internal/upstreams/flow/sub_aggregation.go
+++ b/internal/upstreams/flow/sub_aggregation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/rating"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -21,6 +22,15 @@ import (
 // onto one source regardless of their selectors (one head tap per chain).
 const localNewHeadsKey = "local|newHeads"
 
+// localLogsKey is the aggregation key for the locally-synthesized logs source.
+// All logs subscribers on a chain share ONE all-logs source (no address/topic
+// filter in the source); per-client filtering happens in the processor. The key
+// is therefore per-chain, NOT RequestHash-based (which would split the source
+// per filter and defeat sharing). Selectors are ignored for the same reason the
+// newHeads key ignores them - there is a single merged head per chain - and
+// resolveSource only takes the local path when no selectors are present.
+const localLogsKey = "local|logs"
+
 // resolveSource decides how the shared source for this subscription is produced
 // and returns its aggregation key alongside the builder, keeping the local-vs-
 // generic decision and the key in one place:
@@ -32,11 +42,17 @@ func resolveSource(
 	supervisor upstreams.UpstreamSupervisor,
 	request protocol.RequestHolder,
 	strategy UpstreamStrategy,
-) (string, subengine.SourceBuilder) {
+	registry *rating.RatingRegistry,
+) (string, subengine.SourceBuilder, SubFilter) {
 	if isNewHeadsRequest(request) && localNewHeadsAvailable(chain, supervisor) {
-		return localNewHeadsKey, subengine.NewHeadsSourceBuilder(supervisor, chain)
+		return localNewHeadsKey, subengine.NewHeadsSourceBuilder(supervisor, chain), nil
 	}
-	return subscriptionKey(request), newGenericSourceBuilder(supervisor, request, strategy)
+	if isLogsRequest(request) && localLogsAvailable(chain, supervisor) && len(request.Selectors()) == 0 {
+		if filter, err := parseLogFilter(request); err == nil {
+			return localLogsKey, newLogsSourceBuilder(supervisor, chain, registry), filter
+		}
+	}
+	return subscriptionKey(request), newGenericSourceBuilder(supervisor, request, strategy), nil
 }
 
 // isNewHeadsRequest reports whether request is eth_subscribe("newHeads"). Only
@@ -71,6 +87,39 @@ func localNewHeadsAvailable(chain chains.Chain, supervisor upstreams.UpstreamSup
 	}
 	caps := chainSup.GetChainState().Caps
 	return caps != nil && caps.Contains(protocol.NewHeadsCap)
+}
+
+// isLogsRequest reports whether request is eth_subscribe("logs", ...). Only EVM
+// chains expose eth_subscribe, so this also implies an EVM chain.
+func isLogsRequest(request protocol.RequestHolder) bool {
+	if request.Method() != "eth_subscribe" {
+		return false
+	}
+	body, err := request.Body()
+	if err != nil {
+		return false
+	}
+	node, err := sonic.Get(body, "params", 0)
+	if err != nil {
+		return false
+	}
+	value, err := node.String()
+	if err != nil {
+		return false
+	}
+	return value == "logs"
+}
+
+// localLogsAvailable reports whether the chain can synthesize logs locally, i.e.
+// some available upstream has a ws-driven head and eth_getLogs (LogsCap). Chains
+// without it fall back to the generic node-backed source.
+func localLogsAvailable(chain chains.Chain, supervisor upstreams.UpstreamSupervisor) bool {
+	chainSup := supervisor.GetChainSupervisor(chain)
+	if chainSup == nil {
+		return false
+	}
+	caps := chainSup.GetChainState().Caps
+	return caps != nil && caps.Contains(protocol.LogsCap)
 }
 
 // subscriptionKey is the aggregation key: subscriptions that share method and

--- a/internal/upstreams/flow/sub_aggregation_internal_test.go
+++ b/internal/upstreams/flow/sub_aggregation_internal_test.go
@@ -155,20 +155,82 @@ func TestParseLogFilterAndMatches(t *testing.T) {
 		{"address string match (case-insensitive)", `["logs",{"address":"0xabc"}]`, logAB, true},
 		{"address string mismatch", `["logs",{"address":"0xabc"}]`, logOther, false},
 		{"address array match", `["logs",{"address":["0x111","0xabc"]}]`, logAB, true},
+		{"address array mismatch", `["logs",{"address":["0x111","0x222"]}]`, logAB, false},
 		{"topic exact match", `["logs",{"topics":["0xaaa"]}]`, logAB, true},
 		{"topic null is wildcard", `["logs",{"topics":[null,"0xddd"]}]`, logAB, true},
 		{"topic OR-set match (case-insensitive)", `["logs",{"topics":[null,null,["0xb","0xc"]]}]`, logAB, true},
 		{"topic mismatch", `["logs",{"topics":["0xzzz"]}]`, logAB, false},
 		{"more filter topics than log has -> reject", `["logs",{"topics":["0xaaa","0xddd","0xc"]}]`, logTwoTopics, false},
 		{"address+topics combined", `["logs",{"address":"0xabc","topics":["0xaaa"]}]`, logAB, true},
+
+		// [topic1, null, topic2] — exact at pos0, wildcard at pos1, exact at pos2.
+		{"[t1,null,t2] all positions satisfied", `["logs",{"topics":["0xaaa",null,"0xc"]}]`, logAB, true},
+		{"[t1,null,t2] pos0 mismatch", `["logs",{"topics":["0xzzz",null,"0xc"]}]`, logAB, false},
+		{"[t1,null,t2] pos2 mismatch", `["logs",{"topics":["0xaaa",null,"0xzzz"]}]`, logAB, false},
+		{"[t1,null,t2] but log too short", `["logs",{"topics":["0xaaa",null,"0xc"]}]`, logTwoTopics, false},
+
+		// [topic1, [topic2, topic3]] — exact at pos0, OR-set at pos1.
+		{"[t1,[a,b]] OR-set hit", `["logs",{"topics":["0xaaa",["0xddd","0xeee"]]}]`, logAB, true},
+		{"[t1,[a,b]] OR-set miss", `["logs",{"topics":["0xaaa",["0xfff","0xeee"]]}]`, logAB, false},
+		{"[t1,[a,b]] pos0 mismatch with OR-set pos1", `["logs",{"topics":["0xzzz",["0xddd","0xeee"]]}]`, logAB, false},
+
+		// OR-set / null at the first position.
+		{"OR-set at pos0 hit", `["logs",{"topics":[["0xaaa","0xbbb"]]}]`, logAB, true},
+		{"OR-set at pos0 miss", `["logs",{"topics":[["0xbbb","0xccc"]]}]`, logAB, false},
+		{"all-null positions match all", `["logs",{"topics":[null,null]}]`, logAB, true},
+
+		// Degenerate topic positions are treated as wildcards.
+		{"empty topics array matches all", `["logs",{"topics":[]}]`, logAB, true},
+		{"empty OR-set is wildcard", `["logs",{"topics":[[]]}]`, logAB, true},
+
+		// A wildcard trailing position never imposes a length requirement.
+		{"trailing null past log length still matches", `["logs",{"topics":["0xaaa","0xddd","0xc",null]}]`, logAB, true},
+		// ...but a concrete trailing position past log length rejects.
+		{"trailing concrete topic past log length rejects", `["logs",{"topics":[null,null,null,"0xc"]}]`, logAB, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			filter, err := parseLogFilter(logsRequest(tc.params))
 			assert.NoError(t, err)
-			assert.Equal(t, tc.match, filter.Matches(tc.log))
+			assert.Equal(t, tc.match, filter.Matches(parseLogEvent(tc.log)))
 		})
 	}
+}
+
+func TestParseLogFilterMalformedAddress(t *testing.T) {
+	// A present-but-malformed address must be rejected (error -> generic
+	// node-backed path) rather than silently matching every address (firehose).
+	malformed := []string{
+		`["logs",{"address":123}]`,
+		`["logs",{"address":{"foo":"bar"}}]`,
+		`["logs",{"address":[1,2,3]}]`,
+		`["logs",{"address":true}]`,
+	}
+	for _, params := range malformed {
+		t.Run(params, func(t *testing.T) {
+			_, err := parseLogFilter(logsRequest(params))
+			assert.Error(t, err)
+		})
+	}
+
+	// Absent address must NOT error and must match any address.
+	filter, err := parseLogFilter(logsRequest(`["logs",{"topics":["0xaaa"]}]`))
+	assert.NoError(t, err)
+	assert.True(t, filter.Matches(parseLogEvent([]byte(`{"address":"0xanything","topics":["0xaaa"]}`))))
+}
+
+func TestParseLogEvent(t *testing.T) {
+	// address and topics are lowercased; raw is preserved verbatim.
+	raw := []byte(`{"address":"0xABC","topics":["0xAAA","0xDdD"],"removed":false}`)
+	pl := parseLogEvent(raw)
+	assert.Equal(t, "0xabc", pl.address)
+	assert.Equal(t, []string{"0xaaa", "0xddd"}, pl.topics)
+	assert.Equal(t, raw, []byte(pl.Raw()))
+
+	// Missing fields stay zero-valued (no panic): empty address, no topics.
+	plEmpty := parseLogEvent([]byte(`{"data":"0x0"}`))
+	assert.Equal(t, "", plEmpty.address)
+	assert.Empty(t, plEmpty.topics)
 }
 
 func TestSubscriptionKeyDependsOnMethodParamsAndSelectors(t *testing.T) {

--- a/internal/upstreams/flow/sub_aggregation_internal_test.go
+++ b/internal/upstreams/flow/sub_aggregation_internal_test.go
@@ -103,6 +103,74 @@ func TestIsNewHeadsRequest(t *testing.T) {
 	assert.False(t, isNewHeadsRequest(other))
 }
 
+func TestIsLogsRequest(t *testing.T) {
+	logs := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["logs",{}]`)}, true, "eth")
+	logsNoObj := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["logs"]`)}, true, "eth")
+	newHeads := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}, true, "eth")
+	other := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_call", Params: []byte(`[]`)}, false, "eth")
+
+	assert.True(t, isLogsRequest(logs))
+	assert.True(t, isLogsRequest(logsNoObj))
+	assert.False(t, isLogsRequest(newHeads))
+	assert.False(t, isLogsRequest(other))
+}
+
+func TestLocalLogsAvailable(t *testing.T) {
+	supNil := mocks.NewUpstreamSupervisorMock()
+	supNil.On("GetChainSupervisor", chains.ETHEREUM).Return(nil)
+	assert.False(t, localLogsAvailable(chains.ETHEREUM, supNil))
+
+	// ws head connector without eth_getLogs → NewHeadsCap but no LogsCap
+	supHeads := mocks.NewUpstreamSupervisorMock()
+	supHeads.On("GetChainSupervisor", chains.ETHEREUM).Return(&stubChainSupervisor{
+		state: upstreams.ChainSupervisorState{Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap)},
+	})
+	assert.False(t, localLogsAvailable(chains.ETHEREUM, supHeads))
+
+	// ws head connector with eth_getLogs → LogsCap → local synthesis
+	supLogs := mocks.NewUpstreamSupervisorMock()
+	supLogs.On("GetChainSupervisor", chains.ETHEREUM).Return(&stubChainSupervisor{
+		state: upstreams.ChainSupervisorState{Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap)},
+	})
+	assert.True(t, localLogsAvailable(chains.ETHEREUM, supLogs))
+}
+
+func logsRequest(params string) protocol.RequestHolder {
+	return protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(params)}, true, "eth")
+}
+
+func TestParseLogFilterAndMatches(t *testing.T) {
+	logAB := []byte(`{"address":"0xABC","topics":["0xaaa","0xddd","0xC"]}`)
+	logOther := []byte(`{"address":"0xdef","topics":["0xaaa"]}`)
+	logTwoTopics := []byte(`{"address":"0xABC","topics":["0xaaa","0xddd"]}`)
+
+	tests := []struct {
+		name   string
+		params string
+		log    []byte
+		match  bool
+	}{
+		{"empty object matches all", `["logs",{}]`, logAB, true},
+		{"no filter object matches all", `["logs"]`, logAB, true},
+		{"address string match (case-insensitive)", `["logs",{"address":"0xabc"}]`, logAB, true},
+		{"address string mismatch", `["logs",{"address":"0xabc"}]`, logOther, false},
+		{"address array match", `["logs",{"address":["0x111","0xabc"]}]`, logAB, true},
+		{"topic exact match", `["logs",{"topics":["0xaaa"]}]`, logAB, true},
+		{"topic null is wildcard", `["logs",{"topics":[null,"0xddd"]}]`, logAB, true},
+		{"topic OR-set match (case-insensitive)", `["logs",{"topics":[null,null,["0xb","0xc"]]}]`, logAB, true},
+		{"topic mismatch", `["logs",{"topics":["0xzzz"]}]`, logAB, false},
+		{"more filter topics than log has -> reject", `["logs",{"topics":["0xaaa","0xddd","0xc"]}]`, logTwoTopics, false},
+		{"address+topics combined", `["logs",{"address":"0xabc","topics":["0xaaa"]}]`, logAB, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := parseLogFilter(logsRequest(tc.params))
+			assert.NoError(t, err)
+			assert.Equal(t, tc.match, filter.Matches(tc.log))
+		})
+	}
+}
+
 func TestSubscriptionKeyDependsOnMethodParamsAndSelectors(t *testing.T) {
 	newHeads := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["newHeads"]`)}, true, "eth")
 	logs := protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(`["logs"]`)}, true, "eth")

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/rating"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/internal/upstreams/flow/subengine"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -21,6 +22,7 @@ type SubscriptionRequestProcessor struct {
 	upstreamSupervisor upstreams.UpstreamSupervisor
 	engine             subengine.Engine
 	subCtx             *SubCtx
+	registry           *rating.RatingRegistry
 }
 
 func NewSubscriptionRequestProcessor(
@@ -28,12 +30,14 @@ func NewSubscriptionRequestProcessor(
 	upstreamSupervisor upstreams.UpstreamSupervisor,
 	engine subengine.Engine,
 	subCtx *SubCtx,
+	registry *rating.RatingRegistry,
 ) *SubscriptionRequestProcessor {
 	return &SubscriptionRequestProcessor{
 		chain:              chain,
 		upstreamSupervisor: upstreamSupervisor,
 		engine:             engine,
 		subCtx:             subCtx,
+		registry:           registry,
 	}
 }
 
@@ -63,7 +67,7 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 		// The shared source emits events only - each client allocates its own
 		// client-facing subscription id below, independent of the single
 		// upstream subscription id.
-		key, builder := resolveSource(s.chain, s.upstreamSupervisor, request, upstreamStrategy)
+		key, builder, filter := resolveSource(s.chain, s.upstreamSupervisor, request, upstreamStrategy, s.registry)
 		sub, err := s.engine.Subscribe(key, builder)
 		if err != nil {
 			responses <- totalFailureWrapper(request, err)
@@ -96,6 +100,12 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 						responses <- totalFailureWrapper(request, cause)
 					}
 					return
+				}
+				// Per-client logs filtering: the shared logs source carries every
+				// log of the chain; drop the ones this client did not subscribe to.
+				// Never filter terminal frames (handled above; they carry no Message).
+				if filter != nil && !filter.Matches(r.Message) {
+					continue
 				}
 				var subResponse protocol.ResponseHolder
 				if s.subCtx.IsSubscriptionResultOnly() {

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -104,7 +104,7 @@ func (s *SubscriptionRequestProcessor) ProcessRequest(
 				// Per-client logs filtering: the shared logs source carries every
 				// log of the chain; drop the ones this client did not subscribe to.
 				// Never filter terminal frames (handled above; they carry no Message).
-				if filter != nil && !filter.Matches(r.Message) {
+				if filter != nil && !filter.Matches(r.ParsedEvent) {
 					continue
 				}
 				var subResponse protocol.ResponseHolder

--- a/internal/upstreams/flow/sub_processor_test.go
+++ b/internal/upstreams/flow/sub_processor_test.go
@@ -35,7 +35,7 @@ func newSubProcessor(upSupervisor *mocks.UpstreamSupervisorMock, subCtx *flow.Su
 	// node-backed path; tests that want local synthesis override this.
 	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
 	engine := subengine.NewRegistry(context.Background()).Get(chains.ETHEREUM)
-	return flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, subCtx)
+	return flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, subCtx, nil)
 }
 
 func TestSubscriptionRequestProcessorAndCantSelectUpstreamThenError(t *testing.T) {
@@ -203,8 +203,8 @@ func TestSubscriptionRequestProcessorTwoSubscribersShareOneUpstreamSub(t *testin
 	upSupervisor.On("GetChainSupervisor", mock.Anything).Return(nil).Maybe()
 	// One shared engine backs both client processors.
 	engine := subengine.NewRegistry(ctx).Get(chains.ETHEREUM)
-	p1 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
-	p2 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx())
+	p1 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx(), nil)
+	p2 := flow.NewSubscriptionRequestProcessor(chains.ETHEREUM, upSupervisor, engine, flow.NewSubCtx(), nil)
 
 	req1 := testEthSubscribeRequestWithId("c1")
 	req2 := testEthSubscribeRequestWithId("c2")

--- a/internal/upstreams/flow/subengine/blockupdates.go
+++ b/internal/upstreams/flow/subengine/blockupdates.go
@@ -186,7 +186,6 @@ func StreamBlockUpdates(srcCtx context.Context, chainSup upstreams.ChainSupervis
 					continue
 				}
 				for _, update := range t.advance(head.Head) {
-					fmt.Println("block update", update.Block.Height, update.Kind)
 					select {
 					case out <- update:
 					case <-srcCtx.Done():

--- a/internal/upstreams/flow/subengine/blockupdates.go
+++ b/internal/upstreams/flow/subengine/blockupdates.go
@@ -1,0 +1,199 @@
+package subengine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/google/uuid"
+)
+
+// historyRingSize bounds how deep a reorg we keep enough history to reconcile.
+// Indexed by height % historyRingSize.
+const historyRingSize = 18
+
+// UpdateKind classifies a BlockUpdate.
+type UpdateKind int
+
+const (
+	// BlockNew marks a block that just became canonical; its logs are emitted
+	// with removed:false.
+	BlockNew UpdateKind = iota
+	// BlockDrop marks a previously-canonical block that was orphaned by a reorg;
+	// its cached logs are re-emitted with removed:true.
+	BlockDrop
+)
+
+// BlockUpdate is a single canonical-chain transition derived from the merged
+// head stream. No upstream id is carried: the logs source picks an upstream by
+// the block's height, not by the head producer.
+type BlockUpdate struct {
+	Block protocol.Block
+	Kind  UpdateKind
+}
+
+// ringEntry remembers the (height, hash) the tracker last considered canonical at
+// a height. Reorg detection compares this stored hash against the arriving head
+// (its own hash for a same/lower height, its parent hash for a direct successor),
+// so the parent hash of the stored block is not needed.
+type ringEntry struct {
+	populated bool
+	height    uint64
+	hash      blockchain.HashId
+}
+
+// blockTracker turns the merged head stream into ordered NEW/DROP updates. It
+// owns a bounded history ring keyed by height and is single-goroutine (no
+// locking). Classification is by HASH per height, not by height alone, so a
+// benign rollback (a faster upstream dropping out, leaving a lower head from a
+// slower upstream on the same chain) is a no-op, while a head that disagrees on
+// the hash at a height we already announced is a reorg.
+//
+// The merged head fork-choice (fork_choice/height_fc.go) republishes a head only
+// when the max height CHANGES, which still constrains what this tracker can see:
+//   - A same-height 1-block reorg with no height movement is invisible (it
+//     self-heals on the next height change via the parent/hash mismatch).
+//   - Forward gaps (height jumps N -> N+2) are not backfilled.
+//   - Reorg reconciliation is bounded by the ring window: orphans deeper than
+//     historyRingSize have already been evicted, and the reorged-in block at the
+//     same height as a dropped tip is not backfilled.
+type blockTracker struct {
+	ring    []ringEntry
+	haveTip bool
+	tipH    uint64
+}
+
+func newBlockTracker() *blockTracker {
+	return &blockTracker{ring: make([]ringEntry, historyRingSize)}
+}
+
+// advance applies a merged head to the tracker and returns the resulting block
+// updates: zero or more BlockDrop (a reorged-out suffix, top-down) followed by an
+// optional BlockNew. It is pure with respect to channels/goroutines, so it can be
+// table-tested directly.
+func (t *blockTracker) advance(block protocol.Block) []BlockUpdate {
+	if len(block.Hash) == 0 {
+		return nil // cannot key getLogs or the ring without a hash
+	}
+	h := block.Height
+
+	if !t.haveTip {
+		t.put(block)
+		t.haveTip = true
+		t.tipH = h
+		return []BlockUpdate{{Block: block, Kind: BlockNew}}
+	}
+
+	// A block we already announced at this exact height+hash: a benign re-report
+	// (e.g. a slower upstream becoming the head after a faster one drops) or a
+	// plain duplicate. Nothing to do.
+	if e := t.ring[h%historyRingSize]; e.populated && e.height == h && e.hash.Equals(block.Hash) {
+		return nil
+	}
+
+	if reorgFrom, ok := t.reorgPoint(block); ok {
+		updates := t.dropFrom(reorgFrom)
+		t.put(block)
+		t.tipH = h
+		return append(updates, BlockUpdate{Block: block, Kind: BlockNew})
+	}
+
+	if h > t.tipH {
+		// Clean extension, or a forward gap we cannot reconcile - just announce it.
+		t.put(block)
+		t.tipH = h
+		return []BlockUpdate{{Block: block, Kind: BlockNew}}
+	}
+
+	// h <= tipH with no block announced at this height: a lower head we can't
+	// reason about (e.g. below a gap). Don't drop, don't backfill.
+	return nil
+}
+
+// reorgPoint reports the lowest announced height orphaned by block, and whether
+// block reorgs anything we have already announced. An exact height+hash match is
+// handled as a duplicate by the caller before this is reached.
+func (t *blockTracker) reorgPoint(block protocol.Block) (uint64, bool) {
+	h := block.Height
+	if h > t.tipH {
+		// Forward: only a direct successor whose parent disagrees with our tip
+		// reveals a (tip) reorg. Forward gaps can't be reasoned about.
+		if h == t.tipH+1 && len(block.ParentHash) > 0 {
+			if e := t.ring[t.tipH%historyRingSize]; e.populated && e.height == t.tipH && !e.hash.Equals(block.ParentHash) {
+				return t.tipH, true
+			}
+		}
+		return 0, false
+	}
+	// h <= tipH with a different hash at a height we announced: the chain reorged
+	// at h, orphaning everything we announced from h up to the tip.
+	if e := t.ring[h%historyRingSize]; e.populated && e.height == h {
+		return h, true
+	}
+	return 0, false
+}
+
+// dropFrom emits BlockDrop for every announced block in [reorgFrom..tipH],
+// top-down, and clears them. It is bounded to the last historyRingSize heights
+// (older entries have already been evicted from the ring).
+func (t *blockTracker) dropFrom(reorgFrom uint64) []BlockUpdate {
+	lo := reorgFrom
+	if t.tipH >= historyRingSize && lo < t.tipH-historyRingSize+1 {
+		lo = t.tipH - historyRingSize + 1
+	}
+	var drops []BlockUpdate
+	for hh := t.tipH; hh >= lo; hh-- {
+		if e := t.ring[hh%historyRingSize]; e.populated && e.height == hh {
+			drops = append(drops, BlockUpdate{Block: protocol.Block{Height: e.height, Hash: e.hash}, Kind: BlockDrop})
+			t.ring[hh%historyRingSize] = ringEntry{}
+		}
+		if hh == 0 {
+			break // avoid uint64 underflow
+		}
+	}
+	return drops
+}
+
+func (t *blockTracker) put(block protocol.Block) {
+	t.ring[block.Height%historyRingSize] = ringEntry{
+		populated: true,
+		height:    block.Height,
+		hash:      block.Hash,
+	}
+}
+
+// StreamBlockUpdates taps the chain head stream and pushes ordered BlockUpdates
+// to out until srcCtx is cancelled or the head subscription closes. It owns its
+// blockTracker; the caller owns out (it is not closed here).
+func StreamBlockUpdates(srcCtx context.Context, chainSup upstreams.ChainSupervisor, out chan<- BlockUpdate) {
+	sub := chainSup.SubscribeState(fmt.Sprintf("subengine_logs_%s_%s", chainSup.GetChain(), uuid.NewString()))
+	defer sub.Unsubscribe()
+
+	t := newBlockTracker()
+	for {
+		select {
+		case <-srcCtx.Done():
+			return
+		case event, ok := <-sub.Events:
+			if !ok {
+				return
+			}
+			for _, wrapper := range event.Wrappers {
+				head, ok := wrapper.(*upstreams.HeadWrapper)
+				if !ok {
+					continue
+				}
+				for _, update := range t.advance(head.Head) {
+					fmt.Println("block update", update.Block.Height, update.Kind)
+					select {
+					case out <- update:
+					case <-srcCtx.Done():
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/upstreams/flow/subengine/blockupdates.go
+++ b/internal/upstreams/flow/subengine/blockupdates.go
@@ -4,15 +4,37 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
 )
 
 // historyRingSize bounds how deep a reorg we keep enough history to reconcile.
 // Indexed by height % historyRingSize.
 const historyRingSize = 18
+
+// reorgClampedMetric counts reorgs whose orphaned suffix reaches deeper than the
+// history ring, so the oldest orphans are never emitted as removed:true. A
+// non-zero value means a reorg exceeded the reconciliation window and some
+// removals were silently dropped.
+var reorgClampedMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: config.AppName,
+		Subsystem: "logs_source",
+		Name:      "reorg_clamped_total",
+		Help:      "The total number of reorgs deeper than the history window whose oldest removals were dropped",
+	},
+	[]string{"chain"},
+)
+
+func init() {
+	prometheus.MustRegister(reorgClampedMetric)
+}
 
 // UpdateKind classifies a BlockUpdate.
 type UpdateKind int
@@ -63,6 +85,7 @@ type blockTracker struct {
 	ring    []ringEntry
 	haveTip bool
 	tipH    uint64
+	chain   chains.Chain
 }
 
 func newBlockTracker() *blockTracker {
@@ -141,7 +164,11 @@ func (t *blockTracker) reorgPoint(block protocol.Block) (uint64, bool) {
 func (t *blockTracker) dropFrom(reorgFrom uint64) []BlockUpdate {
 	lo := reorgFrom
 	if t.tipH >= historyRingSize && lo < t.tipH-historyRingSize+1 {
+		// Reorg reaches deeper than the ring: orphans below lo were already
+		// evicted and are never emitted as removed. Surface this incompleteness.
 		lo = t.tipH - historyRingSize + 1
+		log.Warn().Msgf("subengine: reorg on %s deeper than history window (reorgFrom=%d clamped to %d, tip=%d); oldest removals dropped", t.chain, reorgFrom, lo, t.tipH)
+		reorgClampedMetric.WithLabelValues(t.chain.String()).Inc()
 	}
 	var drops []BlockUpdate
 	for hh := t.tipH; hh >= lo; hh-- {
@@ -166,12 +193,17 @@ func (t *blockTracker) put(block protocol.Block) {
 
 // StreamBlockUpdates taps the chain head stream and pushes ordered BlockUpdates
 // to out until srcCtx is cancelled or the head subscription closes. It owns its
-// blockTracker; the caller owns out (it is not closed here).
+// blockTracker and closes out on return, so the consumer exits deterministically
+// (via its `if !ok` branch) even when the head subscription closes while srcCtx
+// is still live.
 func StreamBlockUpdates(srcCtx context.Context, chainSup upstreams.ChainSupervisor, out chan<- BlockUpdate) {
+	defer close(out)
+
 	sub := chainSup.SubscribeState(fmt.Sprintf("subengine_logs_%s_%s", chainSup.GetChain(), uuid.NewString()))
 	defer sub.Unsubscribe()
 
 	t := newBlockTracker()
+	t.chain = chainSup.GetChain()
 	for {
 		select {
 		case <-srcCtx.Done():

--- a/internal/upstreams/flow/subengine/blockupdates_test.go
+++ b/internal/upstreams/flow/subengine/blockupdates_test.go
@@ -1,0 +1,329 @@
+package subengine
+
+import (
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func blk(height uint64, hash, parent string) protocol.Block {
+	return protocol.Block{
+		Height:     height,
+		Hash:       blockchain.NewHashIdFromString(hash),
+		ParentHash: blockchain.NewHashIdFromString(parent),
+	}
+}
+
+type wantUpdate struct {
+	height uint64
+	hash   string
+	kind   UpdateKind
+}
+
+func assertUpdates(t *testing.T, got []BlockUpdate, want []wantUpdate) {
+	t.Helper()
+	require.Len(t, got, len(want))
+	for i, w := range want {
+		assert.Equal(t, w.height, got[i].Block.Height, "update %d height", i)
+		assert.Equal(t, blockchain.NewHashIdFromString(w.hash), got[i].Block.Hash, "update %d hash", i)
+		assert.Equal(t, w.kind, got[i].Kind, "update %d kind", i)
+	}
+}
+
+func TestBlockTrackerLinearExtension(t *testing.T) {
+	tr := newBlockTracker()
+	assertUpdates(t, tr.advance(blk(1, "aa", "00")), []wantUpdate{{1, "aa", BlockNew}})
+	assertUpdates(t, tr.advance(blk(2, "bb", "aa")), []wantUpdate{{2, "bb", BlockNew}})
+	assertUpdates(t, tr.advance(blk(3, "cc", "bb")), []wantUpdate{{3, "cc", BlockNew}})
+}
+
+func TestBlockTrackerForwardGapEmitsOnlyNew(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	// Height jumps 1 -> 3: the intermediate block was never delivered, so no DROP
+	// and no backfill - just NEW for height 3.
+	assertUpdates(t, tr.advance(blk(3, "cc", "bb")), []wantUpdate{{3, "cc", BlockNew}})
+}
+
+func TestBlockTrackerDepth1Reorg(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa")) // canonical at height 2 is "bb"
+	// New head at height 3 builds on "b2" (a different height-2 block), so the
+	// "bb" we had at height 2 is orphaned: DROP("bb") then NEW("cc").
+	got := tr.advance(blk(3, "cc", "b2"))
+	assertUpdates(t, got, []wantUpdate{{2, "bb", BlockDrop}, {3, "cc", BlockNew}})
+}
+
+// A faster upstream drops out and the merged head falls back to a lower head from
+// a slower upstream on the SAME chain (same hashes). Nothing is dropped.
+func TestBlockTrackerBenignRollbackNoOp(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(3, "cc", "bb")) // tip = 3 via the fast upstream
+
+	// Fast upstream gone; head rolls back to the slower upstream's head, still on
+	// the same chain - each height keeps its hash, so no DROP, no NEW.
+	assert.Empty(t, tr.advance(blk(2, "bb", "aa")), "benign rollback to a known block")
+	assert.Empty(t, tr.advance(blk(1, "aa", "00")), "benign rollback further down")
+
+	// The slow upstream catches back up: known blocks are no-ops, new ones NEW.
+	assert.Empty(t, tr.advance(blk(2, "bb", "aa")))
+	assert.Empty(t, tr.advance(blk(3, "cc", "bb")))
+	assertUpdates(t, tr.advance(blk(4, "dd", "cc")), []wantUpdate{{4, "dd", BlockNew}})
+}
+
+// A reorg that surfaces BELOW the current tip (a head at an already-announced
+// height with a different hash) drops the orphaned suffix [h..tip] top-down and
+// announces the new block.
+func TestBlockTrackerReorgBelowTip(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(3, "cc", "bb")) // tip = 3
+
+	// Height 2 reappears with a different hash -> reorg at 2: drop cc@3 then bb@2,
+	// then announce the new b2@2.
+	got := tr.advance(blk(2, "b2", "aa"))
+	assertUpdates(t, got, []wantUpdate{{3, "cc", BlockDrop}, {2, "bb", BlockDrop}, {2, "b2", BlockNew}})
+}
+
+func TestBlockTrackerDuplicateAndStaleAreNoOps(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	assert.Empty(t, tr.advance(blk(2, "bb", "aa")), "exact duplicate -> no update")
+	assert.Empty(t, tr.advance(blk(1, "aa", "00")), "stale lower height -> no update")
+}
+
+func TestBlockTrackerSameHeightSwapIsDefensivelyHandled(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	// A same-height head with a different hash (the fork choice normally suppresses
+	// this, but if it ever surfaces) drops the old tip and emits the new one.
+	got := tr.advance(blk(2, "b2", "aa"))
+	assertUpdates(t, got, []wantUpdate{{2, "bb", BlockDrop}, {2, "b2", BlockNew}})
+}
+
+func TestBlockTrackerEmptyHashSkipped(t *testing.T) {
+	tr := newBlockTracker()
+	assert.Empty(t, tr.advance(protocol.Block{Height: 5}), "no hash -> no update")
+}
+
+func TestBlockTrackerRingWraparoundNoSpuriousDrop(t *testing.T) {
+	tr := newBlockTracker()
+	// Advance well past the ring size so old entries are evicted/overwritten.
+	parent := "00"
+	for h := uint64(1); h <= historyRingSize+5; h++ {
+		cur := hexFor(h)
+		assertUpdates(t, tr.advance(blk(h, cur, parent)), []wantUpdate{{h, cur, BlockNew}})
+		parent = cur
+	}
+	// A reorg deeper than the ring can hold: the displaced predecessor at h-1 is
+	// still in the ring (depth-1), so exactly one DROP + one NEW, never more.
+	top := historyRingSize + 5
+	got := tr.advance(blk(uint64(top+1), "ff", "deadbeef"))
+	require.Len(t, got, 2)
+	assert.Equal(t, BlockDrop, got[0].Kind)
+	assert.Equal(t, BlockNew, got[1].Kind)
+}
+
+// --- additional coverage -------------------------------------------------
+
+func noUpdate(t *testing.T, tr *blockTracker, b protocol.Block, msg string) {
+	t.Helper()
+	assert.Empty(t, tr.advance(b), msg)
+}
+
+// The very first head is always announced as NEW regardless of its parent.
+func TestBlockTrackerFirstBlockEmitsNew(t *testing.T) {
+	tr := newBlockTracker()
+	assertUpdates(t, tr.advance(blk(7, "aa", "00")), []wantUpdate{{7, "aa", BlockNew}})
+}
+
+// A direct successor with no parent hash cannot be classified as a reorg, so it
+// is announced as a clean extension (no false DROP).
+func TestBlockTrackerCleanExtensionEmptyParentNoReorg(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	got := tr.advance(protocol.Block{Height: 2, Hash: blockchain.NewHashIdFromString("bb")}) // empty parent
+	assertUpdates(t, got, []wantUpdate{{2, "bb", BlockNew}})
+}
+
+// Re-announcing the exact tip is a no-op.
+func TestBlockTrackerExactTipReannounceNoOp(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	noUpdate(t, tr, blk(2, "bb", "aa"), "exact tip re-announce")
+}
+
+// A reorg that displaces several blocks drops the whole suffix top-down (highest
+// height first) before announcing the new block.
+func TestBlockTrackerDeepBackwardReorgDropsSuffixTopDown(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(3, "cc", "bb"))
+	tr.advance(blk(4, "dd", "cc"))
+	tr.advance(blk(5, "ee", "dd")) // tip = 5
+
+	got := tr.advance(blk(2, "b2", "aa")) // reorg at height 2
+	assertUpdates(t, got, []wantUpdate{
+		{5, "ee", BlockDrop},
+		{4, "dd", BlockDrop},
+		{3, "cc", BlockDrop},
+		{2, "bb", BlockDrop},
+		{2, "b2", BlockNew},
+	})
+}
+
+// When the dropped suffix spans heights that were never announced (a prior gap),
+// only the announced ones are dropped.
+func TestBlockTrackerReorgSuffixSkipsUnannouncedHeights(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(5, "ee", "dd")) // gap: heights 3,4 never announced. tip = 5
+
+	got := tr.advance(blk(2, "b2", "aa")) // reorg at 2
+	assertUpdates(t, got, []wantUpdate{
+		{5, "ee", BlockDrop}, // 4 and 3 were never announced -> skipped
+		{2, "bb", BlockDrop},
+		{2, "b2", BlockNew},
+	})
+}
+
+// A lower head at a height we never announced (e.g. below a gap) is ignored: no
+// DROP and no backfill.
+func TestBlockTrackerLowerHeadUnannouncedHeightSkipped(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(3, "cc", "bb")) // gap: height 2 never announced. tip = 3
+
+	noUpdate(t, tr, blk(2, "xx", "aa"), "unannounced lower height")
+	// tip is unchanged, so a real extension still works.
+	assertUpdates(t, tr.advance(blk(4, "dd", "cc")), []wantUpdate{{4, "dd", BlockNew}})
+}
+
+// A reorg older than the history window cannot be reconciled (its entry has been
+// evicted), so it is skipped rather than mis-detected.
+func TestBlockTrackerReorgBelowWindowSkipped(t *testing.T) {
+	tr := newBlockTracker()
+	parent := "00"
+	for h := uint64(1); h <= historyRingSize+5; h++ {
+		cur := hexFor(h)
+		tr.advance(blk(h, cur, parent))
+		parent = cur
+	}
+	// Height 3 is far below the retained window (its ring slot now holds 3+N).
+	noUpdate(t, tr, blk(3, "zz", "02"), "reorg older than the window")
+}
+
+// After a reorg the tip moves down to the reorg point and the new chain extends
+// cleanly from there; the orphaned hashes are gone from history.
+func TestBlockTrackerReorgThenNewChainExtends(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(3, "cc", "bb")) // tip = 3
+
+	assertUpdates(t, tr.advance(blk(2, "b2", "aa")), []wantUpdate{
+		{3, "cc", BlockDrop}, {2, "bb", BlockDrop}, {2, "b2", BlockNew},
+	})
+	// new chain continues from b2@2
+	assertUpdates(t, tr.advance(blk(3, "c2", "b2")), []wantUpdate{{3, "c2", BlockNew}})
+	assertUpdates(t, tr.advance(blk(4, "d2", "c2")), []wantUpdate{{4, "d2", BlockNew}})
+}
+
+// Two forward reorgs in a row, each replacing the freshly-announced tip.
+func TestBlockTrackerSequentialForwardReorgs(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	tr.advance(blk(3, "cc", "bb")) // tip = 3
+
+	assertUpdates(t, tr.advance(blk(4, "dd", "c2")), []wantUpdate{ // 4 builds on c2 != cc
+		{3, "cc", BlockDrop}, {4, "dd", BlockNew},
+	})
+	assertUpdates(t, tr.advance(blk(5, "ee", "d2")), []wantUpdate{ // 5 builds on d2 != dd
+		{4, "dd", BlockDrop}, {5, "ee", BlockNew},
+	})
+}
+
+// A forward reorg at the tip right after a gap drops the gapped tip and announces
+// the new successor.
+func TestBlockTrackerForwardReorgAfterGap(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(5, "ee", "dd")) // gap. tip = 5
+	got := tr.advance(blk(6, "ff", "e2"))
+	assertUpdates(t, got, []wantUpdate{{5, "ee", BlockDrop}, {6, "ff", BlockNew}})
+}
+
+// An empty-hash head mid-stream is ignored without corrupting tracker state.
+func TestBlockTrackerEmptyHashDoesNotCorruptState(t *testing.T) {
+	tr := newBlockTracker()
+	tr.advance(blk(1, "aa", "00"))
+	tr.advance(blk(2, "bb", "aa"))
+	noUpdate(t, tr, protocol.Block{Height: 3}, "empty hash mid-stream")
+	assertUpdates(t, tr.advance(blk(3, "cc", "bb")), []wantUpdate{{3, "cc", BlockNew}})
+}
+
+// A reorg at height 0 must not underflow the descending drop loop.
+func TestBlockTrackerReorgAtHeightZero(t *testing.T) {
+	tr := newBlockTracker()
+	assertUpdates(t, tr.advance(blk(0, "aa", "00")), []wantUpdate{{0, "aa", BlockNew}})
+	got := tr.advance(blk(0, "a0", "00"))
+	assertUpdates(t, got, []wantUpdate{{0, "aa", BlockDrop}, {0, "a0", BlockNew}})
+}
+
+// dropFrom clamps the drop range to the last historyRingSize heights even when
+// asked to start below the retained window.
+func TestDropFromClampedToWindow(t *testing.T) {
+	tr := newBlockTracker()
+	const base = uint64(100)
+	for h := base; h <= base+historyRingSize-1; h++ {
+		tr.put(blk(h, hexFor(h), "00"))
+	}
+	tr.haveTip = true
+	tr.tipH = base + historyRingSize - 1
+
+	drops := tr.dropFrom(1) // far below the window
+	require.Len(t, drops, historyRingSize)
+	assert.Equal(t, tr.tipH, drops[0].Block.Height)         // top-down
+	assert.Equal(t, base, drops[len(drops)-1].Block.Height) // clamped lower bound
+}
+
+// dropFrom from height 0 drops the single entry and stops without underflow.
+func TestDropFromHeightZeroNoUnderflow(t *testing.T) {
+	tr := newBlockTracker()
+	tr.put(blk(0, "aa", "00"))
+	tr.haveTip = true
+	tr.tipH = 0
+	drops := tr.dropFrom(0)
+	require.Len(t, drops, 1)
+	assert.Equal(t, uint64(0), drops[0].Block.Height)
+}
+
+// hexFor returns a short, unique, valid hex string for a height.
+func hexFor(h uint64) string {
+	const digits = "0123456789abcdef"
+	if h == 0 {
+		return "00"
+	}
+	out := ""
+	for h > 0 {
+		out = string(digits[h&0xf]) + out
+		h >>= 4
+	}
+	if len(out)%2 != 0 {
+		out = "0" + out
+	}
+	return out
+}

--- a/internal/upstreams/flow/subengine/engine.go
+++ b/internal/upstreams/flow/subengine/engine.go
@@ -21,6 +21,7 @@
 package subengine
 
 import (
+	"cmp"
 	"context"
 	"time"
 
@@ -46,6 +47,11 @@ const subscriberBufferSize = 100
 type Source struct {
 	Events <-chan *protocol.WsResponse
 	Stop   func()
+	// Buffer optionally overrides the per-subscriber fan-out buffer size for this
+	// source. Zero means subscriberBufferSize. A source that bursts many events
+	// per upstream message (e.g. all logs of one block) sets a larger value so a
+	// momentarily-busy client is not disconnected as "too slow".
+	Buffer int
 }
 
 // SourceBuilder starts a Source bound to srcCtx. srcCtx is cancelled by the
@@ -195,6 +201,8 @@ func (e *baseEngine) run(a *sourceActor, build SourceBuilder) {
 		return
 	}
 
+	bufSize := cmp.Or(src.Buffer, subscriberBufferSize)
+
 	subs := make(map[int]*subscriber)
 	var seq, refs int
 	var teardown *time.Timer
@@ -263,7 +271,7 @@ func (e *baseEngine) run(a *sourceActor, build SourceBuilder) {
 					close(s.ch)
 					delete(subs, id)
 					refs--
-					log.Warn().Msgf("disconnected lagging subscriber %s/sub-%d: buffer of %d full", a.key, id, subscriberBufferSize)
+					log.Warn().Msgf("disconnected lagging subscriber %s/sub-%d: buffer of %d full", a.key, id, bufSize)
 				}
 			}
 			if refs == 0 && teardownC == nil {
@@ -281,7 +289,7 @@ func (e *baseEngine) run(a *sourceActor, build SourceBuilder) {
 			}
 			seq++
 			refs++
-			s := &subscriber{id: seq, ch: make(chan *protocol.WsResponse, subscriberBufferSize)}
+			s := &subscriber{id: seq, ch: make(chan *protocol.WsResponse, bufSize)}
 			subs[s.id] = s
 			cmd.reply <- e.newSubscription(a, s)
 

--- a/internal/upstreams/flow/subengine/engine_test.go
+++ b/internal/upstreams/flow/subengine/engine_test.go
@@ -244,6 +244,34 @@ func TestEngineSlowConsumerDisconnectedDespiteFullBuffer(t *testing.T) {
 	assert.Equal(t, protocol.WsSubscriberTooSlowError().Code, sub.Err().Code)
 }
 
+// A source may enlarge its per-subscriber fan-out buffer via Source.Buffer; a
+// subscriber then tolerates a burst larger than the default before being
+// disconnected, while a default-buffer source still disconnects at the default.
+func TestEngineSourceBufferOverride(t *testing.T) {
+	e := newTestEngine(time.Minute)
+	const big = subscriberBufferSize + 200
+	events := make(chan *protocol.WsResponse)
+	build := func(_ context.Context) (*Source, error) {
+		return &Source{Events: events, Stop: func() {}, Buffer: big}, nil
+	}
+	sub, err := e.Subscribe("k", build)
+	require.NoError(t, err)
+
+	// Push more than the default buffer but within the override; the subscriber
+	// must NOT be disconnected (events sit in its enlarged buffer).
+	for i := 0; i < subscriberBufferSize+100; i++ {
+		events <- &protocol.WsResponse{Message: []byte("e")}
+	}
+	assert.Nil(t, sub.Err(), "subscriber disconnected below its enlarged buffer")
+
+	drained := 0
+	for drained < subscriberBufferSize+100 {
+		<-sub.Events
+		drained++
+	}
+	sub.Unsubscribe()
+}
+
 // A fast subscriber keeps receiving even when a peer on the same source is
 // disconnected for lagging.
 func TestEngineSlowConsumerDoesNotAffectFastPeer(t *testing.T) {


### PR DESCRIPTION
# Local EVM `logs` subscriptions + reorg handling (subscription rework, stage 3)

## Why

Stages 1–2 of the subscription rework are merged: a per-chain **aggregation engine**
(`internal/upstreams/flow/subengine`) dedups node-backed subscriptions, and EVM `newHeads` is
synthesized locally from nodecore's merged-head stream.

This PR is **stage 3**: synthesize EVM `logs` locally too. Instead of opening
`eth_subscribe("logs")` on a node for every client, the chain watches new blocks, calls
`eth_getLogs {blockHash}` once per block, and fans the logs out to all `logs` subscribers — with
per-client address/topic filtering and reorg-aware `removed:true` re-emits. As with newHeads, routing
lives in the flow layer, so **HTTP and gRPC both benefit**. This mirrors dshackle's
`ConnectBlockUpdates` / `EthereumDirectReader`.

## What's in this PR

**Block-update tracking — `subengine/blockupdates.go` (new):**
- `blockTracker` turns the merged-head stream into ordered `NEW`/`DROP` `BlockUpdate`s via a bounded
  height-indexed history ring. Classification is **by hash per height**, not height alone, so a
  *benign rollback* (a faster upstream dropping out, leaving a lower head from a slower upstream on
  the same chain) is a no-op, while a head that disagrees on the hash at an already-announced height
  (or a forward successor whose parent ≠ our tip) is a **reorg** that drops the orphaned suffix
  `[reorgFrom..tip]`.
- `StreamBlockUpdates` is the thin pump over `ChainSupervisor.SubscribeState`.

**Logs source — `flow/logs_source.go` (new):**
- `newLogsSourceBuilder` builds the chain's single shared **all-logs** source: for each `NEW` block
  it issues one `eth_getLogs {blockHash}` (no address/topic filter), caches the result (FIFO ~32
  blocks), and emits every log as its own event; on a `DROP` it re-emits the cached logs with
  `removed:true`. It terminates (so clients fail over to the generic node-backed path) when the chain
  loses `LogsCap`.
- **Upstream selection is by block HEIGHT, not by the head producer** (dshackle `EthereumDirectReader`
  parity + robustness): a fresh `NewRatingStrategy(chain, "eth_getLogs", [NewHeightMatcher(height)])`
  per block picks any available, best-rated upstream at ≥ that height, with a bounded walk-down on
  error. The head producer may be gone by the time we fetch; height matching tolerates that. We
  already have the height from the head wrapper, so no blockHash→height cache is needed.

**Selection-only execution — `flow/request_processor.go`:**
- `selectAndSend` runs `strategy.SelectUpstream` + the existing `sendUnaryRequest` **without** the
  failsafe executor (no retry/hedge) — the lightweight one-shot path the logs source needs.

**Per-client filtering — `flow/log_filter.go` (new):**
- Exported `SubFilter` interface (`Matches([]byte) bool`) so any shared local source can supply
  per-client filtering; `logFilter` implements it (address set + positional topic matcher, EVM
  semantics). The shared source carries every log; each client drops the ones it didn't subscribe to.

**Routing + wiring:**
- `sub_aggregation.go` — `isLogsRequest`, `localLogsAvailable` (checks `LogsCap`), the per-chain
  `localLogsKey`, and `resolveSource` now returns a `SubFilter` and takes the rating registry. The
  local logs path is gated on `len(request.Selectors()) == 0` so a selector-pinned `logs` sub takes
  the generic node-backed path instead of being silently mis-routed.
- `sub_processor.go` / `execution_flow.go` — the `SubscriptionRequestProcessor` carries the rating
  registry and applies the per-client `SubFilter` in its event loop (newHeads/generic unchanged).
- `subengine/engine.go` — `Source` gains an optional `Buffer` field; the logs source requests a 4096
  per-subscriber fan-out buffer (a busy block can yield thousands of logs) while newHeads/generic keep
  the default 100.

(`protocol.LogsCap` already exists, is granted for a ws head connector exposing `eth_getLogs`, and is
already advertised as the `logs` topic by `processSubMethods` — no changes needed there.)

## Behavior

- **One node-side cost per chain**: a single `eth_getLogs` per block serves all `logs` subscribers,
  regardless of how many distinct address/topic filters they use.
- **Reorgs** re-emit the orphaned block's logs with `removed:true`, then the new block's logs.
- **No durable reconnect**: on `LogsCap` loss the source emits a terminal frame and clients resubscribe
  (they then fall back to the generic node-backed path).

### Accepted limitations (height-only merged head fork-choice)

`HeightForkChoice` only republishes when the max height changes, so:
- a same-height 1-block reorg with no height movement is invisible (it self-heals on the next height
  change via the parent/hash mismatch);
- forward gaps (height jumps) are not backfilled;
- reorg reconciliation is bounded by the history window (~18 blocks).
