### PR TITLE
fix(bounds): treat BSC 'metadata is not found' as no-data error

### DIFF
--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
@@ -364,6 +364,7 @@ var evmNoDataErrorHints = []string{
 	"no state available for block",
 	"missing trie node",
 	"header not found",
+	"metadata is not found",
 	"node state is pruned",
 	"is not available, lowest height is",
 	"state already discarded for",


### PR DESCRIPTION
BSC Geth returns '-32000: metadata is not found, <block>' when historical state data is unavailable (fast/full sync, not archive). Without this hint in evmNoDataErrorHints, the lower bound detector treats it as a real error instead of 'no data at this height', preventing state/proof bound detection.

Add 'metadata is not found' to evmNoDataErrorHints so the detector correctly skips pruned BSC blocks and finds the actual boundary.