### PR TITLE
fix(bounds): treat proof window distance error as no-data

### DIFF
--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
@@ -365,6 +365,7 @@ var evmNoDataErrorHints = []string{
 	"missing trie node",
 	"header not found",
 	"metadata is not found",
+	"distance to target block exceeds maximum proof window",
 	"node state is pruned",
 	"is not available, lowest height is",
 	"state already discarded for",


### PR DESCRIPTION
Add 'distance to target block exceeds maximum proof window' to evmNoDataErrorHints. This error is returned by EVM nodes when eth_getProof is called at a height outside the proof window (~1000 blocks from head). The detector should treat it as 'no data at this height' and continue binary search toward head, not as a fatal error.

Affected networks: lisk, superseed, tempo-mainnet, moderato, base.