### PR TITLE
Pending TX validator + cap processor

### DIFF
--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -374,8 +374,10 @@ const (
 	LogsCap
 	// PendingTxCap means the upstream has a live websocket connector usable for
 	// eth_subscribe("newPendingTransactions"), so pending-tx subscriptions can be
-	// aggregated locally. Set alongside WsCap; the topics are EVM-only but the cap
-	// is harmless elsewhere since only eth_subscribe clients request them.
+	// aggregated locally. Governed by the cap pipeline: a live ws connector is enough
+	// on most chains, but on chains with a pending-tx validator (e.g. BASE) it is also
+	// gated on txpool_content showing a non-trivial mempool. The topics are EVM-only
+	// but the cap is harmless elsewhere since only eth_subscribe clients request them.
 	PendingTxCap
 )
 

--- a/internal/protocol/upstream_state_events.go
+++ b/internal/protocol/upstream_state_events.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/samber/lo"
 )
 
@@ -128,46 +129,20 @@ func (u *UnbanMethodUpstreamStateEvent) ProcessEvent(state UpstreamState) Upstre
 	return state
 }
 
-type SubscribeUpstreamStateEvent struct {
-	State         SubscribeConnectorState
-	HeadConnector bool
+// CapsUpstreamStateEvent replaces the upstream's capability set wholesale. Caps are
+// produced by the per-chain cap pipeline (caps.CapProcessor aggregating CapDetectors),
+// which already merges every detector's view into one set, so the event carries the
+// full set rather than incremental add/remove.
+type CapsUpstreamStateEvent struct {
+	Caps mapset.Set[Cap]
 }
 
-func (s *SubscribeUpstreamStateEvent) Same(state UpstreamState) bool {
-	if s.HeadConnector {
-		return false
-	}
-	switch s.State {
-	case WsConnected:
-		return state.Caps.Contains(WsCap)
-	case WsDisconnected:
-		return !state.Caps.Contains(WsCap)
-	}
-	return false
+func (c *CapsUpstreamStateEvent) Same(state UpstreamState) bool {
+	return state.Caps != nil && c.Caps != nil && state.Caps.Equal(c.Caps)
 }
 
-func (s *SubscribeUpstreamStateEvent) ProcessEvent(state UpstreamState) UpstreamState {
-	copyCaps := state.Caps.Clone()
-	switch s.State {
-	case WsConnected:
-		copyCaps.Add(WsCap)
-		// A live ws connector is enough to aggregate pending-tx subscriptions
-		// (eth_subscribe("newPendingTransactions")) locally; unlike newHeads/logs
-		// it does not require the head connector to be ws-driven.
-		copyCaps.Add(PendingTxCap)
-		// A websocket head connector means the head is subscription-driven, so
-		// newHeads can be synthesized locally; logs additionally needs
-		// eth_getLogs. eth_subscribe presence implies an EVM chain.
-		if s.HeadConnector && state.UpstreamMethods != nil && state.UpstreamMethods.HasMethod("eth_subscribe") {
-			copyCaps.Add(NewHeadsCap)
-			if state.UpstreamMethods.HasMethod("eth_getLogs") {
-				copyCaps.Add(LogsCap)
-			}
-		}
-	case WsDisconnected:
-		copyCaps.Clear()
-	}
-	state.Caps = copyCaps
+func (c *CapsUpstreamStateEvent) ProcessEvent(state UpstreamState) UpstreamState {
+	state.Caps = c.Caps.Clone()
 	return state
 }
 
@@ -191,7 +166,7 @@ func (l *LabelsUpstreamStateEvent) ProcessEvent(state UpstreamState) UpstreamSta
 }
 
 var _ AbstractUpstreamStateEvent = (*LabelsUpstreamStateEvent)(nil)
-var _ AbstractUpstreamStateEvent = (*SubscribeUpstreamStateEvent)(nil)
+var _ AbstractUpstreamStateEvent = (*CapsUpstreamStateEvent)(nil)
 var _ AbstractUpstreamStateEvent = (*UnbanMethodUpstreamStateEvent)(nil)
 var _ AbstractUpstreamStateEvent = (*BanMethodUpstreamStateEvent)(nil)
 var _ AbstractUpstreamStateEvent = (*BlockUpstreamStateEvent)(nil)

--- a/internal/protocol/upstream_state_events_test.go
+++ b/internal/protocol/upstream_state_events_test.go
@@ -120,117 +120,56 @@ func TestUnbanMethodUpstreamStateEvent(t *testing.T) {
 	assert.Equal(t, state, event.ProcessEvent(state))
 }
 
-func TestSubscribeUpstreamStateEvent(t *testing.T) {
-	t.Run("ws connected adds capability", func(t *testing.T) {
-		state := newUpstreamState()
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected}
-
-		assert.False(t, event.Same(state))
-
-		nextState := event.ProcessEvent(state)
-
-		assert.False(t, state.Caps.Contains(protocol.WsCap))
-		assert.True(t, nextState.Caps.Contains(protocol.WsCap))
-		// a live ws connector also grants the pending-tx capability
-		assert.True(t, nextState.Caps.Contains(protocol.PendingTxCap))
-		assert.NotSame(t, state.Caps, nextState.Caps)
-		assert.True(t, event.Same(nextState))
-	})
-
-	t.Run("ws disconnected removes capability", func(t *testing.T) {
-		state := newUpstreamState()
-		state.Caps.Add(protocol.WsCap)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsDisconnected}
-
-		assert.False(t, event.Same(state))
-
-		nextState := event.ProcessEvent(state)
-
-		assert.True(t, state.Caps.Contains(protocol.WsCap))
-		assert.False(t, nextState.Caps.Contains(protocol.WsCap))
-		assert.NotSame(t, state.Caps, nextState.Caps)
-		assert.True(t, event.Same(nextState))
-	})
-
-	t.Run("unexpected state returns false in Same", func(t *testing.T) {
-		state := newUpstreamState()
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.SubscribeConnectorState(99)}
-
-		assert.False(t, event.Same(state))
-	})
-
-	t.Run("evm head connector ws connect adds newHeads and logs caps", func(t *testing.T) {
-		methodsMock := mocks.NewMethodsMock()
-		methodsMock.On("HasMethod", "eth_subscribe").Return(true)
-		methodsMock.On("HasMethod", "eth_getLogs").Return(true)
-		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
+func TestCapsUpstreamStateEvent(t *testing.T) {
+	t.Run("replaces the cap set wholesale", func(t *testing.T) {
+		state := protocol.DefaultUpstreamState(
+			mocks.NewMethodsMock(),
+			mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+			"u", nil, nil,
+		)
+		event := &protocol.CapsUpstreamStateEvent{
+			Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap),
+		}
 
 		next := event.ProcessEvent(state)
 
 		assert.True(t, next.Caps.Contains(protocol.WsCap))
 		assert.True(t, next.Caps.Contains(protocol.NewHeadsCap))
-		assert.True(t, next.Caps.Contains(protocol.LogsCap))
+		// PendingTxCap was in the old set but not the new one -> dropped.
+		assert.False(t, next.Caps.Contains(protocol.PendingTxCap))
+		// the event carries a clone, mutating it must not touch upstream state
+		assert.NotSame(t, event.Caps, next.Caps)
 	})
 
-	t.Run("evm head connector ws connect without eth_getLogs has no logs cap", func(t *testing.T) {
-		methodsMock := mocks.NewMethodsMock()
-		methodsMock.On("HasMethod", "eth_subscribe").Return(true)
-		methodsMock.On("HasMethod", "eth_getLogs").Return(false)
-		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
-
-		next := event.ProcessEvent(state)
-
-		assert.True(t, next.Caps.Contains(protocol.NewHeadsCap))
-		assert.False(t, next.Caps.Contains(protocol.LogsCap))
-	})
-
-	// A ws connector used only for requests (head connector is e.g. json-rpc)
-	// must not grant local-sub caps - otherwise newHeads routes to local
-	// synthesis with a polled head and emits nothing.
-	t.Run("non-head ws connect grants only WsCap", func(t *testing.T) {
-		methodsMock := mocks.NewMethodsMock()
-		methodsMock.On("HasMethod", "eth_subscribe").Return(true).Maybe()
-		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: false}
-
-		next := event.ProcessEvent(state)
-
-		assert.True(t, next.Caps.Contains(protocol.WsCap))
-		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
-		assert.False(t, next.Caps.Contains(protocol.LogsCap))
-		// pending-tx aggregation only needs a ws connector, not a ws-driven head
-		assert.True(t, next.Caps.Contains(protocol.PendingTxCap))
-	})
-
-	t.Run("non-evm head connector ws connect grants only WsCap", func(t *testing.T) {
-		methodsMock := mocks.NewMethodsMock()
-		methodsMock.On("HasMethod", "eth_subscribe").Return(false)
-		state := protocol.DefaultUpstreamState(methodsMock, mapset.NewThreadUnsafeSet[protocol.Cap](), "u", nil, nil)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected, HeadConnector: true}
-
-		next := event.ProcessEvent(state)
-
-		assert.True(t, next.Caps.Contains(protocol.WsCap))
-		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
-		assert.False(t, next.Caps.Contains(protocol.LogsCap))
-	})
-
-	t.Run("ws disconnect removes all sub caps", func(t *testing.T) {
+	t.Run("empty caps clears everything", func(t *testing.T) {
 		state := protocol.DefaultUpstreamState(
 			mocks.NewMethodsMock(),
 			mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.NewHeadsCap, protocol.LogsCap, protocol.PendingTxCap),
 			"u", nil, nil,
 		)
-		event := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsDisconnected}
+		event := &protocol.CapsUpstreamStateEvent{Caps: mapset.NewThreadUnsafeSet[protocol.Cap]()}
 
 		next := event.ProcessEvent(state)
 
-		assert.False(t, next.Caps.Contains(protocol.WsCap))
-		assert.False(t, next.Caps.Contains(protocol.NewHeadsCap))
-		assert.False(t, next.Caps.Contains(protocol.LogsCap))
-		assert.False(t, next.Caps.Contains(protocol.PendingTxCap))
+		assert.Equal(t, 0, next.Caps.Cardinality())
+	})
+
+	t.Run("Same is true only for an equal set", func(t *testing.T) {
+		state := protocol.DefaultUpstreamState(
+			mocks.NewMethodsMock(),
+			mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+			"u", nil, nil,
+		)
+
+		same := &protocol.CapsUpstreamStateEvent{
+			Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+		}
+		different := &protocol.CapsUpstreamStateEvent{
+			Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap),
+		}
+
+		assert.True(t, same.Same(state))
+		assert.False(t, different.Same(state))
 	})
 }
 

--- a/internal/server/emerald/grpc_auth.go
+++ b/internal/server/emerald/grpc_auth.go
@@ -34,6 +34,7 @@ const (
 type grpcSessionStore struct {
 	ttl      time.Duration
 	sessions *utils.CMap[string, time.Time]
+	now      func() time.Time
 }
 
 func newGrpcSessionStore(ttl time.Duration) *grpcSessionStore {
@@ -43,6 +44,7 @@ func newGrpcSessionStore(ttl time.Duration) *grpcSessionStore {
 	return &grpcSessionStore{
 		ttl:      ttl,
 		sessions: utils.NewCMap[string, time.Time](),
+		now:      time.Now,
 	}
 }
 
@@ -50,14 +52,14 @@ func (s *grpcSessionStore) Put(sessionID string) {
 	if sessionID == "" {
 		return
 	}
-	s.sessions.Store(sessionID, time.Now().Add(s.ttl))
+	s.sessions.Store(sessionID, s.now().Add(s.ttl))
 }
 
 func (s *grpcSessionStore) Exists(sessionID string) bool {
 	if sessionID == "" {
 		return false
 	}
-	now := time.Now()
+	now := s.now()
 
 	expireAt, ok := s.sessions.Load(sessionID)
 	if !ok {

--- a/internal/server/emerald/grpc_auth_test.go
+++ b/internal/server/emerald/grpc_auth_test.go
@@ -121,15 +121,18 @@ func TestGrpcAuthServiceAuthenticateNilRequest(t *testing.T) {
 }
 
 func TestGrpcSessionStoreTTL(t *testing.T) {
+	now := time.Unix(0, 0)
 	store := newGrpcSessionStore(40 * time.Millisecond)
+	store.now = func() time.Time { return now }
+
 	store.Put("session-1")
 
 	assert.True(t, store.Exists("session-1"))
-	time.Sleep(30 * time.Millisecond)
+	now = now.Add(30 * time.Millisecond)
 	assert.True(t, store.Exists("session-1")) // extends ttl on access
-	time.Sleep(30 * time.Millisecond)
+	now = now.Add(30 * time.Millisecond)
 	assert.True(t, store.Exists("session-1"))
-	time.Sleep(60 * time.Millisecond)
+	now = now.Add(60 * time.Millisecond)
 	assert.False(t, store.Exists("session-1"))
 }
 

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -459,7 +459,7 @@ func mapToEthSubscribeFallback(requestedMethod string, payload []byte) (string, 
 }
 
 func mapEthSubscribeParams(requestedMethod string, payload []byte) ([]byte, error) {
-	methodRaw, _ := json.Marshal(requestedMethod)
+	methodRaw, _ := sonic.Marshal(requestedMethod)
 	params := []json.RawMessage{methodRaw}
 
 	// dproxy NativeSubscribe sends Method as the concrete subscription type and
@@ -473,7 +473,7 @@ func mapEthSubscribeParams(requestedMethod string, payload []byte) ([]byte, erro
 		params = append(params, append(json.RawMessage(nil), payload...))
 	}
 
-	result, err := json.Marshal(params)
+	result, err := sonic.Marshal(params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/upstreams/caps/cap_processor.go
+++ b/internal/upstreams/caps/cap_processor.go
@@ -1,0 +1,131 @@
+package caps
+
+import (
+	"context"
+	"fmt"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/rs/zerolog/log"
+)
+
+// CapProcessor aggregates a chain's CapDetectors into a single stream of the
+// upstream's merged capability set, mirroring how LowerBoundProcessor aggregates
+// LowerBoundDetectors.
+type CapProcessor interface {
+	utils.Lifecycle
+	Subscribe(name string) *utils.Subscription[mapset.Set[protocol.Cap]]
+}
+
+type capUpdate struct {
+	index int
+	caps  mapset.Set[protocol.Cap]
+}
+
+type BaseCapProcessor struct {
+	upstreamId string
+
+	lifecycle  *utils.BaseLifecycle
+	subManager *utils.SubscriptionManager[mapset.Set[protocol.Cap]]
+
+	detectors []CapDetector
+}
+
+func NewBaseCapProcessor(ctx context.Context, upstreamId string, detectors []CapDetector) *BaseCapProcessor {
+	if len(detectors) == 0 {
+		return nil
+	}
+
+	name := fmt.Sprintf("%s_cap_service", upstreamId)
+	return &BaseCapProcessor{
+		upstreamId: upstreamId,
+		lifecycle:  utils.NewBaseLifecycle(name, ctx),
+		subManager: utils.NewSubscriptionManager[mapset.Set[protocol.Cap]](name),
+		detectors:  detectors,
+	}
+}
+
+func (b *BaseCapProcessor) Start() {
+	b.lifecycle.Start(func(ctx context.Context) error {
+		updates := make(chan capUpdate, 100)
+		for i, detector := range b.detectors {
+			go b.consume(ctx, i, detector, updates)
+		}
+		go b.aggregate(ctx, updates)
+		return nil
+	})
+}
+
+func (b *BaseCapProcessor) Stop() {
+	b.lifecycle.Stop()
+}
+
+func (b *BaseCapProcessor) Running() bool {
+	return b.lifecycle.Running()
+}
+
+func (b *BaseCapProcessor) Subscribe(name string) *utils.Subscription[mapset.Set[protocol.Cap]] {
+	return b.subManager.Subscribe(name)
+}
+
+// consume forwards one detector's snapshots onto the shared updates channel, tagged
+// with the detector index so the aggregator can replace just that detector's slice
+// of the merged set.
+func (b *BaseCapProcessor) consume(ctx context.Context, index int, detector CapDetector, updates chan<- capUpdate) {
+	capsChan := detector.DetectCaps(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case caps, ok := <-capsChan:
+			if !ok {
+				return
+			}
+			select {
+			case updates <- capUpdate{index: index, caps: caps}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// aggregate keeps the latest snapshot per detector, unions them on every update, and
+// publishes the merged set only when it changes.
+func (b *BaseCapProcessor) aggregate(ctx context.Context, updates <-chan capUpdate) {
+	latest := make([]mapset.Set[protocol.Cap], len(b.detectors))
+	for i := range latest {
+		latest[i] = mapset.NewThreadUnsafeSet[protocol.Cap]()
+	}
+	var published mapset.Set[protocol.Cap]
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case update, ok := <-updates:
+			if !ok {
+				return
+			}
+			if update.caps != nil {
+				latest[update.index] = update.caps
+			} else {
+				latest[update.index] = mapset.NewThreadUnsafeSet[protocol.Cap]()
+			}
+
+			merged := mapset.NewThreadUnsafeSet[protocol.Cap]()
+			for _, s := range latest {
+				merged = merged.Union(s)
+			}
+
+			if published == nil || !published.Equal(merged) {
+				published = merged
+				log.Debug().Msgf("upstream '%s' caps changed to %v", b.upstreamId, merged.ToSlice())
+				b.subManager.Publish(merged.Clone())
+			}
+		}
+	}
+}
+
+var _ CapProcessor = (*BaseCapProcessor)(nil)

--- a/internal/upstreams/caps/caps_test.go
+++ b/internal/upstreams/caps/caps_test.go
@@ -1,0 +1,128 @@
+package caps_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func capSet(c ...protocol.Cap) mapset.Set[protocol.Cap] {
+	return mapset.NewThreadUnsafeSet[protocol.Cap](c...)
+}
+
+// stateFeed wires a ConnectorMock so SubscribeStates returns a subscription the test
+// can publish into.
+func stateFeed(name string) (*mocks.ConnectorMock, *utils.SubscriptionManager[protocol.SubscribeConnectorState]) {
+	mgr := utils.NewSubscriptionManager[protocol.SubscribeConnectorState]("test_states")
+	sub := mgr.Subscribe(name)
+	conn := mocks.NewConnectorMock()
+	conn.On("SubscribeStates", name).Return(sub)
+	return conn, mgr
+}
+
+func TestWsPresenceCapDetector(t *testing.T) {
+	t.Run("asserts the cap on connect and retracts on disconnect", func(t *testing.T) {
+		conn, mgr := stateFeed("ws")
+		detector := caps.NewWsPresenceCapDetector("ws", protocol.WsCap, conn)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.True(t, (<-out).Contains(protocol.WsCap))
+
+		mgr.Publish(protocol.WsDisconnected)
+		assert.False(t, (<-out).Contains(protocol.WsCap))
+	})
+
+	t.Run("nil connector never asserts the cap", func(t *testing.T) {
+		detector := caps.NewWsPresenceCapDetector("ws", protocol.WsCap, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		_, ok := <-out
+		assert.False(t, ok, "expected a closed channel for an upstream without a ws connector")
+	})
+
+	t.Run("connector without a state stream never asserts the cap", func(t *testing.T) {
+		conn := mocks.NewConnectorMock()
+		conn.On("SubscribeStates", "ws").Return(nil)
+		detector := caps.NewWsPresenceCapDetector("ws", protocol.WsCap, conn)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		_, ok := <-out
+		assert.False(t, ok)
+	})
+}
+
+// scriptedDetector is a CapDetector whose snapshots the test pushes by hand.
+type scriptedDetector struct {
+	domain []protocol.Cap
+	ch     chan mapset.Set[protocol.Cap]
+}
+
+func (s *scriptedDetector) Domain() []protocol.Cap { return s.domain }
+func (s *scriptedDetector) DetectCaps(_ context.Context) <-chan mapset.Set[protocol.Cap] {
+	return s.ch
+}
+
+func TestBaseCapProcessor(t *testing.T) {
+	t.Run("nil when there are no detectors", func(t *testing.T) {
+		assert.Nil(t, caps.NewBaseCapProcessor(context.Background(), "u", nil))
+	})
+
+	t.Run("merges disjoint detectors and publishes on change only", func(t *testing.T) {
+		ws := &scriptedDetector{domain: []protocol.Cap{protocol.WsCap}, ch: make(chan mapset.Set[protocol.Cap], 1)}
+		pt := &scriptedDetector{domain: []protocol.Cap{protocol.PendingTxCap}, ch: make(chan mapset.Set[protocol.Cap], 1)}
+
+		proc := caps.NewBaseCapProcessor(context.Background(), "u", []caps.CapDetector{ws, pt})
+		require.NotNil(t, proc)
+
+		sub := proc.Subscribe("s")
+		proc.Start()
+		defer proc.Stop()
+
+		ws.ch <- capSet(protocol.WsCap)
+		got := <-sub.Events
+		assert.True(t, got.Contains(protocol.WsCap))
+		assert.False(t, got.Contains(protocol.PendingTxCap))
+
+		pt.ch <- capSet(protocol.PendingTxCap)
+		got = <-sub.Events
+		assert.True(t, got.Contains(protocol.WsCap))
+		assert.True(t, got.Contains(protocol.PendingTxCap))
+
+		// An identical snapshot must not produce a new merged event.
+		pt.ch <- capSet(protocol.PendingTxCap)
+		assertNoEvent(t, sub)
+
+		// Dropping ws retracts only WsCap; PendingTxCap survives.
+		ws.ch <- capSet()
+		got = <-sub.Events
+		assert.False(t, got.Contains(protocol.WsCap))
+		assert.True(t, got.Contains(protocol.PendingTxCap))
+	})
+}
+
+func assertNoEvent(t *testing.T, sub *utils.Subscription[mapset.Set[protocol.Cap]]) {
+	t.Helper()
+	select {
+	case got := <-sub.Events:
+		t.Fatalf("expected no new cap event, got %v", got.ToSlice())
+	case <-time.After(150 * time.Millisecond):
+	}
+}

--- a/internal/upstreams/caps/detector.go
+++ b/internal/upstreams/caps/detector.go
@@ -1,0 +1,46 @@
+package caps
+
+import (
+	"context"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/methods"
+	"github.com/drpcorg/nodecore/pkg/utils"
+)
+
+// CapDetector streams the set of capabilities it currently asserts. Unlike the
+// poll-only LowerBoundDetector, a cap detector owns its own cadence: it may be
+// push-driven (watching a connector's state stream) or poll-driven (a ticker), and
+// re-emits a fresh snapshot - restricted to Domain() - whenever its inputs change.
+// The channel is closed when ctx is done.
+type CapDetector interface {
+	DetectCaps(ctx context.Context) <-chan mapset.Set[protocol.Cap]
+	// Domain is the set of caps this detector governs. The processor attributes only
+	// these caps to the detector when merging, so detectors with disjoint domains
+	// compose into the upstream's full cap set.
+	Domain() []protocol.Cap
+}
+
+// DetectorInput bundles everything a chain needs to build its cap detectors. It is
+// assembled at the upstream level (where the connector set and methods are known)
+// and handed to ChainSpecific.CapDetectors.
+type DetectorInput struct {
+	// WsConnector is the upstream's websocket connector, or nil if it has none.
+	WsConnector connectors.ApiConnector
+	// HeadConnector is the connector driving the head; for ws-derived caps like
+	// NewHeads it must be a websocket connector.
+	HeadConnector connectors.ApiConnector
+	Methods       methods.Methods
+}
+
+// subscribeStates returns the connector's state stream, or nil when the connector is
+// absent or doesn't expose states (e.g. an http connector). Detectors treat a nil
+// result as "this cap can never be asserted".
+func subscribeStates(conn connectors.ApiConnector, name string) *utils.Subscription[protocol.SubscribeConnectorState] {
+	if conn == nil {
+		return nil
+	}
+	return conn.SubscribeStates(name)
+}

--- a/internal/upstreams/caps/evm_caps/evm_caps_test.go
+++ b/internal/upstreams/caps/evm_caps/evm_caps_test.go
@@ -1,0 +1,202 @@
+package evm_caps_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps/evm_caps"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// stateFeed wires a ConnectorMock so SubscribeStates returns a subscription the test
+// can publish into.
+func stateFeed(name string) (*mocks.ConnectorMock, *utils.SubscriptionManager[protocol.SubscribeConnectorState]) {
+	mgr := utils.NewSubscriptionManager[protocol.SubscribeConnectorState]("test_states")
+	sub := mgr.Subscribe(name)
+	conn := mocks.NewConnectorMock()
+	conn.On("SubscribeStates", name).Return(sub)
+	return conn, mgr
+}
+
+// txpoolResult builds a txpool_content result with `pending` sender entries under
+// "pending" and `queued` under "queued".
+func txpoolResult(pending, queued int) []byte {
+	var b strings.Builder
+	b.WriteString(`{"pending":{`)
+	writeAddrs(&b, 0, pending)
+	b.WriteString(`},"queued":{`)
+	writeAddrs(&b, 1_000_000, queued)
+	b.WriteString(`}}`)
+	return []byte(b.String())
+}
+
+func writeAddrs(b *strings.Builder, offset, n int) {
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(b, `"0x%040x":{}`, offset+i)
+	}
+}
+
+func TestEvmPendingTxCapDetector(t *testing.T) {
+	t.Run("asserts PendingTxCap when txpool is at the limit and ws is up", func(t *testing.T) {
+		wsConn, mgr := stateFeed("pt")
+		internalConn := mocks.NewConnectorMock()
+		internalConn.On("SendRequest", mock.Anything, mock.Anything).
+			Return(protocol.NewSimpleHttpUpstreamResponse("1", txpoolResult(600, 400), protocol.JsonRpc))
+
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", wsConn, internalConn, chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.True(t, (<-out).Contains(protocol.PendingTxCap))
+	})
+
+	t.Run("does not assert when txpool is below the limit", func(t *testing.T) {
+		wsConn, mgr := stateFeed("pt")
+		internalConn := mocks.NewConnectorMock()
+		internalConn.On("SendRequest", mock.Anything, mock.Anything).
+			Return(protocol.NewSimpleHttpUpstreamResponse("1", txpoolResult(500, 499), protocol.JsonRpc))
+
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", wsConn, internalConn, chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.False(t, (<-out).Contains(protocol.PendingTxCap))
+	})
+
+	t.Run("missing pending/queued keys count as zero", func(t *testing.T) {
+		wsConn, mgr := stateFeed("pt")
+		internalConn := mocks.NewConnectorMock()
+		internalConn.On("SendRequest", mock.Anything, mock.Anything).
+			Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(`{}`), protocol.JsonRpc))
+
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", wsConn, internalConn, chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.False(t, (<-out).Contains(protocol.PendingTxCap))
+	})
+
+	t.Run("rpc error keeps the cap off", func(t *testing.T) {
+		wsConn, mgr := stateFeed("pt")
+		internalConn := mocks.NewConnectorMock()
+		internalConn.On("SendRequest", mock.Anything, mock.Anything).
+			Return(protocol.NewHttpUpstreamResponseWithError(protocol.ServerError()))
+
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", wsConn, internalConn, chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.False(t, (<-out).Contains(protocol.PendingTxCap))
+	})
+
+	t.Run("drops the cap on disconnect even with a full mempool", func(t *testing.T) {
+		wsConn, mgr := stateFeed("pt")
+		internalConn := mocks.NewConnectorMock()
+		internalConn.On("SendRequest", mock.Anything, mock.Anything).
+			Return(protocol.NewSimpleHttpUpstreamResponse("1", txpoolResult(1000, 0), protocol.JsonRpc))
+
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", wsConn, internalConn, chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		assert.True(t, (<-out).Contains(protocol.PendingTxCap))
+
+		mgr.Publish(protocol.WsDisconnected)
+		assert.False(t, (<-out).Contains(protocol.PendingTxCap))
+	})
+
+	t.Run("no ws connector never asserts the cap", func(t *testing.T) {
+		detector := evm_caps.NewEvmPendingTxCapDetector("pt", nil, mocks.NewConnectorMock(), chains.BASE, time.Second, evm_caps.BaseTxLimit)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		_, ok := <-out
+		assert.False(t, ok)
+	})
+}
+
+func TestEvmHeadSubCapDetector(t *testing.T) {
+	t.Run("ws head with eth_subscribe and eth_getLogs asserts NewHeads and Logs", func(t *testing.T) {
+		headConn, mgr := stateFeed("head")
+		methods := mocks.NewMethodsMock()
+		methods.On("HasMethod", "eth_subscribe").Return(true)
+		methods.On("HasMethod", "eth_getLogs").Return(true)
+
+		detector := evm_caps.NewEvmHeadSubCapDetector("head", headConn, methods)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		got := <-out
+		assert.True(t, got.Contains(protocol.NewHeadsCap))
+		assert.True(t, got.Contains(protocol.LogsCap))
+	})
+
+	t.Run("ws head without eth_getLogs asserts only NewHeads", func(t *testing.T) {
+		headConn, mgr := stateFeed("head")
+		methods := mocks.NewMethodsMock()
+		methods.On("HasMethod", "eth_subscribe").Return(true)
+		methods.On("HasMethod", "eth_getLogs").Return(false)
+
+		detector := evm_caps.NewEvmHeadSubCapDetector("head", headConn, methods)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		got := <-out
+		assert.True(t, got.Contains(protocol.NewHeadsCap))
+		assert.False(t, got.Contains(protocol.LogsCap))
+	})
+
+	t.Run("without eth_subscribe asserts nothing", func(t *testing.T) {
+		headConn, mgr := stateFeed("head")
+		methods := mocks.NewMethodsMock()
+		methods.On("HasMethod", "eth_subscribe").Return(false)
+
+		detector := evm_caps.NewEvmHeadSubCapDetector("head", headConn, methods)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		mgr.Publish(protocol.WsConnected)
+		got := <-out
+		assert.Equal(t, 0, got.Cardinality())
+	})
+
+	t.Run("non-ws head connector asserts nothing", func(t *testing.T) {
+		headConn := mocks.NewConnectorMock()
+		headConn.On("SubscribeStates", "head").Return(nil)
+
+		detector := evm_caps.NewEvmHeadSubCapDetector("head", headConn, mocks.NewMethodsMock())
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		_, ok := <-out
+		assert.False(t, ok)
+	})
+}

--- a/internal/upstreams/caps/evm_caps/evm_head_sub_detector.go
+++ b/internal/upstreams/caps/evm_caps/evm_head_sub_detector.go
@@ -1,0 +1,77 @@
+package evm_caps
+
+import (
+	"context"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/methods"
+	"github.com/drpcorg/nodecore/pkg/utils"
+)
+
+// EvmHeadSubCapDetector asserts NewHeadsCap (and LogsCap) while the head connector is
+// a live websocket and the upstream supports the required subscription methods. A ws
+// head connector means the head is subscription-driven, so newHeads can be
+// synthesized locally; logs additionally needs eth_getLogs. If the head connector is
+// not a websocket (SubscribeStates returns nil) the caps are never asserted. Mirrors
+// the head-connector branch of the old SubscribeUpstreamStateEvent.
+type EvmHeadSubCapDetector struct {
+	name     string
+	headConn connectors.ApiConnector
+	methods  methods.Methods
+}
+
+func NewEvmHeadSubCapDetector(name string, headConn connectors.ApiConnector, methods methods.Methods) *EvmHeadSubCapDetector {
+	return &EvmHeadSubCapDetector{name: name, headConn: headConn, methods: methods}
+}
+
+func (e *EvmHeadSubCapDetector) Domain() []protocol.Cap {
+	return []protocol.Cap{protocol.NewHeadsCap, protocol.LogsCap}
+}
+
+func (e *EvmHeadSubCapDetector) DetectCaps(ctx context.Context) <-chan mapset.Set[protocol.Cap] {
+	out := make(chan mapset.Set[protocol.Cap], 1)
+
+	var stateSub *utils.Subscription[protocol.SubscribeConnectorState]
+	if e.headConn != nil {
+		stateSub = e.headConn.SubscribeStates(e.name)
+	}
+	if stateSub == nil {
+		close(out)
+		return out
+	}
+
+	go func() {
+		defer close(out)
+		defer stateSub.Unsubscribe()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case state, ok := <-stateSub.Events:
+				if !ok {
+					return
+				}
+				select {
+				case out <- e.capsFor(state):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+func (e *EvmHeadSubCapDetector) capsFor(state protocol.SubscribeConnectorState) mapset.Set[protocol.Cap] {
+	caps := mapset.NewThreadUnsafeSet[protocol.Cap]()
+	if state == protocol.WsConnected && e.methods != nil && e.methods.HasMethod("eth_subscribe") {
+		caps.Add(protocol.NewHeadsCap)
+		if e.methods.HasMethod("eth_getLogs") {
+			caps.Add(protocol.LogsCap)
+		}
+	}
+	return caps
+}

--- a/internal/upstreams/caps/evm_caps/evm_pending_tx_detector.go
+++ b/internal/upstreams/caps/evm_caps/evm_pending_tx_detector.go
@@ -1,0 +1,169 @@
+package evm_caps
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/bytedance/sonic"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// BaseTxLimit is the combined pending+queued tx count at or above which a node's
+	// mempool is considered usable for pending-tx subscriptions. Mirrors dshackle's
+	// BASE_TX_LIMIT.
+	BaseTxLimit = 1000
+	// pendingTxValidationInterval is how often txpool_content is polled while the ws
+	// connector is up. Mempool size changes slowly relative to this; dshackle polls
+	// on a similar minutes-scale cadence.
+	pendingTxValidationInterval = 5 * time.Minute
+)
+
+// EvmPendingTxCapDetector asserts PendingTxCap only while the websocket connector is
+// connected AND the node's txpool_content reports at least BaseTxLimit combined
+// pending+queued transactions. It is built only for chains that actually need the
+// check (BASE mainnet); other chains use the generic ws-presence detector. Mirrors
+// dshackle's PendingTransactionValidatorImpl.
+type EvmPendingTxCapDetector struct {
+	name            string
+	wsConn          connectors.ApiConnector
+	internalConn    connectors.ApiConnector
+	chain           chains.Chain
+	internalTimeout time.Duration
+	// txLimit is the combined pending+queued tx count at or above which the mempool
+	// is considered usable. Passed in per chain so different chains can use different
+	// thresholds.
+	txLimit int
+}
+
+func NewEvmPendingTxCapDetector(
+	name string,
+	wsConn connectors.ApiConnector,
+	internalConn connectors.ApiConnector,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+	txLimit int,
+) *EvmPendingTxCapDetector {
+	return &EvmPendingTxCapDetector{
+		name:            name,
+		wsConn:          wsConn,
+		internalConn:    internalConn,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+		txLimit:         txLimit,
+	}
+}
+
+func (e *EvmPendingTxCapDetector) Domain() []protocol.Cap {
+	return []protocol.Cap{protocol.PendingTxCap}
+}
+
+func (e *EvmPendingTxCapDetector) DetectCaps(ctx context.Context) <-chan mapset.Set[protocol.Cap] {
+	out := make(chan mapset.Set[protocol.Cap], 1)
+
+	var stateSub *utils.Subscription[protocol.SubscribeConnectorState]
+	if e.wsConn != nil {
+		stateSub = e.wsConn.SubscribeStates(e.name)
+	}
+	if stateSub == nil {
+		close(out)
+		return out
+	}
+
+	go func() {
+		defer close(out)
+		defer stateSub.Unsubscribe()
+
+		ticker := time.NewTicker(pendingTxValidationInterval)
+		defer ticker.Stop()
+
+		wsConnected := false
+		txpoolFull := false
+		var emitted mapset.Set[protocol.Cap]
+
+		emit := func() {
+			caps := mapset.NewThreadUnsafeSet[protocol.Cap]()
+			if wsConnected && txpoolFull {
+				caps.Add(protocol.PendingTxCap)
+			}
+			if emitted != nil && emitted.Equal(caps) {
+				return
+			}
+			emitted = caps
+			select {
+			case out <- caps:
+			case <-ctx.Done():
+			}
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case state, ok := <-stateSub.Events:
+				if !ok {
+					return
+				}
+				wsConnected = state == protocol.WsConnected
+				// Poll immediately on connect so the cap appears without waiting a full
+				// interval; drop it at once on disconnect.
+				if wsConnected {
+					txpoolFull = e.txpoolAboveLimit(ctx)
+				} else {
+					txpoolFull = false
+				}
+				emit()
+			case <-ticker.C:
+				if wsConnected {
+					txpoolFull = e.txpoolAboveLimit(ctx)
+					emit()
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+// txpoolAboveLimit reports whether txpool_content shows at least txLimit combined
+// pending+queued transactions. Any error (method unsupported, timeout, malformed
+// response) is treated as below the limit, matching dshackle's onErrorResume(false).
+func (e *EvmPendingTxCapDetector) txpoolAboveLimit(ctx context.Context) bool {
+	if e.internalConn == nil {
+		return false
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, e.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("txpool_content", nil, e.chain)
+	if err != nil {
+		return false
+	}
+
+	response := e.internalConn.SendRequest(reqCtx, request)
+	if response.HasError() {
+		log.Error().Err(response.GetError()).Msgf("unable to read txpool_content of upstream cap detector '%s'", e.name)
+		return false
+	}
+
+	// pending/queued are maps keyed by sender address; their sizes are the per-sender
+	// tx-group counts. Decoding the values as raw messages skips parsing each tx,
+	// matching dshackle counting fieldNames() of each node.
+	var content struct {
+		Pending map[string]json.RawMessage `json:"pending"`
+		Queued  map[string]json.RawMessage `json:"queued"`
+	}
+	if err := sonic.Unmarshal(response.ResponseResult(), &content); err != nil {
+		log.Error().Err(err).Msgf("unable to parse txpool_content of upstream cap detector '%s'", e.name)
+		return false
+	}
+
+	return len(content.Pending)+len(content.Queued) >= e.txLimit
+}

--- a/internal/upstreams/caps/ws_presence_detector.go
+++ b/internal/upstreams/caps/ws_presence_detector.go
@@ -1,0 +1,76 @@
+package caps
+
+import (
+	"context"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+)
+
+// WsPresenceCapDetector asserts a single cap while the given websocket connector
+// reports a live connection, and retracts it on disconnect. It is the building block
+// for WsCap on every chain, and for PendingTxCap on chains that don't gate it behind
+// a deeper check (matching the previous "a live ws connector implies the cap"
+// behavior).
+type WsPresenceCapDetector struct {
+	name   string
+	cap    protocol.Cap
+	wsConn connectors.ApiConnector
+}
+
+func NewWsPresenceCapDetector(name string, cap protocol.Cap, wsConn connectors.ApiConnector) *WsPresenceCapDetector {
+	return &WsPresenceCapDetector{name: name, cap: cap, wsConn: wsConn}
+}
+
+// DefaultCapDetectors returns the cap detectors for chains whose only ws-derived
+// capability is WsCap - every non-EVM chain. PendingTxCap is intentionally not set
+// here: it is an EVM-only capability (eth_subscribe("newPendingTransactions")) that
+// these chains cannot serve. EVM chains compose their own list, which adds the
+// pending-tx and head-subscription detectors.
+func DefaultCapDetectors(upstreamId string, wsConn connectors.ApiConnector) []CapDetector {
+	return []CapDetector{
+		NewWsPresenceCapDetector(upstreamId+"_ws_cap", protocol.WsCap, wsConn),
+	}
+}
+
+func (w *WsPresenceCapDetector) Domain() []protocol.Cap {
+	return []protocol.Cap{w.cap}
+}
+
+func (w *WsPresenceCapDetector) DetectCaps(ctx context.Context) <-chan mapset.Set[protocol.Cap] {
+	out := make(chan mapset.Set[protocol.Cap], 1)
+
+	var stateSub = subscribeStates(w.wsConn, w.name)
+	if stateSub == nil {
+		// No ws connector (http-only upstream): the cap can never be asserted.
+		close(out)
+		return out
+	}
+
+	go func() {
+		defer close(out)
+		defer stateSub.Unsubscribe()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case state, ok := <-stateSub.Events:
+				if !ok {
+					return
+				}
+				caps := mapset.NewThreadUnsafeSet[protocol.Cap]()
+				if state == protocol.WsConnected {
+					caps.Add(w.cap)
+				}
+				select {
+				case out <- caps:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return out
+}

--- a/internal/upstreams/chains_specific/algorand_specific/algorand_chain_specific.go
+++ b/internal/upstreams/chains_specific/algorand_specific/algorand_chain_specific.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -64,6 +65,10 @@ func (a *AlgorandChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 		),
 	}
 	return labels.NewBaseLabelsProcessor(a.ctx, a.upstreamId, labelsDetectors, a.labelsDelay)
+}
+
+func (a *AlgorandChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	return caps.DefaultCapDetectors(a.upstreamId, input.WsConnector)
 }
 
 func (a *AlgorandChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {

--- a/internal/upstreams/chains_specific/aztec_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_specific/aztec_chain_specific.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -67,6 +68,10 @@ func (a *AztecChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 		),
 	}
 	return labels.NewBaseLabelsProcessor(a.ctx, a.upstreamId, labelsDetectors, a.labelsDelay)
+}
+
+func (a *AztecChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	return caps.DefaultCapDetectors(a.upstreamId, input.WsConnector)
 }
 
 func (a *AztecChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {

--- a/internal/upstreams/chains_specific/chain_specific.go
+++ b/internal/upstreams/chains_specific/chain_specific.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
 	"github.com/drpcorg/nodecore/internal/upstreams/validations"
@@ -21,6 +22,11 @@ type ChainSpecific interface {
 
 	HealthValidators() []validations.Validator[protocol.AvailabilityStatus]
 	SettingsValidators() []validations.Validator[validations.ValidationSettingResult]
+
+	// CapDetectors returns the chain's capability detectors, given the connectors and
+	// methods discovered at the upstream level. The detectors are aggregated by a
+	// caps.CapProcessor into the upstream's live capability set.
+	CapDetectors(input caps.DetectorInput) []caps.CapDetector
 
 	LowerBoundProcessor() lower_bounds.LowerBoundProcessor
 	LabelsProcessor() labels.LabelsProcessor

--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps/evm_caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -125,6 +127,29 @@ func (e *EvmChainSpecificObject) SettingsValidators() []validations.Validator[va
 	}
 
 	return settingsValidators
+}
+
+func (e *EvmChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	detectors := []caps.CapDetector{
+		caps.NewWsPresenceCapDetector(fmt.Sprintf("%s_ws_cap", e.upstreamId), protocol.WsCap, input.WsConnector),
+		evm_caps.NewEvmHeadSubCapDetector(fmt.Sprintf("%s_head_sub_cap", e.upstreamId), input.HeadConnector, input.Methods),
+	}
+
+	pendingTxName := fmt.Sprintf("%s_pending_tx_cap", e.upstreamId)
+	if e.chain.Chain == chains.BASE {
+		detectors = append(detectors, evm_caps.NewEvmPendingTxCapDetector(
+			pendingTxName,
+			input.WsConnector,
+			e.connector,
+			e.chain.Chain,
+			e.options.InternalTimeout,
+			evm_caps.BaseTxLimit,
+		))
+	} else {
+		detectors = append(detectors, caps.NewWsPresenceCapDetector(pendingTxName, protocol.PendingTxCap, input.WsConnector))
+	}
+
+	return detectors
 }
 
 func (e *EvmChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {

--- a/internal/upstreams/chains_specific/solana_specific/solana_chain_specific.go
+++ b/internal/upstreams/chains_specific/solana_specific/solana_chain_specific.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
@@ -46,6 +47,10 @@ func (s *SolanaChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 	}
 
 	return labels.NewBaseLabelsProcessor(s.ctx, s.upstreamId, labelsDetectors, s.options.ValidationInterval*5)
+}
+
+func (s *SolanaChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	return caps.DefaultCapDetectors(s.upstreamId, input.WsConnector)
 }
 
 func (s *SolanaChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {

--- a/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
+++ b/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/evm_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
@@ -129,6 +130,10 @@ func (t *TronRestSpecific) HealthValidators() []validations.Validator[protocol.A
 
 func (t *TronRestSpecific) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
 	return nil
+}
+
+func (t *TronRestSpecific) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	return caps.DefaultCapDetectors(t.upstreamId, input.WsConnector)
 }
 
 func (t *TronRestSpecific) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {

--- a/internal/upstreams/event_processors/cap_event_processor.go
+++ b/internal/upstreams/event_processors/cap_event_processor.go
@@ -1,0 +1,79 @@
+package event_processors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/rs/zerolog/log"
+)
+
+type CapEventProcessor interface {
+	UpstreamStateEventProcessor
+}
+
+type BaseCapEventProcessor struct {
+	lifecycle    *utils.BaseLifecycle
+	upstreamId   string
+	capProcessor caps.CapProcessor
+	emitter      Emitter
+}
+
+func (b *BaseCapEventProcessor) Type() EventProcessorType {
+	return CapEventProcessorType
+}
+
+func (b *BaseCapEventProcessor) SetEmitter(emitter Emitter) {
+	b.emitter = emitter
+}
+
+func (b *BaseCapEventProcessor) Start() {
+	b.lifecycle.Start(func(ctx context.Context) error {
+		// Subscribe before starting the processor so the initial merged cap set,
+		// published as soon as the first detector reports, is never missed.
+		capSub := b.capProcessor.Subscribe(fmt.Sprintf("%s_caps", b.upstreamId))
+		b.capProcessor.Start()
+
+		go func() {
+			defer capSub.Unsubscribe()
+			for {
+				select {
+				case <-ctx.Done():
+					log.Info().Msgf("stopping cap events of upstream '%s'", b.upstreamId)
+					return
+				case capsSet, ok := <-capSub.Events:
+					if ok {
+						b.emitter(&protocol.CapsUpstreamStateEvent{Caps: capsSet})
+					}
+				}
+			}
+		}()
+
+		return nil
+	})
+}
+
+func (b *BaseCapEventProcessor) Stop() {
+	b.lifecycle.Stop()
+	b.capProcessor.Stop()
+}
+
+func (b *BaseCapEventProcessor) Running() bool {
+	return b.lifecycle.Running()
+}
+
+func NewBaseCapEventProcessor(ctx context.Context, upstreamId string, capProcessor caps.CapProcessor) *BaseCapEventProcessor {
+	if capProcessor == nil {
+		return nil
+	}
+
+	return &BaseCapEventProcessor{
+		lifecycle:    utils.NewBaseLifecycle(fmt.Sprintf("%s_cap_event_processor", upstreamId), ctx),
+		upstreamId:   upstreamId,
+		capProcessor: capProcessor,
+	}
+}
+
+var _ CapEventProcessor = (*BaseCapEventProcessor)(nil)

--- a/internal/upstreams/event_processors/event_processor.go
+++ b/internal/upstreams/event_processors/event_processor.go
@@ -15,6 +15,7 @@ const (
 	HealthValidatorProcessorType
 	SettingsValidatorProcessorType
 	LabelsProcessorType
+	CapEventProcessorType
 )
 
 type UpstreamStateEventProcessor interface {

--- a/internal/upstreams/upstream.go
+++ b/internal/upstreams/upstream.go
@@ -112,6 +112,7 @@ func NewBaseUpstream(
 			CreateHealthEventProcessor(ctx, conf, chainSpecific),
 			CreateSettingsEventProcessor(ctx, conf, chainSpecific),
 			CreateLabelsEventProcessor(ctx, conf, chainSpecific),
+			CreateCapEventProcessor(ctx, conf, chainSpecific, creationData.upstreamConnectorsInfo, creationData.upstreamMethods),
 		},
 	)
 	processorAggregator.SetEmitter(emitter)
@@ -250,6 +251,7 @@ func (u *BaseUpstream) PartialStop() {
 	u.processorAggregator.StopProcessor(event_processors.LowerBoundEventProcessorType)
 	u.processorAggregator.StopProcessor(event_processors.HeadEventProcessorType)
 	u.processorAggregator.StopProcessor(event_processors.LabelsProcessorType)
+	u.processorAggregator.StopProcessor(event_processors.CapEventProcessorType)
 }
 
 func (u *BaseUpstream) Resume() {
@@ -258,6 +260,7 @@ func (u *BaseUpstream) Resume() {
 	u.processorAggregator.StartProcessor(event_processors.HealthValidatorProcessorType)
 	u.processorAggregator.StartProcessor(event_processors.LowerBoundEventProcessorType)
 	u.processorAggregator.StartProcessor(event_processors.LabelsProcessorType)
+	u.processorAggregator.StartProcessor(event_processors.CapEventProcessorType)
 }
 
 func (u *BaseUpstream) Subscribe(name string) *utils.Subscription[protocol.UpstreamEvent] {
@@ -311,28 +314,11 @@ func (u *BaseUpstream) newUpstreamMethods(bannedMethods mapset.Set[string]) meth
 	return newMethods
 }
 
-func (u *BaseUpstream) startConnectors(ctx context.Context) {
-	headConnectorType := u.upConfig.GetHeadApiConnectorType()
+func (u *BaseUpstream) startConnectors(_ context.Context) {
+	// Capabilities derived from connector state (WsCap, NewHeads/Logs, PendingTx) are
+	// now produced by the cap pipeline (caps.CapProcessor + CapDetectors), which
+	// subscribes to the connectors' state streams itself. Here we only start them.
 	for _, connector := range u.apiConnectors {
 		connector.Start()
-		go func(conn connectors.ApiConnector) {
-			stateSubscription := conn.SubscribeStates(fmt.Sprintf("%s_%s_sub_states", u.id, conn.GetType()))
-			if stateSubscription == nil {
-				return
-			}
-			defer stateSubscription.Unsubscribe()
-
-			isHeadConnector := conn.GetType() == headConnectorType
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case event, okEvent := <-stateSubscription.Events:
-					if okEvent {
-						u.emitter(&protocol.SubscribeUpstreamStateEvent{State: event, HeadConnector: isHeadConnector})
-					}
-				}
-			}
-		}(connector)
 	}
 }

--- a/internal/upstreams/upstream_processors.go
+++ b/internal/upstreams/upstream_processors.go
@@ -5,10 +5,14 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/event_processors"
+	"github.com/drpcorg/nodecore/internal/upstreams/methods"
 	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/samber/lo"
 )
 
 func CreateHeadEventProcessor(
@@ -85,6 +89,33 @@ func CreateBlockEventProcessor(
 		return nil
 	}
 	eventProcessor := event_processors.NewBaseBlockEventProcessor(ctx, conf.Id, configuredChain.Chain, blockProcessor)
+	if eventProcessor == nil {
+		return nil
+	}
+	return eventProcessor
+}
+
+func CreateCapEventProcessor(
+	ctx context.Context,
+	conf *config.Upstream,
+	chainSpecific chains_specific.ChainSpecific,
+	connectorsInfo *connectorsInfo,
+	upstreamMethods methods.Methods,
+) event_processors.UpstreamStateEventProcessor {
+	wsConnector, _ := lo.Find(connectorsInfo.allConnectors, func(c connectors.ApiConnector) bool {
+		return c.GetType() == specs.WebsocketConnector
+	})
+	input := caps.DetectorInput{
+		WsConnector:   wsConnector,
+		HeadConnector: connectorsInfo.headConnector,
+		Methods:       upstreamMethods,
+	}
+
+	capProcessor := caps.NewBaseCapProcessor(ctx, conf.Id, chainSpecific.CapDetectors(input))
+	if capProcessor == nil {
+		return nil
+	}
+	eventProcessor := event_processors.NewBaseCapEventProcessor(ctx, conf.Id, capProcessor)
 	if eventProcessor == nil {
 		return nil
 	}

--- a/internal/upstreams/upstream_test.go
+++ b/internal/upstreams/upstream_test.go
@@ -294,14 +294,16 @@ func TestBaseUpstreamProcessStateEvents_DuplicateHeadStateStillPublishes(t *test
 	assertUpstreamStateMatches(t, expectedState, upstream.GetUpstreamState())
 }
 
-func TestBaseUpstreamProcessStateEvents_AddsWsCapOnConnected(t *testing.T) {
+func TestBaseUpstreamProcessStateEvents_AppliesCaps(t *testing.T) {
 	upstream, emit, sub := newTestBaseUpstream(t, nil, nil, nil)
 
 	t.Cleanup(upstream.Stop)
 
 	startUpstream(t, upstream, sub)
 
-	emit(&protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected})
+	emit(&protocol.CapsUpstreamStateEvent{
+		Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+	})
 
 	event := nextUpstreamEvent(t, sub)
 	expectedState := protocol.DefaultUpstreamState(
@@ -316,16 +318,18 @@ func TestBaseUpstreamProcessStateEvents_AddsWsCapOnConnected(t *testing.T) {
 	assertUpstreamStateMatches(t, expectedState, upstream.GetUpstreamState())
 }
 
-func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateWsConnectedState(t *testing.T) {
+func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateCaps(t *testing.T) {
 	upstream, emit, sub := newTestBaseUpstream(t, nil, nil, nil)
 
 	t.Cleanup(upstream.Stop)
 
 	startUpstream(t, upstream, sub)
 
-	wsConnectedEvent := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected}
+	capsEvent := &protocol.CapsUpstreamStateEvent{
+		Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+	}
 
-	emit(wsConnectedEvent)
+	emit(capsEvent)
 	event := nextUpstreamEvent(t, sub)
 	expectedState := protocol.DefaultUpstreamState(
 		mustNewUpstreamMethods(t, nil),
@@ -337,22 +341,24 @@ func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateWsConnectedState(t *test
 	expectedState.Status = protocol.Available
 	assertStateEventMatches(t, event, expectedState)
 
-	emit(wsConnectedEvent)
+	emit(capsEvent)
 	assertNoUpstreamEvent(t, sub)
 	assertUpstreamStateMatches(t, expectedState, upstream.GetUpstreamState())
 }
 
-func TestBaseUpstreamProcessStateEvents_RemovesWsCapOnDisconnected(t *testing.T) {
+func TestBaseUpstreamProcessStateEvents_ClearsCaps(t *testing.T) {
 	upstream, emit, sub := newTestBaseUpstream(t, nil, nil, nil)
 
 	t.Cleanup(upstream.Stop)
 
 	startUpstream(t, upstream, sub)
 
-	emit(&protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected})
+	emit(&protocol.CapsUpstreamStateEvent{
+		Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+	})
 	_ = nextUpstreamEvent(t, sub)
 
-	emit(&protocol.SubscribeUpstreamStateEvent{State: protocol.WsDisconnected})
+	emit(&protocol.CapsUpstreamStateEvent{Caps: mapset.NewThreadUnsafeSet[protocol.Cap]()})
 
 	event := nextUpstreamEvent(t, sub)
 	expectedState := protocol.DefaultUpstreamState(
@@ -367,18 +373,20 @@ func TestBaseUpstreamProcessStateEvents_RemovesWsCapOnDisconnected(t *testing.T)
 	assertUpstreamStateMatches(t, expectedState, upstream.GetUpstreamState())
 }
 
-func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateWsDisconnectedState(t *testing.T) {
+func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateClearedCaps(t *testing.T) {
 	upstream, emit, sub := newTestBaseUpstream(t, nil, nil, nil)
 
 	t.Cleanup(upstream.Stop)
 
 	startUpstream(t, upstream, sub)
 
-	emit(&protocol.SubscribeUpstreamStateEvent{State: protocol.WsConnected})
+	emit(&protocol.CapsUpstreamStateEvent{
+		Caps: mapset.NewThreadUnsafeSet[protocol.Cap](protocol.WsCap, protocol.PendingTxCap),
+	})
 	_ = nextUpstreamEvent(t, sub)
 
-	wsDisconnectedEvent := &protocol.SubscribeUpstreamStateEvent{State: protocol.WsDisconnected}
-	emit(wsDisconnectedEvent)
+	clearedEvent := &protocol.CapsUpstreamStateEvent{Caps: mapset.NewThreadUnsafeSet[protocol.Cap]()}
+	emit(clearedEvent)
 	event := nextUpstreamEvent(t, sub)
 	expectedState := protocol.DefaultUpstreamState(
 		mustNewUpstreamMethods(t, nil),
@@ -390,7 +398,7 @@ func TestBaseUpstreamProcessStateEvents_IgnoresDuplicateWsDisconnectedState(t *t
 	expectedState.Status = protocol.Available
 	assertStateEventMatches(t, event, expectedState)
 
-	emit(wsDisconnectedEvent)
+	emit(clearedEvent)
 	assertNoUpstreamEvent(t, sub)
 	assertUpstreamStateMatches(t, expectedState, upstream.GetUpstreamState())
 }

--- a/internal/upstreams/validations/eth_validations/eth_log_index_validator.go
+++ b/internal/upstreams/validations/eth_validations/eth_log_index_validator.go
@@ -2,12 +2,12 @@ package eth_validations
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/validations"
@@ -185,7 +185,7 @@ func (v *EthLogIndexValidator) getBlock(blockHex string) (logIndexBlock, error) 
 		return logIndexBlock{}, response.GetError()
 	}
 	var block logIndexBlock
-	if err := json.Unmarshal(response.ResponseResult(), &block); err != nil {
+	if err := sonic.Unmarshal(response.ResponseResult(), &block); err != nil {
 		return logIndexBlock{}, err
 	}
 	return block, nil
@@ -200,7 +200,7 @@ func (v *EthLogIndexValidator) getTransactionReceipt(txHash string) (logIndexRec
 		return logIndexReceipt{}, response.GetError()
 	}
 	var receipt logIndexReceipt
-	if err := json.Unmarshal(response.ResponseResult(), &receipt); err != nil {
+	if err := sonic.Unmarshal(response.ResponseResult(), &receipt); err != nil {
 		return logIndexReceipt{}, err
 	}
 	return receipt, nil

--- a/internal/upstreams/ws/ws_processor.go
+++ b/internal/upstreams/ws/ws_processor.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -45,11 +46,18 @@ type BaseWsProcessor struct {
 
 	executor   failsafe.Executor[bool]
 	subManager *utils.SubscriptionManager[protocol.SubscribeConnectorState]
+	// connected tracks the last published connection state so new subscribers can
+	// be seeded with it immediately (SubscribeWsStates replays it). Without this a
+	// subscriber that registers after the initial WsConnected publish would never
+	// learn the connector is up.
+	connected atomic.Bool
 }
 
 func (b *BaseWsProcessor) Unsubscribe(opId string) {
 	b.requestRegistry.Cancel(opId)
 }
+
+var i = 0
 
 func (b *BaseWsProcessor) Start() {
 	b.lifecycle.Start(func(ctx context.Context) error {
@@ -66,6 +74,7 @@ func (b *BaseWsProcessor) Start() {
 						b.disconnect("stopping ws loop after connect failure", err)
 						return
 					}
+					b.connected.Store(true)
 					b.subManager.Publish(protocol.WsConnected)
 					b.startReader(ctx)
 				}
@@ -158,6 +167,14 @@ func (b *BaseWsProcessor) SendWsRequest(ctx context.Context, upstreamRequest pro
 }
 
 func (b *BaseWsProcessor) SubscribeWsStates(name string) *utils.Subscription[protocol.SubscribeConnectorState] {
+	// If the connector is already connected, seed the new subscriber with WsConnected
+	// right away: the initial WsConnected was published once on connect and a late
+	// subscriber (e.g. a cap detector started after the connection came up) would
+	// otherwise never learn the connector is live. When disconnected we subscribe
+	// normally - the next connect publishes WsConnected as usual.
+	if b.connected.Load() {
+		return b.subManager.SubscribeWithInitialState(name, 100, protocol.WsConnected)
+	}
 	return b.subManager.Subscribe(name)
 }
 
@@ -236,6 +253,7 @@ func (b *BaseWsProcessor) disconnect(reason string, cause error) {
 	if err := b.wsSession.CloseCurrent(); err != nil {
 		log.Error().Err(err).Msg("couldn't close a ws connection")
 	}
+	b.connected.Store(false)
 	b.requestRegistry.CancelAll()
 }
 

--- a/internal/upstreams/ws/ws_processor.go
+++ b/internal/upstreams/ws/ws_processor.go
@@ -3,7 +3,6 @@ package ws
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -46,11 +45,6 @@ type BaseWsProcessor struct {
 
 	executor   failsafe.Executor[bool]
 	subManager *utils.SubscriptionManager[protocol.SubscribeConnectorState]
-	// connected tracks the last published connection state so new subscribers can
-	// be seeded with it immediately (SubscribeWsStates replays it). Without this a
-	// subscriber that registers after the initial WsConnected publish would never
-	// learn the connector is up.
-	connected atomic.Bool
 }
 
 func (b *BaseWsProcessor) Unsubscribe(opId string) {
@@ -72,7 +66,6 @@ func (b *BaseWsProcessor) Start() {
 						b.disconnect("stopping ws loop after connect failure", err)
 						return
 					}
-					b.connected.Store(true)
 					b.subManager.Publish(protocol.WsConnected)
 					b.startReader(ctx)
 				}
@@ -165,15 +158,13 @@ func (b *BaseWsProcessor) SendWsRequest(ctx context.Context, upstreamRequest pro
 }
 
 func (b *BaseWsProcessor) SubscribeWsStates(name string) *utils.Subscription[protocol.SubscribeConnectorState] {
-	// If the connector is already connected, seed the new subscriber with WsConnected
-	// right away: the initial WsConnected was published once on connect and a late
+	// Replay the last published connection state to the new subscriber. A late
 	// subscriber (e.g. a cap detector started after the connection came up) would
-	// otherwise never learn the connector is live. When disconnected we subscribe
-	// normally - the next connect publishes WsConnected as usual.
-	if b.connected.Load() {
-		return b.subManager.SubscribeWithInitialState(name, 100, protocol.WsConnected)
-	}
-	return b.subManager.Subscribe(name)
+	// otherwise never learn the connector is live, since WsConnected is published
+	// once on connect. The replay is atomic with respect to a concurrent connect/
+	// disconnect publish, so the subscriber can't miss a state transition in the gap
+	// between snapshotting the state and registering.
+	return b.subManager.SubscribeWithReplay(name)
 }
 
 func NewBaseWsProcessor(
@@ -251,7 +242,6 @@ func (b *BaseWsProcessor) disconnect(reason string, cause error) {
 	if err := b.wsSession.CloseCurrent(); err != nil {
 		log.Error().Err(err).Msg("couldn't close a ws connection")
 	}
-	b.connected.Store(false)
 	b.requestRegistry.CancelAll()
 }
 

--- a/internal/upstreams/ws/ws_processor.go
+++ b/internal/upstreams/ws/ws_processor.go
@@ -57,8 +57,6 @@ func (b *BaseWsProcessor) Unsubscribe(opId string) {
 	b.requestRegistry.Cancel(opId)
 }
 
-var i = 0
-
 func (b *BaseWsProcessor) Start() {
 	b.lifecycle.Start(func(ctx context.Context) error {
 		go func() {

--- a/pkg/utils/subscriptions.go
+++ b/pkg/utils/subscriptions.go
@@ -57,6 +57,14 @@ func (s *Subscription[T]) Unsubscribe() {
 type SubscriptionManager[T any] struct {
 	subscriptions CMap[string, *Subscription[T]]
 	name          string
+	// mu serializes Publish against SubscribeWithReplay so that registering a new
+	// subscriber and snapshotting the last published event happen atomically with
+	// respect to a concurrent Publish. Without this a replay-subscriber could read
+	// the last state, then have a Publish run (and miss it, being unregistered),
+	// then register - ending up permanently stale. lastEvent/hasLast are guarded by mu.
+	mu        sync.Mutex
+	lastEvent T
+	hasLast   bool
 }
 
 func (sm *SubscriptionManager[T]) Subscribe(name string) *Subscription[T] {
@@ -77,15 +85,31 @@ func (sm *SubscriptionManager[T]) SubscribeWithSize(name string, size int) *Subs
 	return sub
 }
 
-func (sm *SubscriptionManager[T]) SubscribeWithInitialState(name string, size int, initialState T) *Subscription[T] {
+// SubscribeWithReplay registers a subscriber and, if any event has been published
+// before, seeds it with the most recent one. The snapshot-and-register is done under
+// sm.mu (the same lock Publish holds), so it is atomic with respect to a concurrent
+// Publish: the subscriber either sees a publish that happened entirely before it
+// registered (replayed as the seed) or one that happened entirely after (delivered
+// normally) - never a publish that slips through the gap. Use this for state-style
+// streams where a late subscriber must learn the current state.
+func (sm *SubscriptionManager[T]) SubscribeWithReplay(name string) *Subscription[T] {
+	return sm.SubscribeWithReplaySize(name, 100)
+}
+
+func (sm *SubscriptionManager[T]) SubscribeWithReplaySize(name string, size int) *Subscription[T] {
 	sub := &Subscription[T]{
 		name:    name,
 		Events:  make(chan T, size),
 		manager: sm,
 	}
-	sub.Events <- initialState
 
+	sm.mu.Lock()
+	if sm.hasLast {
+		sub.Events <- sm.lastEvent
+	}
 	_, loaded := sm.subscriptions.LoadOrStore(name, sub)
+	sm.mu.Unlock()
+
 	if loaded {
 		log.Panic().Msgf("Fatal error - %s subscription already exists at %s", name, sm.name)
 	}
@@ -94,6 +118,9 @@ func (sm *SubscriptionManager[T]) SubscribeWithInitialState(name string, size in
 }
 
 func (sm *SubscriptionManager[T]) Publish(event T) {
+	sm.mu.Lock()
+	sm.lastEvent = event
+	sm.hasLast = true
 	sm.subscriptions.Range(func(key string, sub *Subscription[T]) bool {
 		sub.mu.Lock()
 		defer sub.mu.Unlock()
@@ -110,6 +137,7 @@ func (sm *SubscriptionManager[T]) Publish(event T) {
 
 		return true
 	})
+	sm.mu.Unlock()
 	publishRate.WithLabelValues(sm.name).Inc()
 }
 

--- a/pkg/utils/subscriptions_test.go
+++ b/pkg/utils/subscriptions_test.go
@@ -1,0 +1,153 @@
+package utils_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeReceivesPublishedEvents(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sub := sm.Subscribe("s1")
+
+	sm.Publish(1)
+	sm.Publish(2)
+
+	assert.Equal(t, 1, <-sub.Events)
+	assert.Equal(t, 2, <-sub.Events)
+}
+
+func TestPublishFansOutToAllSubscribers(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sub1 := sm.Subscribe("s1")
+	sub2 := sm.Subscribe("s2")
+
+	sm.Publish(42)
+
+	assert.Equal(t, 42, <-sub1.Events)
+	assert.Equal(t, 42, <-sub2.Events)
+}
+
+func TestSubscribeDoesNotReplayPriorEvents(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sm.Publish(1) // published before anyone subscribed
+
+	sub := sm.Subscribe("s1")
+
+	// A plain Subscribe only sees events published after it registered.
+	assert.Empty(t, drain(sub))
+
+	sm.Publish(2)
+	assert.Equal(t, 2, <-sub.Events)
+}
+
+func TestSubscribeWithReplaySeedsLastEvent(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sm.Publish(1)
+	sm.Publish(2)
+
+	sub := sm.SubscribeWithReplay("s1")
+
+	// Replay seeds with the most recent event, not the whole history.
+	assert.Equal(t, []int{2}, drain(sub))
+
+	sm.Publish(3)
+	assert.Equal(t, 3, <-sub.Events)
+}
+
+func TestSubscribeWithReplayNoPriorEvent(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+
+	// Nothing has been published yet, so there is nothing to replay.
+	sub := sm.SubscribeWithReplay("s1")
+	assert.Empty(t, drain(sub))
+
+	sm.Publish(7)
+	assert.Equal(t, 7, <-sub.Events)
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sub := sm.Subscribe("s1")
+
+	sub.Unsubscribe()
+
+	// Channel is closed by Unsubscribe.
+	_, ok := <-sub.Events
+	assert.False(t, ok)
+
+	// Publishing after Unsubscribe must not panic on the closed channel.
+	assert.NotPanics(t, func() { sm.Publish(1) })
+}
+
+func TestPublishDropsWhenBufferFull(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sub := sm.SubscribeWithSize("s1", 1)
+
+	// First fits the buffer; second is dropped (non-blocking send) rather than
+	// blocking the publisher.
+	assert.NotPanics(t, func() {
+		sm.Publish(1)
+		sm.Publish(2)
+	})
+
+	assert.Equal(t, []int{1}, drain(sub))
+}
+
+func TestDuplicateSubscriptionPanics(t *testing.T) {
+	sm := utils.NewSubscriptionManager[int]("test")
+	sm.Subscribe("dup")
+
+	assert.Panics(t, func() { sm.Subscribe("dup") })
+}
+
+// TestSubscribeWithReplayAtomicVsPublish exercises the TOCTOU window the manager
+// lock closes: a subscriber that snapshots the last state and then registers must
+// never miss a transition that happens in between. We publish an initial state,
+// then race a single state-change publish against a replay-subscribe, and assert
+// the subscriber's observed sequence always ends on the final published state.
+// Run with -race; without the lock this fails intermittently (the subscriber gets
+// stuck on the stale initial state).
+func TestSubscribeWithReplayAtomicVsPublish(t *testing.T) {
+	for i := 0; i < 2000; i++ {
+		sm := utils.NewSubscriptionManager[bool]("test")
+		sm.Publish(true) // initial "connected" state
+
+		var sub *utils.Subscription[bool]
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			sm.Publish(false) // "disconnect"
+		}()
+		go func() {
+			defer wg.Done()
+			sub = sm.SubscribeWithReplay("s1")
+		}()
+
+		wg.Wait()
+
+		got := drain(sub)
+		require.NotEmptyf(t, got, "iteration %d: subscriber observed no state", i)
+		// Whether it replayed [false], replayed [true] then received [false], or
+		// replayed [false] directly, the last observed state must be the final one.
+		assert.Falsef(t, got[len(got)-1], "iteration %d: subscriber stuck on stale state, saw %v", i, got)
+	}
+}
+
+// drain returns all currently-buffered events without blocking.
+func drain[T any](sub *utils.Subscription[T]) []T {
+	var out []T
+	for {
+		select {
+		case v := <-sub.Events:
+			out = append(out, v)
+		default:
+			return out
+		}
+	}
+}


### PR DESCRIPTION
# Pending-tx validator + capability detection pipeline

## Why

`PendingTxCap` — the capability the local pending-tx aggregation source
(`flow/pending_tx_source.go`) keys off to decide an upstream can serve
`eth_subscribe("newPendingTransactions")` — was added **unconditionally** the moment a
ws connector connected (`SubscribeUpstreamStateEvent.ProcessEvent`). But a live ws
connection doesn't mean the node actually exposes a usable mempool. dshackle solves
this with `PendingTransactionValidatorImpl`: on BASE it polls `txpool_content` and only
advertises the capability when `pending + queued >= 1000`; other chains keep it
always-on.

Rather than bolt a one-off validator onto the side, this restructures **all** capability
detection into a per-chain pipeline — a `CapProcessor` aggregating `CapDetector`s,
mirroring how `LowerBoundProcessor` aggregates `LowerBoundDetector`s. Cap logic moves
out of the upstream/`startConnectors` into one place where each chain decides its own
caps, and the txpool-gated `PendingTxCap` on BASE becomes just one detector among them.

## What changed

### New cap pipeline (`internal/upstreams/caps`)

- **`CapDetector`** — streams the cap set it currently asserts (its `Domain()`),
  re-emitting whenever its inputs change. Each detector owns its cadence (push or poll).
- **`BaseCapProcessor`** — fans in all detectors, keeps the latest snapshot per detector,
  unions them, and publishes the merged set **on change only**.
- **`WsPresenceCapDetector`** — generic; asserts a cap while the ws connector reports a
  live connection. Used for `WsCap` everywhere.

### EVM-specific detectors (`internal/upstreams/caps/evm_caps`)

- **`EvmHeadSubCapDetector`** — `NewHeadsCap` / `LogsCap`, gated on a ws head connector
  plus `eth_subscribe` / `eth_getLogs` support.
- **`EvmPendingTxCapDetector`** — `PendingTxCap`, gating ws-presence on a periodic
  `txpool_content` poll: asserted only while ws is up **and** `pending + queued >= txLimit`.
  The threshold is a constructor parameter (`txLimit`) so other chains can be onboarded
  with their own limit; BASE passes `BaseTxLimit = 1000` (dshackle parity).

### Wiring

- `ChainSpecific` gains `CapDetectors(input)`. EVM composes
  `WsCap + head-sub + (BASE → txpool-validated PendingTxCap | other EVM → ws-presence PendingTxCap)`.
- Non-EVM chains (solana, tron-rest, aztec, algorand) use `DefaultCapDetectors`, which now
  returns **only `WsCap`** — `PendingTxCap` is EVM-only and these chains can't serve it
  (previously set globally for no benefit).
- New `BaseCapEventProcessor` emits a replace-set `CapsUpstreamStateEvent`;
  `SubscribeUpstreamStateEvent` and the per-connector state loop in `startConnectors` are
  removed. The processor is driven by the existing `Resume`/`PartialStop` lifecycle.

### Supporting fix

- `ws_processor` only published `WsConnected` on transition, so a cap detector
  subscribing after the connection came up (the cap processor starts in `Resume`, after
  blocking settings validation) would miss it. `SubscribeWsStates` now seeds
  `WsConnected` to a late subscriber when the connector is already connected.
