### PR TITLE
Add blockchain type to cache policy; Use cache processor as decorator

### DIFF
--- a/docs/nodecore/04-cache.md
+++ b/docs/nodecore/04-cache.md
@@ -126,6 +126,11 @@ policies:
     connector-id: memory-connector
     object-max-size: "1000KB"
     ttl: 10s
+  - blockchain-type: "eth"
+    id: memory-policy-3
+    method: "eth_chainId"
+    connector-id: memory-connector
+    ttl: 1h
 ```
 
 The `policies` section defines the rules for which requests should be cached, how long they remain valid, and which connector should store them. Each policy is tied to specific chains and methods, allowing fine-grained caching control.
@@ -133,9 +138,13 @@ The `policies` section defines the rules for which requests should be cached, ho
 `policies` fields:
 
 - `id` - Unique identifier for the policy. **_Required_**, **_Unique_**
-- `chain` - Target blockchain(s) this policy applies to. **_Required_**. Possible values:
+- `chain` - Target blockchain(s) this policy applies to. **_Required_** unless `blockchain-type` is set (the two are mutually exclusive). Possible values:
   - `*` matches all supported chains
   - Multiple chains can be specified with `|` (e.g., `optimism|polygon|ethereum`)
+- `blockchain-type` - Target blockchain type family this policy applies to. Mutually exclusive with `chain` — set exactly one of the two. Useful to cache a method across a whole family without listing every chain. Possible values:
+  - `*` matches all blockchain types
+  - Multiple types can be specified with `|` (e.g., `eth|solana`)
+  - Supported types: `eth`, `eth-beacon-chain`, `solana`, `avm`, `aztec`, `cosmos`, `ton`, `bitcoin`, `near`, `polkadot`, `starknet`
 - `method` - RPC method or method pattern to which the policy applies. **_Required_**. Possible values:
   - exact names (`eth_getBlockByNumber`)
   - wildcards (`debug*` to cover all debug methods or `*` matches all methods)

--- a/internal/caches/cache_policies.go
+++ b/internal/caches/cache_policies.go
@@ -38,6 +38,7 @@ type CachePolicy struct {
 	connector          CacheConnector
 	methods            mapset.Set[string]
 	chains             mapset.Set[chains.Chain]
+	blockchainTypes    mapset.Set[chains.BlockchainType]
 	cacheEmpty         bool
 	maxSizeBytes       int
 	ttl                time.Duration
@@ -63,6 +64,7 @@ func NewCachePolicy(
 		cacheEmpty:         policyConfig.CacheEmpty,
 		ttl:                ttl,
 		chains:             getCacheChains(policyConfig.Chain),
+		blockchainTypes:    getCacheBlockchainTypes(policyConfig.BlockchainType),
 		methods:            getCacheMethods(policyConfig.Method),
 		maxSizeBytes:       int(maxSizeInBytes(policyConfig.ObjectMaxSize)),
 		finalizationType:   mapFinalizationType(policyConfig.FinalizationType),
@@ -146,10 +148,10 @@ func maxSizeInBytes(maxSizeStr string) int64 {
 
 	return maxSizeInt * multiplier
 }
-
 func getCacheChains(chainConfig string) mapset.Set[chains.Chain] {
-	if chainConfig == "*" {
+	if chainConfig == "*" || chainConfig == "" {
 		// empty set means that any chain can be processed
+		// (an empty config happens for blockchain-type-based policies)
 		return mapset.NewThreadUnsafeSet[chains.Chain]()
 	}
 
@@ -168,6 +170,30 @@ func getCacheChains(chainConfig string) mapset.Set[chains.Chain] {
 		return nil
 	}
 	return cacheChainsSet
+}
+
+func getCacheBlockchainTypes(blockchainTypeConfig string) mapset.Set[chains.BlockchainType] {
+	if blockchainTypeConfig == "*" || blockchainTypeConfig == "" {
+		// empty set means that any blockchain type can be processed
+		// (an empty config happens for chain-based policies)
+		return mapset.NewThreadUnsafeSet[chains.BlockchainType]()
+	}
+
+	cacheBlockchainTypes := lo.Map(strings.Split(blockchainTypeConfig, "|"), func(item string, index int) string {
+		return strings.TrimSpace(item)
+	})
+	cacheBlockchainTypesSet := mapset.NewThreadUnsafeSet[chains.BlockchainType]()
+	for _, blockchainTypeStr := range cacheBlockchainTypes {
+		if chains.IsValidBlockchainType(blockchainTypeStr) {
+			cacheBlockchainTypesSet.Add(chains.BlockchainType(blockchainTypeStr))
+		}
+	}
+
+	if cacheBlockchainTypesSet.IsEmpty() {
+		// nil means that there are no supported blockchain types in the config, so nothing can be processed
+		return nil
+	}
+	return cacheBlockchainTypesSet
 }
 
 func getCacheMethods(methodConfig string) mapset.Set[string] {
@@ -204,6 +230,17 @@ func (c *CachePolicy) methodMatched(request protocol.RequestHolder) bool {
 
 func (c *CachePolicy) chainNotMatched(chain chains.Chain) bool {
 	return c.chains == nil || (!c.chains.IsEmpty() && !c.chains.ContainsOne(chain))
+}
+
+func (c *CachePolicy) blockchainTypeNotMatched(chain chains.Chain) bool {
+	if c.blockchainTypes == nil {
+		return true
+	}
+	if c.blockchainTypes.IsEmpty() {
+		return false
+	}
+	blockchainType := chains.GetChain(chain.String()).Type
+	return !c.blockchainTypes.ContainsOne(blockchainType)
 }
 
 func getCacheKey(chain chains.Chain, requestHash string) string {
@@ -270,13 +307,13 @@ func (c *CachePolicy) isMethodCacheable(ctx context.Context, chain chains.Chain,
 }
 
 func (c *CachePolicy) baseCacheableCheck(ctx context.Context, chain chains.Chain, request protocol.RequestHolder) bool {
-	if request.IsStream() {
-		return false
-	}
 	if !c.isMethodCacheable(ctx, chain, request) { // check spec config if a requested method is cacheable or not
 		return false
 	}
 	if c.chainNotMatched(chain) { // check policy and request chains
+		return false
+	}
+	if c.blockchainTypeNotMatched(chain) { // check policy and request blockchain types
 		return false
 	}
 	if !c.methods.IsEmpty() { // check policy and request methods

--- a/internal/caches/cache_policies_test.go
+++ b/internal/caches/cache_policies_test.go
@@ -442,6 +442,52 @@ func TestCachePolicyAllChainThenReceiveResult(t *testing.T) {
 	}
 }
 
+func TestCachePolicyMatchedBlockchainTypeThenReceiveAndStoreResult(t *testing.T) {
+	methodsMock, upSupervisor := test_utils.GetMethodMockAndUpSupervisor()
+	result1 := []byte(`result1`)
+	specMethod := specs.DefaultMethod("method")
+
+	connectorMock := mocks.NewCacheConnectorMock()
+	connectorMock.On("Receive", mock.Anything, mock.Anything).Return(result1, nil)
+	connectorMock.On("Store", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	// polygon belongs to the "eth" blockchain type family
+	policyCfg := test_utils.PolicyConfigBlockchainType("eth", "*", "conn-id", "10KB", "5s", true)
+	policy := caches.NewCachePolicy(upSupervisor, connectorMock, policyCfg)
+	request, _ := protocol.NewUpstreamJsonRpcRequestWithSpecMethod("method", nil, specMethod)
+
+	result, ok := policy.Receive(context.Background(), chains.POLYGON, request)
+	assert.True(t, ok)
+	assert.True(t, bytes.Equal(result, result1))
+
+	ok = policy.Store(context.Background(), chains.POLYGON, request, result1)
+	assert.True(t, ok)
+
+	methodsMock.AssertExpectations(t)
+	upSupervisor.AssertExpectations(t)
+	connectorMock.AssertExpectations(t)
+}
+
+func TestCachePolicyNotMatchedBlockchainTypeThenReceiveAndStoreNothing(t *testing.T) {
+	methodsMock, upSupervisor := test_utils.GetMethodMockAndUpSupervisor()
+	specMethod := specs.DefaultMethod("method")
+
+	// polygon is not part of the "solana" family, so the policy must not apply
+	policyCfg := test_utils.PolicyConfigBlockchainType("solana", "*", "conn-id", "10KB", "5s", true)
+	policy := caches.NewCachePolicy(upSupervisor, mocks.NewCacheConnectorMock(), policyCfg)
+	request, _ := protocol.NewUpstreamJsonRpcRequestWithSpecMethod("method", nil, specMethod)
+
+	result, ok := policy.Receive(context.Background(), chains.POLYGON, request)
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	ok = policy.Store(context.Background(), chains.POLYGON, request, []byte(`result`))
+	assert.False(t, ok)
+
+	methodsMock.AssertExpectations(t)
+	upSupervisor.AssertExpectations(t)
+}
+
 func TestCachePolicySupportedMethodsThenReceiveResultAndStoreOrNothing(t *testing.T) {
 	methodsMock, upSupervisor := test_utils.GetMethodMockAndUpSupervisor()
 	result1 := []byte(`result1`)

--- a/internal/config/cache_config.go
+++ b/internal/config/cache_config.go
@@ -29,6 +29,7 @@ type CacheConnectorConfig struct {
 type CachePolicyConfig struct {
 	Id               string           `yaml:"id"`
 	Chain            string           `yaml:"chain"`
+	BlockchainType   string           `yaml:"blockchain-type"`
 	Method           string           `yaml:"method"`
 	FinalizationType FinalizationType `yaml:"finalization-type"`
 	CacheEmpty       bool             `yaml:"cache-empty"`
@@ -174,8 +175,19 @@ func (f FinalizationType) validate() error {
 }
 
 func (p *CachePolicyConfig) validate(connectors mapset.Set[string]) error {
-	if err := validatePolicyChain(p.Chain); err != nil {
-		return err
+	switch {
+	case p.Chain != "" && p.BlockchainType != "":
+		return errors.New("chain and blockchain-type are mutually exclusive")
+	case p.Chain == "" && p.BlockchainType == "":
+		return errors.New("either chain or blockchain-type must be set")
+	case p.Chain != "":
+		if err := validatePolicyChain(p.Chain); err != nil {
+			return err
+		}
+	default:
+		if err := validatePolicyBlockchainType(p.BlockchainType); err != nil {
+			return err
+		}
 	}
 	if err := validateSize(p.ObjectMaxSize); err != nil {
 		return err
@@ -233,6 +245,21 @@ func validatePolicyChain(chain string) error {
 	for _, chainStr := range cacheChainsStr {
 		if !chains.IsSupported(chainStr) {
 			return fmt.Errorf("chain '%s' is not supported", chainStr)
+		}
+	}
+	return nil
+}
+
+func validatePolicyBlockchainType(blockchainType string) error {
+	if blockchainType == "*" {
+		return nil
+	}
+	blockchainTypesStr := lo.Map(strings.Split(blockchainType, "|"), func(item string, index int) string {
+		return strings.TrimSpace(item)
+	})
+	for _, blockchainTypeStr := range blockchainTypesStr {
+		if !chains.IsValidBlockchainType(blockchainTypeStr) {
+			return fmt.Errorf("blockchain type '%s' is not supported", blockchainTypeStr)
 		}
 	}
 	return nil

--- a/internal/config/cache_config_test.go
+++ b/internal/config/cache_config_test.go
@@ -39,16 +39,28 @@ func TestCachePolicyNoIdThenError(t *testing.T) {
 	assert.ErrorContains(t, err, "error during cache policies validation, cause: no policy id under index 0")
 }
 
-func TestCachePolicyNoChainThenError(t *testing.T) {
+func TestCachePolicyNoChainAndNoBlockchainTypeThenError(t *testing.T) {
 	t.Setenv(config.ConfigPathVar, "configs/cache/cache-empty-chain.yaml")
 	_, err := config.NewAppConfig()
-	assert.ErrorContains(t, err, "error during cache policy 'my_policy' validation, cause: empty chain setting")
+	assert.ErrorContains(t, err, "error during cache policy 'my_policy' validation, cause: either chain or blockchain-type must be set")
+}
+
+func TestCachePolicyBothChainAndBlockchainTypeThenError(t *testing.T) {
+	t.Setenv(config.ConfigPathVar, "configs/cache/cache-chain-and-blockchain-type.yaml")
+	_, err := config.NewAppConfig()
+	assert.ErrorContains(t, err, "error during cache policy 'my_policy' validation, cause: chain and blockchain-type are mutually exclusive")
 }
 
 func TestCachePolicyNotSupportedChainThenError(t *testing.T) {
 	t.Setenv(config.ConfigPathVar, "configs/cache/cache-not-supported-chain.yaml")
 	_, err := config.NewAppConfig()
 	assert.ErrorContains(t, err, "error during cache policy 'my_policy' validation, cause: chain 'not-supported' is not supported")
+}
+
+func TestCachePolicyNotSupportedBlockchainTypeThenError(t *testing.T) {
+	t.Setenv(config.ConfigPathVar, "configs/cache/cache-not-supported-blockchain-type.yaml")
+	_, err := config.NewAppConfig()
+	assert.ErrorContains(t, err, "error during cache policy 'my_policy' validation, cause: blockchain type 'not-supported' is not supported")
 }
 
 func TestCachePolicyWrongMaxSizeThenError(t *testing.T) {

--- a/internal/config/configs/cache/cache-chain-and-blockchain-type.yaml
+++ b/internal/config/configs/cache/cache-chain-and-blockchain-type.yaml
@@ -1,0 +1,28 @@
+server:
+  port: 9095
+
+cache:
+  connectors:
+    - driver: memory
+      id: test
+      memory:
+        max-items: 100
+        expired-remove-interval: 1s
+  policies:
+    - id: my_policy
+      chain: "ethereum"
+      blockchain-type: "eth"
+      method: "*getBlock*"
+      finalization-type: none
+      cache-empty: true
+      connector-id: memory-connector
+      object-max-size: "10KB"
+      ttl: 10s
+
+upstream-config:
+  upstreams:
+    - id: eth-upstream
+      chain: ethereum
+      connectors:
+        - type: json-rpc
+          url: https://test.com

--- a/internal/config/configs/cache/cache-not-supported-blockchain-type.yaml
+++ b/internal/config/configs/cache/cache-not-supported-blockchain-type.yaml
@@ -1,0 +1,27 @@
+server:
+  port: 9095
+
+cache:
+  connectors:
+    - driver: memory
+      id: test
+      memory:
+        max-items: 100
+        expired-remove-interval: 1s
+  policies:
+    - id: my_policy
+      blockchain-type: "not-supported"
+      method: "*getBlock*"
+      finalization-type: none
+      cache-empty: true
+      connector-id: memory-connector
+      object-max-size: "10KB"
+      ttl: 10s
+
+upstream-config:
+  upstreams:
+    - id: eth-upstream
+      chain: ethereum
+      connectors:
+        - type: json-rpc
+          url: https://test.com

--- a/internal/upstreams/flow/cache_request_processor.go
+++ b/internal/upstreams/flow/cache_request_processor.go
@@ -1,0 +1,68 @@
+package flow
+
+import (
+	"context"
+
+	"github.com/drpcorg/nodecore/internal/caches"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/quorum"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// CacheRequestProcessor decorates another RequestProcessor with caching: it does
+// a cache Receive first and only delegates to the inner processor on a miss, then
+// stores a cacheable response. A cache hit short-circuits the inner processor
+// entirely, so expensive delegates (e.g. NotNullRequestProcessor walking upstreams)
+// don't run when the answer is already cached.
+type CacheRequestProcessor struct {
+	chain          chains.Chain
+	cacheProcessor caches.CacheProcessor
+	delegate       RequestProcessor
+}
+
+func NewCacheRequestProcessor(chain chains.Chain, cacheProcessor caches.CacheProcessor, delegate RequestProcessor) *CacheRequestProcessor {
+	return &CacheRequestProcessor{
+		chain:          chain,
+		cacheProcessor: cacheProcessor,
+		delegate:       delegate,
+	}
+}
+
+var _ RequestProcessor = (*CacheRequestProcessor)(nil)
+
+func (p *CacheRequestProcessor) ProcessRequest(
+	ctx context.Context,
+	upstreamStrategy UpstreamStrategy,
+	request protocol.RequestHolder,
+) ProcessedResponse {
+	// Quorum-read requests are served fresh from drpc upstreams: cached payloads
+	// don't carry the QR* signature headers, so both cache Receive and Store
+	// are skipped here.
+	if _, quorumRequested := quorum.FromContext(ctx); quorumRequested {
+		return p.delegate.ProcessRequest(ctx, upstreamStrategy, request)
+	}
+
+	if result, ok := p.cacheProcessor.Receive(ctx, p.chain, request); ok {
+		// change the previous request type since it will not be sent to the upstream
+		request.RequestObserver().
+			WithRequestKind(protocol.Cached)
+		return &UnaryResponse{
+			ResponseWrapper: &protocol.ResponseHolderWrapper{
+				UpstreamId: NoUpstream,
+				RequestId:  request.Id(),
+				Response:   protocol.NewSimpleHttpUpstreamResponse(request.Id(), result, request.RequestType()),
+			},
+		}
+	}
+
+	processedResponse := p.delegate.ProcessRequest(ctx, upstreamStrategy, request)
+
+	if unaryResponse, ok := processedResponse.(*UnaryResponse); ok {
+		response := unaryResponse.ResponseWrapper.Response
+		if !response.HasError() && !response.HasStream() {
+			go p.cacheProcessor.Store(ctx, p.chain, request, response.ResponseResult())
+		}
+	}
+
+	return processedResponse
+}

--- a/internal/upstreams/flow/cache_request_processor_test.go
+++ b/internal/upstreams/flow/cache_request_processor_test.go
@@ -1,0 +1,199 @@
+package flow_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/quorum"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheRequestProcessorReceiveFromCacheSkipsDelegate(t *testing.T) {
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	delegate := NewRequestProcessorMock()
+	chain := chains.POLYGON
+	ctx := context.Background()
+	result := []byte("result")
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
+
+	cacheProcessor.On("Receive", ctx, chain, request).Return(result, true)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, delegate)
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	assert.IsType(t, &flow.UnaryResponse{}, response)
+	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
+	time.Sleep(10 * time.Millisecond)
+
+	// a cache hit must short-circuit the delegate entirely
+	delegate.AssertNotCalled(t, "ProcessRequest")
+	cacheProcessor.AssertNotCalled(t, "Store")
+	cacheProcessor.AssertExpectations(t)
+
+	assert.Equal(t, protocol.Cached, request.RequestObserver().GetRequestKind())
+	assert.Equal(t, "223", unaryRespWrapper.RequestId)
+	assert.Equal(t, flow.NoUpstream, unaryRespWrapper.UpstreamId)
+	assert.False(t, unaryRespWrapper.Response.HasError())
+	assert.False(t, unaryRespWrapper.Response.HasStream())
+	assert.Equal(t, result, unaryRespWrapper.Response.ResponseResult())
+}
+
+func TestCacheRequestProcessorQuorumSkipsCacheAndDelegates(t *testing.T) {
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	delegate := NewRequestProcessorMock()
+	chain := chains.POLYGON
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
+	delegateResponse := &flow.UnaryResponse{ResponseWrapper: &protocol.ResponseHolderWrapper{
+		UpstreamId: "id",
+		RequestId:  "223",
+		Response:   protocol.NewSimpleHttpUpstreamResponse("223", []byte("result"), protocol.JsonRpc),
+	}}
+
+	ctx := quorum.WithParams(context.Background(), quorum.Params{Quorum: 2, QuorumOf: 3})
+	// No cacheProcessor.On(...) — touching the cache under quorum fails the mock.
+	delegate.On("ProcessRequest", ctx, strategy, request).Return(delegateResponse)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, delegate)
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	time.Sleep(10 * time.Millisecond)
+
+	cacheProcessor.AssertNotCalled(t, "Receive")
+	cacheProcessor.AssertNotCalled(t, "Store")
+	delegate.AssertExpectations(t)
+	assert.Same(t, delegateResponse, response)
+}
+
+func TestCacheRequestProcessorMissDelegatesAndStores(t *testing.T) {
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	delegate := NewRequestProcessorMock()
+	chain := chains.POLYGON
+	ctx := context.Background()
+	result := []byte("result")
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
+	delegateResponse := &flow.UnaryResponse{ResponseWrapper: &protocol.ResponseHolderWrapper{
+		UpstreamId: "id",
+		RequestId:  "223",
+		Response:   protocol.NewSimpleHttpUpstreamResponse("223", result, protocol.JsonRpc),
+	}}
+
+	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
+	cacheProcessor.On("Store", ctx, chain, request, result).Return()
+	delegate.On("ProcessRequest", ctx, strategy, request).Return(delegateResponse)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, delegate)
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	time.Sleep(10 * time.Millisecond)
+
+	delegate.AssertExpectations(t)
+	cacheProcessor.AssertExpectations(t)
+	assert.Same(t, delegateResponse, response)
+}
+
+func TestCacheRequestProcessorErrorResponseNotStored(t *testing.T) {
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	delegate := NewRequestProcessorMock()
+	chain := chains.POLYGON
+	ctx := context.Background()
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
+	delegateResponse := &flow.UnaryResponse{ResponseWrapper: &protocol.ResponseHolderWrapper{
+		UpstreamId: flow.NoUpstream,
+		RequestId:  "223",
+		Response:   protocol.NewTotalFailureFromErr("223", assert.AnError, request.RequestType()),
+	}}
+
+	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
+	delegate.On("ProcessRequest", ctx, strategy, request).Return(delegateResponse)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, delegate)
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	time.Sleep(10 * time.Millisecond)
+
+	cacheProcessor.AssertNotCalled(t, "Store")
+	delegate.AssertExpectations(t)
+	cacheProcessor.AssertExpectations(t)
+	assert.Same(t, delegateResponse, response)
+}
+
+func TestCacheRequestProcessorSubscriptionResponseNotStored(t *testing.T) {
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	delegate := NewRequestProcessorMock()
+	chain := chains.POLYGON
+	ctx := context.Background()
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
+	delegateResponse := &flow.SubscriptionResponse{ResponseWrappers: make(chan *protocol.ResponseHolderWrapper)}
+
+	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
+	delegate.On("ProcessRequest", ctx, strategy, request).Return(delegateResponse)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, delegate)
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	time.Sleep(10 * time.Millisecond)
+
+	cacheProcessor.AssertNotCalled(t, "Store")
+	delegate.AssertExpectations(t)
+	cacheProcessor.AssertExpectations(t)
+	assert.Same(t, delegateResponse, response)
+}
+
+// TestCacheRequestProcessorWrappingUnaryStoresFreshResponse exercises the full
+// Cache(Unary) path: a cache miss runs the real unary processor against an
+// upstream and the fresh response is stored.
+func TestCacheRequestProcessorWrappingUnaryStoresFreshResponse(t *testing.T) {
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+	cacheProcessor := mocks.NewCacheProcessorMock()
+	apiConnector := mocks.NewConnectorMock()
+	chain := chains.POLYGON
+	ctx := context.Background()
+	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
+	_ = specs.NewMethodSpecLoader().Load()
+	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
+	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "eth")
+	result := []byte("result")
+	responseHolder := protocol.NewSimpleHttpUpstreamResponse("1", result, protocol.JsonRpc)
+
+	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
+	cacheProcessor.On("Store", ctx, chain, request, result).Return()
+	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+	apiConnector.On("SendRequest", ctx, request).Return(responseHolder)
+
+	processor := flow.NewCacheRequestProcessor(chain, cacheProcessor, flow.NewUnaryRequestProcessor(chain, upSupervisor))
+	response := processor.ProcessRequest(ctx, strategy, request)
+
+	assert.IsType(t, &flow.UnaryResponse{}, response)
+	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
+	time.Sleep(10 * time.Millisecond)
+
+	upSupervisor.AssertExpectations(t)
+	strategy.AssertExpectations(t)
+	cacheProcessor.AssertExpectations(t)
+	apiConnector.AssertExpectations(t)
+
+	assert.Equal(t, "id", unaryRespWrapper.UpstreamId)
+	assert.Equal(t, "223", unaryRespWrapper.RequestId)
+	assert.False(t, unaryRespWrapper.Response.HasError())
+	assert.Equal(t, result, unaryRespWrapper.Response.ResponseResult())
+}

--- a/internal/upstreams/flow/execution_flow.go
+++ b/internal/upstreams/flow/execution_flow.go
@@ -334,23 +334,23 @@ func (e *BaseExecutionFlow) createRequestProcessor(request protocol.RequestHolde
 	} else if request.SpecMethod().DispatchPolicy() != specs.DispatchDefault {
 		if e.dispatchEnabled(request.SpecMethod().DispatchPolicy()) {
 			if request.SpecMethod().DispatchPolicy() == specs.DispatchNotNull {
-				requestProcessor = NewNotNullRequestProcessor(e.upstreamSupervisor)
+				requestProcessor = NewCacheRequestProcessor(e.chain, e.cacheProcessor, NewNotNullRequestProcessor(e.upstreamSupervisor))
 			} else {
 				requestProcessor = NewFanoutRequestProcessor(e.upstreamSupervisor, request.SpecMethod().DispatchPolicy())
 			}
 		} else {
-			requestProcessor = NewUnaryRequestProcessor(e.chain, e.cacheProcessor, e.upstreamSupervisor)
+			requestProcessor = NewCacheRequestProcessor(e.chain, e.cacheProcessor, NewUnaryRequestProcessor(e.chain, e.upstreamSupervisor))
 		}
 		reqObserver.WithRequestKind(protocol.Unary)
 	} else if shouldEnforceIntegrity(request.SpecMethod(), e.appConfig.UpstreamConfig.IntegrityConfig) {
 		requestProcessor = NewIntegrityRequestProcessor(
 			e.chain,
 			e.upstreamSupervisor,
-			NewUnaryRequestProcessor(e.chain, e.cacheProcessor, e.upstreamSupervisor),
+			NewUnaryRequestProcessor(e.chain, e.upstreamSupervisor),
 		)
 		reqObserver.WithRequestKind(protocol.Unary)
 	} else {
-		requestProcessor = NewUnaryRequestProcessor(e.chain, e.cacheProcessor, e.upstreamSupervisor)
+		requestProcessor = NewCacheRequestProcessor(e.chain, e.cacheProcessor, NewUnaryRequestProcessor(e.chain, e.upstreamSupervisor))
 		reqObserver.WithRequestKind(protocol.Unary)
 	}
 

--- a/internal/upstreams/flow/execution_flow_dispatch_test.go
+++ b/internal/upstreams/flow/execution_flow_dispatch_test.go
@@ -67,7 +67,9 @@ func TestCreateRequestProcessorKeepsUnaryForFanoutDispatchDisabled(t *testing.T)
 
 	processor := exec.createRequestProcessor(request)
 
-	assert.IsType(t, &UnaryRequestProcessor{}, processor)
+	cacheProc, ok := processor.(*CacheRequestProcessor)
+	require.True(t, ok)
+	assert.IsType(t, &UnaryRequestProcessor{}, cacheProc.delegate)
 }
 
 func TestCreateStrategyRejectsQuorumForDispatchMethods(t *testing.T) {
@@ -100,7 +102,9 @@ func TestCreateRequestProcessorKeepsUnaryForDefaultMethods(t *testing.T) {
 
 	processor := exec.createRequestProcessor(request)
 
-	assert.IsType(t, &UnaryRequestProcessor{}, processor)
+	cacheProc, ok := processor.(*CacheRequestProcessor)
+	require.True(t, ok)
+	assert.IsType(t, &UnaryRequestProcessor{}, cacheProc.delegate)
 }
 
 func TestCreateRequestProcessorKeepsUnaryForNotNullDispatchDisabled(t *testing.T) {
@@ -117,7 +121,9 @@ func TestCreateRequestProcessorKeepsUnaryForNotNullDispatchDisabled(t *testing.T
 
 	processor := exec.createRequestProcessor(request)
 
-	assert.IsType(t, &UnaryRequestProcessor{}, processor)
+	cacheProc, ok := processor.(*CacheRequestProcessor)
+	require.True(t, ok)
+	assert.IsType(t, &UnaryRequestProcessor{}, cacheProc.delegate)
 }
 
 func TestCreateRequestProcessorUsesNotNullWhenEnabled(t *testing.T) {
@@ -136,5 +142,7 @@ func TestCreateRequestProcessorUsesNotNullWhenEnabled(t *testing.T) {
 
 	processor := exec.createRequestProcessor(request)
 
-	assert.IsType(t, &NotNullRequestProcessor{}, processor)
+	cacheProc, ok := processor.(*CacheRequestProcessor)
+	require.True(t, ok)
+	assert.IsType(t, &NotNullRequestProcessor{}, cacheProc.delegate)
 }

--- a/internal/upstreams/flow/request_processor.go
+++ b/internal/upstreams/flow/request_processor.go
@@ -7,10 +7,8 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/drpcorg/nodecore/internal/caches"
 	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
-	"github.com/drpcorg/nodecore/internal/quorum"
 	"github.com/drpcorg/nodecore/internal/upstreams"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -64,14 +62,12 @@ type RequestProcessor interface {
 
 type UnaryRequestProcessor struct {
 	chain              chains.Chain
-	cacheProcessor     caches.CacheProcessor
 	upstreamSupervisor upstreams.UpstreamSupervisor
 }
 
-func NewUnaryRequestProcessor(chain chains.Chain, cacheProcessor caches.CacheProcessor, upstreamSupervisor upstreams.UpstreamSupervisor) *UnaryRequestProcessor {
+func NewUnaryRequestProcessor(chain chains.Chain, upstreamSupervisor upstreams.UpstreamSupervisor) *UnaryRequestProcessor {
 	return &UnaryRequestProcessor{
 		chain:              chain,
-		cacheProcessor:     cacheProcessor,
 		upstreamSupervisor: upstreamSupervisor,
 	}
 }
@@ -83,11 +79,6 @@ func (u *UnaryRequestProcessor) ProcessRequest(
 ) ProcessedResponse {
 	var response *protocol.ResponseHolderWrapper
 	var err error
-	fromCache := false // don't store responses from cache
-	// Quorum-read requests are served fresh from drpc upstreams: cached payloads
-	// don't carry the QR* signature headers, so both cache Receive and Store
-	// are skipped here.
-	_, quorumRequested := quorum.FromContext(ctx)
 
 	if specs.IsSubscribeMethod(chains.GetMethodSpecNameByChain(u.chain), request.Method()) {
 		err = protocol.ClientError(fmt.Errorf("unable to process a subscription request %s", request.Method()))
@@ -97,35 +88,14 @@ func (u *UnaryRequestProcessor) ProcessRequest(
 			Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
 		}
 	} else {
-		var result []byte
-		var ok bool
-		if !quorumRequested {
-			result, ok = u.cacheProcessor.Receive(ctx, u.chain, request)
-		}
-		if ok {
-			// change the previous request type since it will not be sent to the upstream
-			request.RequestObserver().
-				WithRequestKind(protocol.Cached)
-			fromCache = true
+		response, err = executeUnaryRequest(ctx, u.chain, request, u.upstreamSupervisor, upstreamStrategy)
+		if err != nil {
 			response = &protocol.ResponseHolderWrapper{
 				UpstreamId: NoUpstream,
 				RequestId:  request.Id(),
-				Response:   protocol.NewSimpleHttpUpstreamResponse(request.Id(), result, request.RequestType()),
-			}
-		} else {
-			response, err = executeUnaryRequest(ctx, u.chain, request, u.upstreamSupervisor, upstreamStrategy)
-			if err != nil {
-				response = &protocol.ResponseHolderWrapper{
-					UpstreamId: NoUpstream,
-					RequestId:  request.Id(),
-					Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
-				}
+				Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
 			}
 		}
-	}
-
-	if !fromCache && !quorumRequested && !response.Response.HasError() && !response.Response.HasStream() {
-		go u.cacheProcessor.Store(ctx, u.chain, request, response.Response.ResponseResult())
 	}
 
 	return &UnaryResponse{ResponseWrapper: response}

--- a/internal/upstreams/flow/request_processor_test.go
+++ b/internal/upstreams/flow/request_processor_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
-	"github.com/drpcorg/nodecore/internal/quorum"
 	"github.com/drpcorg/nodecore/internal/upstreams/flow"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
@@ -25,12 +24,11 @@ func TestUnaryRequestProcessorSubMethodThenError(t *testing.T) {
 
 	upSupervisor := mocks.NewUpstreamSupervisorMock()
 	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
 	chain := chains.ALEPHZERO
 	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_subscribe"}
 	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
 
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
+	processor := flow.NewUnaryRequestProcessor(chain, upSupervisor)
 	response := processor.ProcessRequest(context.Background(), strategy, request)
 
 	assert.IsType(t, &flow.UnaryResponse{}, response)
@@ -40,8 +38,6 @@ func TestUnaryRequestProcessorSubMethodThenError(t *testing.T) {
 	upSupervisor.AssertNotCalled(t, "GetExecutor")
 	upSupervisor.AssertNotCalled(t, "GetUpstream")
 	strategy.AssertNotCalled(t, "SelectUpstream")
-	cacheProcessor.AssertNotCalled(t, "Store")
-	cacheProcessor.AssertNotCalled(t, "Receive")
 
 	assert.Equal(t, flow.NoUpstream, unaryRespWrapper.UpstreamId)
 	assert.Equal(t, "223", unaryRespWrapper.RequestId)
@@ -49,95 +45,27 @@ func TestUnaryRequestProcessorSubMethodThenError(t *testing.T) {
 	assert.Equal(t, protocol.ResponseErrorWithData(400, "client error - unable to process a subscription request eth_subscribe", nil), unaryRespWrapper.Response.GetError())
 }
 
-func TestUnaryRequestProcessorReceiveFromCache(t *testing.T) {
-	upSupervisor := mocks.NewUpstreamSupervisorMock()
-	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
-	chain := chains.POLYGON
-	ctx := context.Background()
-	result := []byte("result")
-	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
-	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
-
-	cacheProcessor.On("Receive", ctx, chain, request).Return(result, true)
-
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
-	response := processor.ProcessRequest(context.Background(), strategy, request)
-
-	assert.IsType(t, &flow.UnaryResponse{}, response)
-
-	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
-	time.Sleep(10 * time.Millisecond)
-
-	upSupervisor.AssertNotCalled(t, "GetExecutor")
-	upSupervisor.AssertNotCalled(t, "GetUpstream")
-	strategy.AssertNotCalled(t, "SelectUpstream")
-	cacheProcessor.AssertNotCalled(t, "Store")
-	cacheProcessor.AssertExpectations(t)
-
-	assert.Equal(t, protocol.Cached, request.RequestObserver().GetRequestKind())
-	assert.Equal(t, "223", unaryRespWrapper.RequestId)
-	assert.Equal(t, flow.NoUpstream, unaryRespWrapper.UpstreamId)
-	assert.False(t, unaryRespWrapper.Response.HasError())
-	assert.False(t, unaryRespWrapper.Response.HasStream())
-	assert.Equal(t, result, unaryRespWrapper.Response.ResponseResult())
-}
-
-func TestUnaryRequestProcessor_QuorumSkipsCacheReadAndStore(t *testing.T) {
-	upSupervisor := mocks.NewUpstreamSupervisorMock()
-	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
-	chain := chains.POLYGON
-	err := errors.New("select err")
-	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
-	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
-
-	// No cacheProcessor.On("Receive", ...) / ("Store", ...) — if the processor
-	// touches the cache when quorum is requested, the mock will fail.
-	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
-	strategy.On("SelectUpstream", request).Return("", err)
-
-	ctx := quorum.WithParams(context.Background(), quorum.Params{Quorum: 2, QuorumOf: 3})
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
-	response := processor.ProcessRequest(ctx, strategy, request)
-
-	time.Sleep(10 * time.Millisecond)
-
-	cacheProcessor.AssertNotCalled(t, "Receive")
-	cacheProcessor.AssertNotCalled(t, "Store")
-
-	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
-	assert.Equal(t, "223", unaryRespWrapper.RequestId)
-	assert.True(t, unaryRespWrapper.Response.HasError())
-}
-
 func TestUnaryRequestProcessorCantGetUpstreamThenError(t *testing.T) {
 	upSupervisor := mocks.NewUpstreamSupervisorMock()
 	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
 	chain := chains.POLYGON
-	ctx := context.Background()
 	err := errors.New("selection error")
 	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
 	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
 
-	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
 	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
 	strategy.On("SelectUpstream", request).Return("", err)
 
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
+	processor := flow.NewUnaryRequestProcessor(chain, upSupervisor)
 	response := processor.ProcessRequest(context.Background(), strategy, request)
 
 	assert.IsType(t, &flow.UnaryResponse{}, response)
 
 	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
-	time.Sleep(10 * time.Millisecond)
 
 	upSupervisor.AssertNotCalled(t, "GetUpstream")
-	cacheProcessor.AssertNotCalled(t, "Store")
 	upSupervisor.AssertExpectations(t)
 	strategy.AssertExpectations(t)
-	cacheProcessor.AssertExpectations(t)
 
 	assert.Equal(t, flow.NoUpstream, unaryRespWrapper.UpstreamId)
 	assert.Equal(t, "223", unaryRespWrapper.RequestId)
@@ -148,76 +76,30 @@ func TestUnaryRequestProcessorCantGetUpstreamThenError(t *testing.T) {
 func TestUnaryRequestProcessorNoConnectorThenError(t *testing.T) {
 	upSupervisor := mocks.NewUpstreamSupervisorMock()
 	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
 	apiConnector := mocks.NewConnectorMockWithType(specs.RestConnector)
 	chain := chains.POLYGON
-	ctx := context.Background()
 	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
 	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
 	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "")
 
-	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
 	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
 	strategy.On("SelectUpstream", request).Return("id", nil)
 	upSupervisor.On("GetUpstream", "id").Return(upstream)
 
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
+	processor := flow.NewUnaryRequestProcessor(chain, upSupervisor)
 	response := processor.ProcessRequest(context.Background(), strategy, request)
 
 	assert.IsType(t, &flow.UnaryResponse{}, response)
 
 	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
-	time.Sleep(10 * time.Millisecond)
 
-	cacheProcessor.AssertNotCalled(t, "Store")
 	upSupervisor.AssertExpectations(t)
 	strategy.AssertExpectations(t)
-	cacheProcessor.AssertExpectations(t)
 
 	assert.Equal(t, flow.NoUpstream, unaryRespWrapper.UpstreamId)
 	assert.Equal(t, "223", unaryRespWrapper.RequestId)
 	assert.True(t, unaryRespWrapper.Response.HasError())
 	assert.Equal(t, protocol.ResponseErrorWithData(protocol.NoApiConnectors, "no suitable api connectors to process method eth_call", nil), unaryRespWrapper.Response.GetError())
-}
-
-func TestUnaryRequestProcessorReceiveResponseThenStoreInCache(t *testing.T) {
-	upSupervisor := mocks.NewUpstreamSupervisorMock()
-	strategy := mocks.NewMockStrategy()
-	cacheProcessor := mocks.NewCacheProcessorMock()
-	apiConnector := mocks.NewConnectorMock()
-	chain := chains.POLYGON
-	ctx := context.Background()
-	upstream := test_utils.TestEvmUpstream(apiConnector, upConfig(), mocks.NewMethodsMock(), nil)
-	_ = specs.NewMethodSpecLoader().Load()
-	jsonBody := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_call"}
-	request := protocol.NewUpstreamJsonRpcRequest("223", jsonBody, false, "eth")
-	result := []byte("result")
-	responseHolder := protocol.NewSimpleHttpUpstreamResponse("1", result, protocol.JsonRpc)
-
-	cacheProcessor.On("Receive", ctx, chain, request).Return([]byte{}, false)
-	cacheProcessor.On("Store", ctx, chain, request, result).Return()
-	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
-	strategy.On("SelectUpstream", request).Return("id", nil)
-	upSupervisor.On("GetUpstream", "id").Return(upstream)
-	apiConnector.On("SendRequest", ctx, request).Return(responseHolder)
-
-	processor := flow.NewUnaryRequestProcessor(chain, cacheProcessor, upSupervisor)
-	response := processor.ProcessRequest(context.Background(), strategy, request)
-
-	assert.IsType(t, &flow.UnaryResponse{}, response)
-
-	unaryRespWrapper := response.(*flow.UnaryResponse).ResponseWrapper
-	time.Sleep(10 * time.Millisecond)
-
-	upSupervisor.AssertExpectations(t)
-	strategy.AssertExpectations(t)
-	cacheProcessor.AssertExpectations(t)
-	apiConnector.AssertExpectations(t)
-
-	assert.Equal(t, "id", unaryRespWrapper.UpstreamId)
-	assert.Equal(t, "223", unaryRespWrapper.RequestId)
-	assert.False(t, unaryRespWrapper.Response.HasError())
-	assert.Equal(t, result, unaryRespWrapper.Response.ResponseResult())
 }
 
 func upConfig() *config.Upstream {

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -31,6 +31,16 @@ const (
 	Aztec               BlockchainType = "aztec"
 )
 
+func IsValidBlockchainType(t string) bool {
+	switch BlockchainType(t) {
+	case Algorand, Bitcoin, Cosmos, Ethereum, EthereumBeaconChain,
+		Near, Polkadot, Solana, Starknet, Ton, Aztec:
+		return true
+	default:
+		return false
+	}
+}
+
 //go:embed public/chains.yaml
 var chainsCfg []byte
 

--- a/pkg/test_utils/test_helpers.go
+++ b/pkg/test_utils/test_helpers.go
@@ -102,6 +102,19 @@ func PolicyConfig(chain, method, connector, maxSize, ttl string, cacheEmpty bool
 	}
 }
 
+func PolicyConfigBlockchainType(blockchainType, method, connector, maxSize, ttl string, cacheEmpty bool) *config.CachePolicyConfig {
+	return &config.CachePolicyConfig{
+		Id:               "policy",
+		BlockchainType:   blockchainType,
+		Method:           method,
+		FinalizationType: config.None,
+		CacheEmpty:       cacheEmpty,
+		Connector:        connector,
+		ObjectMaxSize:    maxSize,
+		TTL:              ttl,
+	}
+}
+
 func PolicyConfigFinalized(chain, method, connector, maxSize, ttl string, cacheEmpty bool) *config.CachePolicyConfig {
 	return &config.CachePolicyConfig{
 		Id:               "policy",


### PR DESCRIPTION
# Add `blockchain-type` to cache policies + make caching a request-processor decorator

## Why

Two related cache improvements:

1. **Family-level cache policies.** Cache policies could only target chains by name
   (`chain: optimism|polygon|ethereum`). Caching a method across a whole family
   (e.g. every EVM chain) meant enumerating every chain. This adds a
   `blockchain-type` selector so a single policy can cover a family.

2. **Caching was hard-wired into `UnaryRequestProcessor`.** The cache `Receive`/`Store`
   calls lived inside `UnaryRequestProcessor.ProcessRequest`, which made caching a leaf
   detail of one processor. Consequences:
   - Other processors that return a cacheable single response (notably
     `NotNullRequestProcessor`) never touched the cache.
   - Expensive processors ran their full work even when the answer was already cached —
     `NotNullRequestProcessor` walks candidate upstreams sequentially, and with the
     cache buried in a sibling processor that never ran, a cached answer couldn't
     short-circuit that walk.

   This lifts caching into a `CacheRequestProcessor` **decorator** that wraps any inner
   `RequestProcessor`, mirroring the existing wrapping idiom in
   `IntegrityRequestProcessor`.

## What changed

### `blockchain-type` cache policy selector

- New `blockchain-type` field on `CachePolicyConfig` (`internal/config/cache_config.go`).
  Mutually exclusive with `chain` — validation now requires **exactly one** of the two
  (`chain and blockchain-type are mutually exclusive` / `either chain or blockchain-type
  must be set`). Accepts `*`, or a `|`-separated list (e.g. `eth|solana`).
- `chains.IsValidBlockchainType` (`pkg/chains/chains.go`) validates type strings against
  the known families (`eth`, `eth-beacon-chain`, `solana`, `avm`, `aztec`, `cosmos`,
  `ton`, `bitcoin`, `near`, `polkadot`, `starknet`).
- `CachePolicy` gains a `blockchainTypes` set and a `blockchainTypeNotMatched` check
  wired into `baseCacheableCheck` (`internal/caches/cache_policies.go`). A request matches
  when its chain's `Type` is in the policy's set (empty set = match all).
- Docs updated (`docs/nodecore/04-cache.md`) and validation test fixtures added
  (`internal/config/configs/cache/cache-chain-and-blockchain-type.yaml`,
  `cache-not-supported-blockchain-type.yaml`).

### Caching as a decorator

- **New** `internal/upstreams/flow/cache_request_processor.go` — `CacheRequestProcessor`
  wraps an inner `RequestProcessor`:
  - On a quorum request → delegates straight through with no cache access (quorum reads
    must be served fresh from drpc upstreams so they carry the QR signature headers).
  - On a cache **hit** → returns the cached `*UnaryResponse`, marks the request kind
    `Cached`, and **does not call the delegate** (so e.g. NotNull stops walking upstreams).
  - On a cache **miss** → delegates, then `Store`s the result only when it's a
    `*UnaryResponse` with no error and no stream. A `*SubscriptionResponse` is never stored.
- `UnaryRequestProcessor` (`request_processor.go`) loses its `cacheProcessor` field/param
  and all Receive/Store logic; it now just runs the subscribe guard and
  `executeUnaryRequest`.
- `createRequestProcessor` (`execution_flow.go`) wraps with `NewCacheRequestProcessor` at
  the cacheable sites: the default unary case, the dispatch-disabled fallback, and the
  **NotNull** dispatch path. `Fanout`, `Sticky`, `Local`, `Subscription`, and the
  `Integrity` branch are left unwrapped.
- Removed the now-redundant `request.IsStream()` early-return from `baseCacheableCheck`;
  stream gating now lives at the response level in the decorator's store condition.

### Behavior change to note

`IntegrityRequestProcessor`'s inner `UnaryRequestProcessor` is **not** wrapped, so its
quorum / no-op-fallback delegate path no longer caches. The methods Integrity actually
enforces (`eth_blockNumber`, `eth_getBlockByNumber`) were never cached anyway — Integrity
calls `executeUnaryRequest` directly for those. `Fanout` stays uncached to avoid
short-circuiting a stale max-value head.
