### PR TITLE
Add hypercore label info detector

### DIFF
--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
@@ -22,15 +22,17 @@ import (
 	"github.com/drpcorg/nodecore/pkg/chains"
 	specs "github.com/drpcorg/nodecore/pkg/methods"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/samber/lo"
 )
 
 type EvmChainSpecificObject struct {
-	ctx          context.Context
-	upstreamId   string
-	pollInterval time.Duration
-	connector    connectors.ApiConnector
-	chain        *chains.ConfiguredChain
-	options      *chains.Options
+	ctx           context.Context
+	upstreamId    string
+	pollInterval  time.Duration
+	connector     connectors.ApiConnector
+	allConnectors []connectors.ApiConnector
+	chain         *chains.ConfiguredChain
+	options       *chains.Options
 }
 
 func (e *EvmChainSpecificObject) BlockProcessor() blocks.BlockProcessor {
@@ -47,6 +49,10 @@ func (e *EvmChainSpecificObject) BlockProcessor() blocks.BlockProcessor {
 }
 
 func (e *EvmChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
+	restAdditional, _ := lo.Find(e.allConnectors, func(c connectors.ApiConnector) bool {
+		return c.GetType() == specs.RestAdditional
+	})
+
 	labelsDetectors := []labels.LabelsDetector{
 		labels.NewClientLabelDetectorHandler(
 			e.upstreamId,
@@ -57,6 +63,7 @@ func (e *EvmChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 		eth_labels.NewEthGasLabelsDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
 		eth_labels.NewEthFlashBlockDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
 		eth_labels.NewEthHLTxLabelsDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout*2, e.connector),
+		eth_labels.NewEthAllInfoLabelsDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, restAdditional),
 		archiveLabelsDetector(e),
 	}
 
@@ -199,17 +206,19 @@ func NewEvmChainSpecific(
 	ctx context.Context,
 	upstreamId string,
 	connector connectors.ApiConnector,
+	allConnectors []connectors.ApiConnector,
 	chain *chains.ConfiguredChain,
 	pollInterval time.Duration,
 	options *chains.Options,
 ) *EvmChainSpecificObject {
 	return &EvmChainSpecificObject{
-		ctx:          ctx,
-		upstreamId:   upstreamId,
-		connector:    connector,
-		chain:        chain,
-		options:      options,
-		pollInterval: pollInterval,
+		ctx:           ctx,
+		upstreamId:    upstreamId,
+		connector:     connector,
+		allConnectors: allConnectors,
+		chain:         chain,
+		options:       options,
+		pollInterval:  pollInterval,
 	}
 }
 

--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific_test.go
@@ -32,14 +32,14 @@ func TestChainValidator(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	chain := chains.GetChain("ethereum")
 
-	validators := specific.NewEvmChainSpecific(context.Background(), "id", connector, chain, 1*time.Second, options).SettingsValidators()
+	validators := specific.NewEvmChainSpecific(context.Background(), "id", connector, nil, chain, 1*time.Second, options).SettingsValidators()
 
 	assert.Len(t, validators, 0)
 
 	options.DisableChainValidation = new(false)
 	options.ValidateCallLimit = new(true)
 
-	validators = specific.NewEvmChainSpecific(context.Background(), "id", connector, chain, 1*time.Second, options).SettingsValidators()
+	validators = specific.NewEvmChainSpecific(context.Background(), "id", connector, nil, chain, 1*time.Second, options).SettingsValidators()
 
 	assert.Len(t, validators, 2)
 	assert.True(t, lo.SomeBy(validators, func(item validations.Validator[validations.ValidationSettingResult]) bool {
@@ -177,6 +177,7 @@ func newEvmChainSpecificForChain(chainName string) *specific.EvmChainSpecificObj
 		context.Background(),
 		"id",
 		mocks.NewConnectorMock(),
+		nil,
 		chains.GetChain(chainName),
 		time.Second,
 		&chains.Options{InternalTimeout: time.Second},

--- a/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
+++ b/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
@@ -209,7 +209,7 @@ func NewTronSpecific(
 	case specs.RestConnector:
 		return newTronRestSpecific(ctx, upstreamId, connector, chain, pollInterval, options)
 	case specs.JsonRpcConnector:
-		return evm_specific.NewEvmChainSpecific(ctx, upstreamId, connector, chain, pollInterval, options), nil
+		return evm_specific.NewEvmChainSpecific(ctx, upstreamId, connector, []connectors.ApiConnector{connector}, chain, pollInterval, options), nil
 	default:
 		return nil, fmt.Errorf("tron specific supports only json-rpc or rest connector but not %s", connector.GetType())
 	}

--- a/internal/upstreams/labels/eth_labels/eth_all_info_detector.go
+++ b/internal/upstreams/labels/eth_labels/eth_all_info_detector.go
@@ -1,0 +1,68 @@
+package eth_labels
+
+import (
+	"context"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/rs/zerolog/log"
+)
+
+// allInfoProbeBody is the cheapest parameterless HyperCore `info` request. It
+// succeeds (HTTP 200) only on the public node and returns 422 on custom nodes,
+// so it cleanly distinguishes upstreams that can serve the full `info` set.
+var allInfoProbeBody = []byte(`{"type":"allMids"}`)
+
+// EthAllInfoLabelsDetector probes the HyperCore `info` endpoint via the
+// rest-additional connector and emits the "allInfo" label: "true" when the
+// upstream can serve public-only info methods (allMids succeeds), "false"
+// otherwise. It is a no-op (returns nil) for non-Hyperliquid chains or when no
+// rest-additional connector is configured.
+type EthAllInfoLabelsDetector struct {
+	upstreamId      string
+	chain           chains.Chain
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+}
+
+func (e *EthAllInfoLabelsDetector) DetectLabels() map[string]string {
+	if e.chain != chains.HYPERLIQUID || e.connector == nil {
+		return nil
+	}
+
+	req := protocol.NewInternalUpstreamRestRequestWithBody("POST", "/info", allInfoProbeBody, e.chain)
+
+	ctx, cancel := context.WithTimeout(context.Background(), e.internalTimeout)
+	defer cancel()
+
+	resp := e.connector.SendRequest(ctx, req)
+	value := "true"
+	if resp.HasError() {
+		value = "false"
+		log.Error().Err(resp.GetError()).Msgf("allMids info probe failed for upstream '%s', marking allInfo=false", e.upstreamId)
+	}
+	return map[string]string{"allInfo": value}
+}
+
+func NewEthAllInfoLabelsDetector(
+	upstreamId string,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EthAllInfoLabelsDetector {
+	if connector != nil && connector.GetType() != specs.RestAdditional {
+		log.Warn().Msgf("hyperliquid info label probe only supported for restAdditional connector, it won't work for upstream '%s'", upstreamId)
+	}
+	return &EthAllInfoLabelsDetector{
+		upstreamId:      upstreamId,
+		chain:           chain,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+	}
+}
+
+var _ labels.LabelsDetector = (*EthAllInfoLabelsDetector)(nil)

--- a/internal/upstreams/labels/eth_labels/eth_all_info_detector_test.go
+++ b/internal/upstreams/labels/eth_labels/eth_all_info_detector_test.go
@@ -1,0 +1,70 @@
+package eth_labels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/eth_labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func matchAllMidsInfoRequest(request protocol.RequestHolder) bool {
+	if request == nil || request.Method() != "POST#/info" || request.RequestType() != protocol.Rest {
+		return false
+	}
+	body, err := request.Body()
+	if err != nil {
+		return false
+	}
+	return string(body) == `{"type":"allMids"}`
+}
+
+func TestEthAllInfoLabelsDetectorReturnsNilForNonHyperliquidChain(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	detector := eth_labels.NewEthAllInfoLabelsDetector("upstream-id", chains.ETHEREUM, time.Second, connector)
+
+	result := detector.DetectLabels()
+
+	assert.Nil(t, result)
+	connector.AssertNotCalled(t, "SendRequest", mock.Anything, mock.Anything)
+}
+
+func TestEthAllInfoLabelsDetectorReturnsNilWhenConnectorIsNil(t *testing.T) {
+	detector := eth_labels.NewEthAllInfoLabelsDetector("upstream-id", chains.HYPERLIQUID, time.Second, nil)
+
+	assert.Nil(t, detector.DetectLabels())
+}
+
+func TestEthAllInfoLabelsDetectorReturnsTrueWhenInfoSucceeds(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchAllMidsInfoRequest)).
+		Return(protocol.NewHttpUpstreamResponse("1", []byte(`{"BTC":"1"}`), 200, protocol.Rest)).
+		Once()
+
+	detector := eth_labels.NewEthAllInfoLabelsDetector("upstream-id", chains.HYPERLIQUID, time.Second, connector)
+
+	result := detector.DetectLabels()
+
+	assert.Equal(t, map[string]string{"allInfo": "true"}, result)
+	connector.AssertExpectations(t)
+}
+
+func TestEthAllInfoLabelsDetectorReturnsFalseWhenInfoErrors(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchAllMidsInfoRequest)).
+		Return(protocol.NewHttpUpstreamResponse("1", []byte(`Failed to deserialize the JSON body into the target type`), 422, protocol.Rest)).
+		Once()
+
+	detector := eth_labels.NewEthAllInfoLabelsDetector("upstream-id", chains.HYPERLIQUID, time.Second, connector)
+
+	result := detector.DetectLabels()
+
+	assert.Equal(t, map[string]string{"allInfo": "false"}, result)
+	connector.AssertExpectations(t)
+}

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -203,6 +203,7 @@ func getChainSpecific(
 			ctx,
 			conf.Id,
 			upstreamConnectorsInfo.internalRequestConnector,
+			upstreamConnectorsInfo.allConnectors,
 			configuredChain,
 			conf.PollInterval,
 			conf.Options,

--- a/internal/upstreams/upstream_processors_test.go
+++ b/internal/upstreams/upstream_processors_test.go
@@ -23,7 +23,7 @@ func TestCreateHeadEventProcessor_ReturnsHeadProcessor(t *testing.T) {
 		Options:      testUpstreamOptions(),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(conf.ChainName), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(conf.ChainName), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateHeadEventProcessor(context.Background(), conf, connector, chainSpecific, chains.POLYGON)
 
@@ -38,7 +38,7 @@ func TestCreateHealthEventProcessor_ReturnsNilWithoutValidators(t *testing.T) {
 		Options: testUpstreamOptions(),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateHealthEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -92,7 +92,7 @@ func TestCreateSettingsEventProcessor_ReturnsNilWhenValidatorsDisabledByChainSpe
 		Options: testUpstreamOptions(withDisableChainValidation(true)),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateSettingsEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -105,7 +105,7 @@ func TestCreateSettingsEventProcessor_ReturnsNilOnlyWhenSettingsValidationDisabl
 		Options: testUpstreamOptions(withDisableSettingsValidation(true)),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateSettingsEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -118,7 +118,7 @@ func TestCreateSettingsEventProcessor_ReturnsNilWhenOnlyGlobalValidationDisabled
 		Options: testUpstreamOptions(withDisableValidation(true)),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateSettingsEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -131,7 +131,7 @@ func TestCreateSettingsEventProcessor_ReturnsSettingsProcessor(t *testing.T) {
 		Options: testUpstreamOptions(),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateSettingsEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -146,7 +146,7 @@ func TestCreateLowerBoundsEventProcessor_ReturnsProcessorForEvm(t *testing.T) {
 		Options: testUpstreamOptions(),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateLowerBoundsEventProcessor(context.Background(), conf, chainSpecific)
 
@@ -230,7 +230,7 @@ func TestCreateBlockEventProcessor_ReturnsProcessorForEthereum(t *testing.T) {
 		Options: testUpstreamOptions(),
 	}
 	connector := mocks.NewConnectorMock()
-	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
+	chainSpecific := evm_specific.NewEvmChainSpecific(context.Background(), conf.Id, connector, nil, chains.GetChain(chains.POLYGON.String()), conf.PollInterval, conf.Options)
 
 	processor := upstreams.CreateBlockEventProcessor(context.Background(), conf, chainSpecific, chains.GetChain(chains.ETHEREUM.String()))
 

--- a/pkg/test_utils/test_helpers.go
+++ b/pkg/test_utils/test_helpers.go
@@ -217,6 +217,7 @@ func NewEvmChainSpecific(connector connectors.ApiConnector) *evm_specific.EvmCha
 		context.Background(),
 		"id",
 		connector,
+		nil,
 		chains.GetChain("polygon"),
 		1*time.Second,
 		newTestChainOptions(),


### PR DESCRIPTION
# Add HyperCore `allInfo` label detector

## What

Adds a new per-upstream label detector for Hyperliquid that probes the HyperCore `info` API and emits an **`allInfo`** label:

- `allInfo: "true"` — the upstream can serve the full HyperCore `info` method set (it's effectively the public node).
- `allInfo: "false"` — the upstream is a custom/self-hosted node that only serves the local-state subset of `info` methods.

The label is intended for routing: HyperCore has a set of `info` methods (e.g. `allMids`, `metaAndAssetCtxs`, `predictedFundings`, `spotMetaAndAssetCtxs`) that are served **only** by the public node (`api.hyperliquid.xyz`) and return `422 "Failed to deserialize the JSON body into the target type"` on a self-hosted node. With `allInfo` we can detect, per upstream, whether those public-only methods can be routed there.

## Why `allMids`

We probed a real custom node against the public API. Of the 35 candidate "public-only" methods, the custom node actually serves 14 and rejects 21. `allMids` is the ideal probe:

- **Parameterless** — no `user`/`coin`/`oid` to synthesize.
- **Cheap & fast** — small response, ~0.7s.
- **Clean discriminator** — `200` on the public node, `422` on a custom node.

## How it works

`EthAllInfoLabelsDetector` (`internal/upstreams/labels/eth_labels/eth_all_info_detector.go`):

1. No-ops (returns `nil`, no label) unless `chain == chains.HYPERLIQUID` and a rest-additional connector is present — mirroring the existing `EthHLTxLabelsDetector` gating convention.
2. Sends `POST /info` with body `{"type":"allMids"}` through the **rest-additional** connector.
3. `parseHttpResponse` turns any non-2xx into a `ResponseError`, so `HasError() == false` (200) ⇒ `allInfo:true`; any error / `422` ⇒ `allInfo:false`.

The probe must go through the **rest-additional** connector (`specs.RestAdditional`, which carries HyperCore's `POST /info` + `POST /exchange` methods) — never the default JSON-RPC connector. The constructor logs a warning if handed a connector of the wrong type.

## Changes

- **New:** `eth_all_info_detector.go` + `eth_all_info_detector_test.go`.
- **`evm_chain_specific.go`:** `EvmChainSpecificObject` now carries the full `allConnectors []connectors.ApiConnector` list (passed into `NewEvmChainSpecific`). `LabelsProcessor()` selects the rest-additional connector via `lo.Find(... GetType() == specs.RestAdditional)` and appends the detector unconditionally (it self-gates internally).
- **`upstream_factory.go`:** passes `upstreamConnectorsInfo.allConnectors` into the constructor (no pre-selection at the call site).
- **Call-site updates** for the new constructor param: `tron_rest_specific.go`, `pkg/test_utils/test_helpers.go`, `upstream_processors_test.go`, `evm_chain_specific_test.go`.

## Notes

- Scope is `chains.HYPERLIQUID` (mainnet, string `"hyperliquid"`) only; testnet is intentionally excluded.
- The label is only emitted for upstreams that have a `rest-additional` connector configured (pointing at the node's `/info` base). Hyperliquid upstreams without one simply carry no `allInfo` label.
