### PR TITLE
fix: sanitize metric label values to prevent panic on invalid UTF-8

### DIFF
--- a/internal/dimensions/dims.go
+++ b/internal/dimensions/dims.go
@@ -132,7 +132,9 @@ func newUpstreamDimensionKey(chain chains.Chain, upstreamId, method string) upst
 	return upstreamDimensionKey{
 		chain:      chain,
 		upstreamId: upstreamId,
-		method:     method,
+		// method feeds Prometheus labels (see dims.go metric calls); sanitize so
+		// an invalid-UTF-8 method can never panic client_golang.
+		method: utils.SanitizeMetricLabel(method),
 	}
 }
 

--- a/internal/upstreams/flow/execution_flow.go
+++ b/internal/upstreams/flow/execution_flow.go
@@ -254,7 +254,8 @@ func hasHttpConnector(up upstreams.Upstream, requestType protocol.RequestType) b
 func (e *BaseExecutionFlow) processRequest(ctx context.Context, upstreamStrategy UpstreamStrategy, request protocol.RequestHolder) {
 	go func() {
 		defer e.wg.Done()
-		requestTotalMetric.WithLabelValues(e.chain.String(), request.Method()).Inc()
+		metricMethod := utils.SanitizeMetricLabel(request.Method())
+		requestTotalMetric.WithLabelValues(e.chain.String(), metricMethod).Inc()
 
 		if request.SpecMethod() == nil {
 			response := protocol.NewTotalFailure(request, protocol.NotSupportedMethodError(request.Method()))
@@ -291,7 +292,7 @@ func (e *BaseExecutionFlow) processRequest(ctx context.Context, upstreamStrategy
 			e.verifyQuorumSignatures(ctx, request, resp.ResponseWrapper)
 
 			if protocol.IsRetryable(resp.ResponseWrapper.Response) {
-				requestErrorsMetric.WithLabelValues(e.chain.String(), request.Method()).Inc()
+				requestErrorsMetric.WithLabelValues(e.chain.String(), metricMethod).Inc()
 			}
 
 			reqObserver.AddResult(

--- a/internal/upstreams/flow/request_processor.go
+++ b/internal/upstreams/flow/request_processor.go
@@ -143,7 +143,7 @@ func executeUnaryRequest(
 
 	if hedged.Load() {
 		// it's important to track the very first upstream that caused the hedge logic
-		hedgeMetric.WithLabelValues(chain.String(), request.Method(), firstUpstream.Load()).Inc()
+		hedgeMetric.WithLabelValues(chain.String(), utils.SanitizeMetricLabel(request.Method()), firstUpstream.Load()).Inc()
 	}
 
 	return result, err

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -3,7 +3,24 @@ package utils
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
+
+// SanitizeMetricLabel makes s safe to use as a Prometheus label value.
+//
+// client_golang panics ("label value ... is not valid UTF-8") when a label
+// value contains invalid UTF-8, and that panic happens inside detached
+// goroutines with no recover, so it crashes the whole process. Any label value
+// derived from untrusted input - most notably a REST request method, which is
+// "<VERB>#<path>" built from the raw request URI - must be passed through this
+// first. Valid input is returned unchanged; invalid byte sequences are replaced
+// with the Unicode replacement character.
+func SanitizeMetricLabel(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, "�")
+}
 
 func WildcardToRegex(pattern string) string {
 	components := strings.Split(pattern, "*")

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -1,0 +1,43 @@
+package utils_test
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeMetricLabel_ValidUnchanged(t *testing.T) {
+	for _, s := range []string{"", "GET#/v2/status", "POST#/wallet/getblock", "юникод"} {
+		assert.Equal(t, s, utils.SanitizeMetricLabel(s))
+	}
+}
+
+func TestSanitizeMetricLabel_InvalidBecomesValid(t *testing.T) {
+	// The exact byte sequence that crashed nodecore in production:
+	// a REST request method "GET#/" followed by the invalid byte 0xC0.
+	bad := "GET#/" + string([]byte{0xc0})
+	require.False(t, utf8.ValidString(bad))
+
+	got := utils.SanitizeMetricLabel(bad)
+	assert.True(t, utf8.ValidString(got))
+	assert.Equal(t, "GET#/�", got)
+}
+
+// TestSanitizeMetricLabel_PrometheusDoesNotPanic is the regression test for the
+// crash: client_golang panics on invalid-UTF-8 label values, so the sanitized
+// value must be accepted by a CounterVec.
+func TestSanitizeMetricLabel_PrometheusDoesNotPanic(t *testing.T) {
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "sanitize_metric_label_test_total"},
+		[]string{"method"},
+	)
+	bad := "GET#/" + string([]byte{0xc0})
+
+	assert.NotPanics(t, func() {
+		counter.WithLabelValues(utils.SanitizeMetricLabel(bad)).Inc()
+	})
+}


### PR DESCRIPTION
## Problem

A malformed public request whose URI contains non-UTF-8 bytes (e.g. `GET /\xc0`) is turned into a REST request method string of the form `"<VERB>#<path>"`, i.e. `"GET#/\xc0"`. That method string is then used **verbatim as a Prometheus label value**.

`client_golang` panics when a label value is not valid UTF-8:

```
panic: label value "GET#/\xc0" is not valid UTF-8

prometheus.(*CounterVec).WithLabelValues
  flow.(*BaseExecutionFlow).processRequest.func1
    internal/upstreams/flow/execution_flow.go
created by flow.(*BaseExecutionFlow).processRequest
```

The panic happens inside the detached goroutine spawned in `processRequest`, which has **no `recover()`**, so it tears down the whole process (`exit 2`). Because the REST endpoint is public, any client can send a single malformed request and trigger a crash loop.

## Affected label sites

Every label value derived from `request.Method()`:

- `internal/upstreams/flow/execution_flow.go` — `requestTotalMetric`, `requestErrorsMetric`
- `internal/upstreams/flow/request_processor.go` — `hedgeMetric`
- `internal/dimensions/dims.go` — request total/errors/retries/duration (via the dimension key)

## Fix

Add `utils.SanitizeMetricLabel`, which returns valid UTF-8 unchanged and replaces invalid byte sequences with the Unicode replacement character (`U+FFFD`), and apply it to every label value derived from `request.Method()`.

The change is confined to the **metric boundary** — request routing, spec-method resolution and upstream forwarding all still see the original, unmodified method string, so there is no behavioral change for legitimate traffic.

## Tests

`pkg/utils/strings_test.go`:
- valid input is returned unchanged
- the exact production byte sequence (`GET#/` + `0xC0`) becomes valid UTF-8
- a `CounterVec.WithLabelValues` call with the sanitized value does **not** panic (direct regression for the crash)

`go build ./...` and `go test ./pkg/utils/ ./internal/upstreams/flow/ ./internal/dimensions/` pass.
