### PR TITLE
Request label selectors to requestKey

### DIFF
--- a/internal/caches/cache_policies_test.go
+++ b/internal/caches/cache_policies_test.go
@@ -554,3 +554,40 @@ func TestCachePolicySupportedMethodsThenReceiveResultAndStoreOrNothing(t *testin
 	upSupervisor.AssertExpectations(t)
 	connectorMock.AssertExpectations(t)
 }
+
+func TestCachePolicyLabelSelectorsNamespaceTheCacheKey(t *testing.T) {
+	_, upSupervisor := test_utils.GetMethodMockAndUpSupervisor()
+
+	connectorMock := mocks.NewCacheConnectorMock()
+	connectorMock.On("Store", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	policyCfg := test_utils.PolicyConfig("polygon", "*", "conn-id", "10KB", "5s", true)
+	policy := caches.NewCachePolicy(upSupervisor, connectorMock, policyCfg)
+
+	body := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "test_method"}
+	reqNoLabel := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth")
+	reqA := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth", protocol.RequestLabelSelector{Name: "type", Values: []string{"a"}})
+	reqB := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth", protocol.RequestLabelSelector{Name: "type", Values: []string{"b"}})
+
+	assert.True(t, policy.Store(context.Background(), chains.POLYGON, reqNoLabel, []byte(`r`)))
+	assert.True(t, policy.Store(context.Background(), chains.POLYGON, reqA, []byte(`r`)))
+	assert.True(t, policy.Store(context.Background(), chains.POLYGON, reqB, []byte(`r`)))
+
+	keys := make([]string, 0, 3)
+	for _, call := range connectorMock.Calls {
+		if call.Method == "Store" {
+			keys = append(keys, call.Arguments.String(1))
+		}
+	}
+
+	assert.Len(t, keys, 3)
+	// Same method+params, but each request resolves to a distinct cache key: the
+	// node class is hashed into the request key, so one class's response can't be
+	// served to a request that pinned another.
+	assert.NotEqual(t, keys[0], keys[1])
+	assert.NotEqual(t, keys[0], keys[2])
+	assert.NotEqual(t, keys[1], keys[2])
+
+	connectorMock.AssertExpectations(t)
+	upSupervisor.AssertExpectations(t)
+}

--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -272,20 +272,6 @@ type RequestUnsupportedSelector struct {
 
 func (RequestUnsupportedSelector) isRequestSelector() {}
 
-type requestSelectorSetter interface {
-	setSelectors([]RequestSelector)
-}
-
-func WithSelectors(request RequestHolder, selectors []RequestSelector) RequestHolder {
-	if request == nil || len(selectors) == 0 {
-		return request
-	}
-	if setter, ok := request.(requestSelectorSetter); ok {
-		setter.setSelectors(selectors)
-	}
-	return request
-}
-
 type UpstreamSubscriptionResponse interface {
 	ResponseChan() chan *WsResponse
 	OpId() string

--- a/internal/protocol/json_rpc_request.go
+++ b/internal/protocol/json_rpc_request.go
@@ -84,7 +84,7 @@ func marshalJsonRPCParams(params any) ([]byte, error) {
 	return sonic.Marshal(params)
 }
 
-func NewUpstreamJsonRpcRequest(id string, jsonRpcRequest JsonRpcRequestBody, isSub bool, specName string) *UpstreamJsonRpcRequest {
+func NewUpstreamJsonRpcRequest(id string, jsonRpcRequest JsonRpcRequestBody, isSub bool, specName string, selectors ...RequestSelector) *UpstreamJsonRpcRequest {
 	specMethod := specs.GetSpecMethodWithFallback(specName, jsonRpcRequest.Method)
 	return &UpstreamJsonRpcRequest{
 		id:              id,
@@ -92,26 +92,30 @@ func NewUpstreamJsonRpcRequest(id string, jsonRpcRequest JsonRpcRequestBody, isS
 		realId:          jsonRpcRequest.Id,
 		requestParams:   jsonRpcRequest.Params,
 		isSub:           isSub,
-		requestKey:      calculateJsonRpcHash(jsonRpcRequest.Method, jsonRpcRequest.Params),
+		requestKey:      calculateJsonRpcHash(jsonRpcRequest.Method, jsonRpcRequest.Params, selectors),
 		specMethod:      specMethod,
 		requestObserver: NewRequestObserver(isSub).WithMethod(jsonRpcRequest.Method),
+		selectors:       selectors,
 	}
 }
 
-func NewStreamUpstreamJsonRpcRequest(id string, jsonRpcRequest JsonRpcRequestBody, specName string) *UpstreamJsonRpcRequest {
-	request := NewUpstreamJsonRpcRequest(id, jsonRpcRequest, false, specName)
+func NewStreamUpstreamJsonRpcRequest(id string, jsonRpcRequest JsonRpcRequestBody, specName string, selectors ...RequestSelector) *UpstreamJsonRpcRequest {
+	request := NewUpstreamJsonRpcRequest(id, jsonRpcRequest, false, specName, selectors...)
 	request.isStream = true
 	return request
 }
 
-func calculateJsonRpcHash(method string, params json.RawMessage) string {
-	var requestHash string
-	if len(params) == 0 {
-		requestHash = calculateHash([]byte(method))
-	} else {
-		requestHash = calculateHash(append(params, []byte(method)...))
-	}
-	return requestHash
+func calculateJsonRpcHash(method string, params json.RawMessage, selectors []RequestSelector) string {
+	// The label key is the request's node-class identity (see LabelCacheKey).
+	// Hashing it alongside method+params keeps responses from one class out of
+	// another class's cache entry. It is empty for class-unconstrained requests,
+	// so their hash is identical to one computed without selectors.
+	labelKey := LabelCacheKey(selectors)
+	buf := make([]byte, 0, len(params)+len(method)+len(labelKey))
+	buf = append(buf, params...)
+	buf = append(buf, method...)
+	buf = append(buf, labelKey...)
+	return calculateHash(buf)
 }
 
 func (u *UpstreamJsonRpcRequest) Id() string {
@@ -239,10 +243,6 @@ func (u *UpstreamJsonRpcRequest) RequestParams() *RequestParams {
 
 func (u *UpstreamJsonRpcRequest) Selectors() []RequestSelector {
 	return append([]RequestSelector(nil), u.selectors...)
-}
-
-func (u *UpstreamJsonRpcRequest) setSelectors(selectors []RequestSelector) {
-	u.selectors = append([]RequestSelector(nil), selectors...)
 }
 
 var _ RequestHolder = (*UpstreamJsonRpcRequest)(nil)

--- a/internal/protocol/request_selector_key.go
+++ b/internal/protocol/request_selector_key.go
@@ -64,3 +64,84 @@ func selectorGroupKey(children []RequestSelector) string {
 	sort.Strings(parts)
 	return strings.Join(parts, "|")
 }
+
+// LabelCacheKey reduces a selector tree to its node-class identity for cache
+// keying. Some chains expose distinct node classes (selected via label
+// selectors) that return different responses for the same method+params, so the
+// chosen class must be part of the cache key or one class's response can be
+// served to a request that pinned another.
+//
+// Only label/exists selectors carry a node-class constraint; every other
+// selector (height, block tag, slot, lower bound, any, unsupported) is treated
+// as ⊤ — it admits every class and is irrelevant to which class answers. The
+// reduction walks the boolean structure over that label dimension only:
+// AND intersects (⊤ children drop out), OR unions (any ⊤ child makes the whole
+// union ⊤), NOT complements. An empty result means the request is unconstrained
+// over node class and shares the default cache entry, leaving keys for
+// label-free traffic byte-identical to before.
+func LabelCacheKey(selectors []RequestSelector) string {
+	// Top-level selectors are applied conjunctively, like an implicit AND.
+	return labelClassKey(RequestAndSelector{Children: selectors})
+}
+
+func labelClassKey(selector RequestSelector) string {
+	switch s := selector.(type) {
+	case RequestLabelSelector:
+		return s.Key()
+	case RequestExistsSelector:
+		return s.Key()
+	case RequestAndSelector:
+		// Intersection: ⊤ (empty-key) children drop out.
+		parts := labelClassParts(s.Children)
+		switch len(parts) {
+		case 0:
+			return ""
+		case 1:
+			return parts[0]
+		default:
+			return fmt.Sprintf("and(%s)", strings.Join(parts, "|"))
+		}
+	case RequestOrSelector:
+		// Union: a single ⊤ child makes the whole union ⊤.
+		parts := make([]string, 0, len(s.Children))
+		for _, child := range s.Children {
+			key := labelClassKey(child)
+			if key == "" {
+				return ""
+			}
+			parts = append(parts, key)
+		}
+		switch len(parts) {
+		case 0:
+			return ""
+		case 1:
+			return parts[0]
+		default:
+			sort.Strings(parts)
+			return fmt.Sprintf("or(%s)", strings.Join(parts, "|"))
+		}
+	case RequestNotSelector:
+		// Complement of ⊤ is the empty set (no class) — irrelevant for keying,
+		// so it too collapses to the shared entry.
+		key := labelClassKey(s.Child)
+		if key == "" {
+			return ""
+		}
+		return fmt.Sprintf("not(%s)", key)
+	default:
+		// RequestAnySelector, height/slot/tag/lower-bound, unsupported, nil:
+		// no node-class constraint.
+		return ""
+	}
+}
+
+func labelClassParts(children []RequestSelector) []string {
+	parts := make([]string, 0, len(children))
+	for _, child := range children {
+		if key := labelClassKey(child); key != "" {
+			parts = append(parts, key)
+		}
+	}
+	sort.Strings(parts)
+	return parts
+}

--- a/internal/protocol/request_selector_key_test.go
+++ b/internal/protocol/request_selector_key_test.go
@@ -1,0 +1,370 @@
+package protocol_test
+
+import (
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+// Constructor helpers keep the selector trees in the tables readable.
+
+func label(name string, values ...string) protocol.RequestLabelSelector {
+	return protocol.RequestLabelSelector{Name: name, Values: values}
+}
+
+func exists(name string) protocol.RequestExistsSelector {
+	return protocol.RequestExistsSelector{Name: name}
+}
+
+func and(children ...protocol.RequestSelector) protocol.RequestAndSelector {
+	return protocol.RequestAndSelector{Children: children}
+}
+
+func or(children ...protocol.RequestSelector) protocol.RequestOrSelector {
+	return protocol.RequestOrSelector{Children: children}
+}
+
+func not(child protocol.RequestSelector) protocol.RequestNotSelector {
+	return protocol.RequestNotSelector{Child: child}
+}
+
+func sel(selectors ...protocol.RequestSelector) []protocol.RequestSelector {
+	return selectors
+}
+
+// TestLabelCacheKey exhaustively pins the node-class reduction for every
+// selector type, every combinator, and their nestings. Non-label selectors are
+// ⊤ (admit every class) and must drop out; only label/exists leaves and the
+// boolean structure connecting them survive.
+func TestLabelCacheKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors []protocol.RequestSelector
+		expected  string
+	}{
+		// --- nothing / unconstrained leaves ---
+		{
+			name:      "no selectors",
+			selectors: nil,
+			expected:  "",
+		},
+		{
+			name:      "empty slice",
+			selectors: sel(),
+			expected:  "",
+		},
+		{
+			name:      "any selector",
+			selectors: sel(protocol.RequestAnySelector{}),
+			expected:  "",
+		},
+		{
+			name:      "height selector",
+			selectors: sel(protocol.RequestHeightSelector{Height: 100}),
+			expected:  "",
+		},
+		{
+			name:      "slot height selector",
+			selectors: sel(protocol.RequestSlotHeightSelector{SlotHeight: 7}),
+			expected:  "",
+		},
+		{
+			name:      "block tag latest",
+			selectors: sel(protocol.RequestBlockTagSelector{Tag: protocol.BlockTagLatest}),
+			expected:  "",
+		},
+		{
+			name:      "block tag finalized",
+			selectors: sel(protocol.RequestBlockTagSelector{Tag: protocol.BlockTagFinalized}),
+			expected:  "",
+		},
+		{
+			name:      "lower height with explicit height",
+			selectors: sel(protocol.RequestLowerHeightSelector{Height: 500, TimeOffset: 1, HeightDelta: 2}),
+			expected:  "",
+		},
+		{
+			name:      "predicted lower bound",
+			selectors: sel(protocol.RequestLowerHeightSelector{Height: 0, TimeOffset: 42}),
+			expected:  "",
+		},
+		{
+			name:      "unsupported selector",
+			selectors: sel(protocol.RequestUnsupportedSelector{Reason: "boom"}),
+			expected:  "",
+		},
+		{
+			name:      "several non-label selectors stay unconstrained",
+			selectors: sel(protocol.RequestHeightSelector{Height: 1}, protocol.RequestBlockTagSelector{Tag: protocol.BlockTagSafe}, protocol.RequestAnySelector{}),
+			expected:  "",
+		},
+
+		// --- label / exists leaves ---
+		{
+			name:      "single label single value",
+			selectors: sel(label("type", "a")),
+			expected:  "label(type=a)",
+		},
+		{
+			name:      "single label multiple values sorted",
+			selectors: sel(label("type", "b", "a", "c")),
+			expected:  "label(type=a|b|c)",
+		},
+		{
+			name:      "label without values",
+			selectors: sel(label("type")),
+			expected:  "label(type=)",
+		},
+		{
+			name:      "exists selector",
+			selectors: sel(exists("archive")),
+			expected:  "exists(archive)",
+		},
+
+		// --- implicit top-level AND (multiple selectors) ---
+		{
+			name:      "label and height drops height",
+			selectors: sel(label("type", "a"), protocol.RequestHeightSelector{Height: 100}),
+			expected:  "label(type=a)",
+		},
+		{
+			name:      "two labels become an AND sorted",
+			selectors: sel(label("type", "a"), label("region", "eu")),
+			expected:  "and(label(region=eu)|label(type=a))",
+		},
+		{
+			name:      "label and exists become an AND sorted",
+			selectors: sel(label("type", "a"), exists("archive")),
+			expected:  "and(exists(archive)|label(type=a))",
+		},
+
+		// --- explicit AND ---
+		{
+			name:      "AND of a single label",
+			selectors: sel(and(label("type", "a"))),
+			expected:  "label(type=a)",
+		},
+		{
+			name:      "AND with empty children",
+			selectors: sel(and()),
+			expected:  "",
+		},
+		{
+			name:      "AND of label and lower bound drops the lower bound",
+			selectors: sel(and(label("type", "a"), protocol.RequestLowerHeightSelector{Height: 0})),
+			expected:  "label(type=a)",
+		},
+		{
+			name:      "AND of only non-label selectors",
+			selectors: sel(and(protocol.RequestHeightSelector{Height: 1}, protocol.RequestAnySelector{})),
+			expected:  "",
+		},
+		{
+			name:      "AND keeps duplicate labels (no canonicalization)",
+			selectors: sel(and(label("type", "a"), label("type", "a"))),
+			expected:  "and(label(type=a)|label(type=a))",
+		},
+
+		// --- explicit OR ---
+		{
+			name:      "OR of two labels keeps both",
+			selectors: sel(or(label("type", "a"), label("type", "b"))),
+			expected:  "or(label(type=a)|label(type=b))",
+		},
+		{
+			name:      "OR of a single label",
+			selectors: sel(or(label("type", "a"))),
+			expected:  "label(type=a)",
+		},
+		{
+			name:      "OR with a non-label branch collapses to unconstrained",
+			selectors: sel(or(label("type", "a"), protocol.RequestHeightSelector{Height: 100})),
+			expected:  "",
+		},
+		{
+			name:      "OR with empty children",
+			selectors: sel(or()),
+			expected:  "",
+		},
+		{
+			name:      "OR of label and exists",
+			selectors: sel(or(label("type", "a"), exists("archive"))),
+			expected:  "or(exists(archive)|label(type=a))",
+		},
+
+		// --- NOT ---
+		{
+			name:      "NOT of a label",
+			selectors: sel(not(label("type", "a"))),
+			expected:  "not(label(type=a))",
+		},
+		{
+			name:      "NOT of an exists",
+			selectors: sel(not(exists("archive"))),
+			expected:  "not(exists(archive))",
+		},
+		{
+			name:      "NOT of a non-label branch is unconstrained",
+			selectors: sel(not(protocol.RequestHeightSelector{Height: 100})),
+			expected:  "",
+		},
+		{
+			name:      "double NOT of a label",
+			selectors: sel(not(not(label("type", "a")))),
+			expected:  "not(not(label(type=a)))",
+		},
+		{
+			name:      "NOT of an AND",
+			selectors: sel(not(and(label("type", "a"), label("type", "b")))),
+			expected:  "not(and(label(type=a)|label(type=b)))",
+		},
+		{
+			name:      "NOT of an OR",
+			selectors: sel(not(or(label("type", "a"), label("type", "b")))),
+			expected:  "not(or(label(type=a)|label(type=b)))",
+		},
+
+		// --- nesting across combinators ---
+		{
+			name:      "AND with a collapsing OR keeps the surviving label",
+			selectors: sel(and(label("type", "c"), or(label("type", "a"), protocol.RequestHeightSelector{Height: 100}))),
+			expected:  "label(type=c)",
+		},
+		{
+			name:      "AND of an OR and a label",
+			selectors: sel(and(or(label("type", "a"), label("type", "b")), label("type", "c"))),
+			expected:  "and(label(type=c)|or(label(type=a)|label(type=b)))",
+		},
+		{
+			name:      "OR of an AND and a label",
+			selectors: sel(or(and(label("type", "a"), label("type", "b")), label("type", "c"))),
+			expected:  "or(and(label(type=a)|label(type=b))|label(type=c))",
+		},
+		{
+			name: "AND with an inner AND that drops its height",
+			// The inner AND keeps a single surviving label, so it collapses to that
+			// label (no and() wrapper) before the outer AND folds it in.
+			selectors: sel(and(label("region", "eu"), and(label("type", "a"), protocol.RequestHeightSelector{Height: 9}))),
+			expected:  "and(label(region=eu)|label(type=a))",
+		},
+		{
+			name:      "NOT inside AND",
+			selectors: sel(and(label("type", "a"), not(label("region", "eu")))),
+			expected:  "and(label(type=a)|not(label(region=eu)))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, protocol.LabelCacheKey(tt.selectors))
+		})
+	}
+}
+
+func TestLabelCacheKeyDistinguishesClasses(t *testing.T) {
+	a := protocol.LabelCacheKey(sel(label("type", "a")))
+	b := protocol.LabelCacheKey(sel(label("type", "b")))
+
+	assert.NotEqual(t, a, b)
+	assert.NotEmpty(t, a)
+	assert.NotEmpty(t, b)
+}
+
+func TestLabelCacheKeyDistinguishesAndOrNot(t *testing.T) {
+	children := sel(label("type", "a"), label("type", "b"))
+	andKey := protocol.LabelCacheKey(sel(and(children...)))
+	orKey := protocol.LabelCacheKey(sel(or(children...)))
+	notAndKey := protocol.LabelCacheKey(sel(not(and(children...))))
+
+	keys := []string{andKey, orKey, notAndKey}
+	for i := range keys {
+		for j := i + 1; j < len(keys); j++ {
+			assert.NotEqualf(t, keys[i], keys[j], "keys %d and %d must differ", i, j)
+		}
+	}
+}
+
+func TestLabelCacheKeyExistsDiffersFromLabel(t *testing.T) {
+	// exists(name) and label(name=...) are different constraints on the same key.
+	assert.NotEqual(t,
+		protocol.LabelCacheKey(sel(exists("type"))),
+		protocol.LabelCacheKey(sel(label("type", "a"))),
+	)
+}
+
+func TestLabelCacheKeyOrderIndependent(t *testing.T) {
+	t.Run("top-level selectors", func(t *testing.T) {
+		forward := protocol.LabelCacheKey(sel(label("type", "a"), label("region", "eu")))
+		reversed := protocol.LabelCacheKey(sel(label("region", "eu"), label("type", "a")))
+		assert.Equal(t, forward, reversed)
+	})
+
+	t.Run("AND children", func(t *testing.T) {
+		forward := protocol.LabelCacheKey(sel(and(label("type", "a"), label("region", "eu"))))
+		reversed := protocol.LabelCacheKey(sel(and(label("region", "eu"), label("type", "a"))))
+		assert.Equal(t, forward, reversed)
+	})
+
+	t.Run("OR children", func(t *testing.T) {
+		forward := protocol.LabelCacheKey(sel(or(label("type", "a"), label("type", "b"))))
+		reversed := protocol.LabelCacheKey(sel(or(label("type", "b"), label("type", "a"))))
+		assert.Equal(t, forward, reversed)
+	})
+
+	t.Run("label values", func(t *testing.T) {
+		forward := protocol.LabelCacheKey(sel(label("type", "a", "b", "c")))
+		reversed := protocol.LabelCacheKey(sel(label("type", "c", "b", "a")))
+		assert.Equal(t, forward, reversed)
+	})
+
+	t.Run("deeply nested children", func(t *testing.T) {
+		// Reorder children of an AND that sits two levels down (inside an OR,
+		// inside the top-level AND) along with the values of a nested label, and
+		// the key must be unchanged - sorting applies at every level, not just
+		// the top.
+		forward := protocol.LabelCacheKey(sel(and(
+			or(
+				and(label("type", "a"), label("region", "eu")),
+				label("tier", "x", "y"),
+			),
+			not(label("zone", "z")),
+		)))
+		reordered := protocol.LabelCacheKey(sel(and(
+			not(label("zone", "z")),
+			or(
+				label("tier", "y", "x"),
+				and(label("region", "eu"), label("type", "a")),
+			),
+		)))
+		assert.Equal(t, forward, reordered)
+		assert.NotEmpty(t, forward)
+	})
+}
+
+func TestLabelCacheKeyDeterministic(t *testing.T) {
+	selectors := sel(and(or(label("type", "a"), label("type", "b")), not(label("region", "eu")), exists("archive")))
+
+	first := protocol.LabelCacheKey(selectors)
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, first, protocol.LabelCacheKey(selectors))
+	}
+}
+
+func TestRequestHashCarriesLabelKey(t *testing.T) {
+	body := protocol.JsonRpcRequestBody{Id: []byte(`1`), Method: "eth_getBalance", Params: []byte(`["0x1","0x2"]`)}
+
+	noLabel := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth")
+	classA := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth", label("type", "a"))
+	classB := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth", label("type", "b"))
+
+	// The same method+params resolves to a distinct hash per class, so a response
+	// cached for one class can never be served to a request that pinned another.
+	assert.NotEqual(t, noLabel.RequestHash(), classA.RequestHash())
+	assert.NotEqual(t, noLabel.RequestHash(), classB.RequestHash())
+	assert.NotEqual(t, classA.RequestHash(), classB.RequestHash())
+
+	// A height-only selector carries no class constraint, so the hash is unchanged.
+	heightOnly := protocol.NewUpstreamJsonRpcRequest("1", body, false, "eth", protocol.RequestHeightSelector{Height: 100})
+	assert.Equal(t, noLabel.RequestHash(), heightOnly.RequestHash())
+}

--- a/internal/protocol/rest_request.go
+++ b/internal/protocol/rest_request.go
@@ -45,21 +45,22 @@ func NewInternalUpstreamRestRequestWithBody(methodTemplate string, requestParams
 	}
 }
 
-func NewUpstreamRestRequest(id, methodTemplate string, requestParams *RequestParams, body []byte, specName string) *UpstreamRestRequest {
+func NewUpstreamRestRequest(id, methodTemplate string, requestParams *RequestParams, body []byte, specName string, selectors ...RequestSelector) *UpstreamRestRequest {
 	specMethod := specs.GetSpecMethodWithFallback(specName, methodTemplate)
 	return &UpstreamRestRequest{
 		id:            id,
 		method:        methodTemplate,
-		requestKey:    calculateRestHash(methodTemplate, requestParams, body),
+		requestKey:    calculateRestHash(methodTemplate, requestParams, body, selectors),
 		body:          body,
 		requestParams: requestParams,
 		observer:      NewRequestObserver(false).WithRequestKind(Unary).WithMethod(methodTemplate),
 		specMethod:    specMethod,
+		selectors:     selectors,
 	}
 }
 
-func NewStreamUpstreamRestRequest(id, methodTemplate string, requestParams *RequestParams, body []byte, specName string) *UpstreamRestRequest {
-	request := NewUpstreamRestRequest(id, methodTemplate, requestParams, body, specName)
+func NewStreamUpstreamRestRequest(id, methodTemplate string, requestParams *RequestParams, body []byte, specName string, selectors ...RequestSelector) *UpstreamRestRequest {
+	request := NewUpstreamRestRequest(id, methodTemplate, requestParams, body, specName, selectors...)
 	request.isStream = true
 	return request
 }
@@ -114,10 +115,6 @@ func (u *UpstreamRestRequest) Selectors() []RequestSelector {
 	return append([]RequestSelector(nil), u.selectors...)
 }
 
-func (u *UpstreamRestRequest) setSelectors(selectors []RequestSelector) {
-	u.selectors = append([]RequestSelector(nil), selectors...)
-}
-
 // calculateRestHash derives a REST request's identity from everything that
 // changes the response: the spec method template, the ordered path captures,
 // the query, and the body. Headers are intentionally excluded - they carry
@@ -129,7 +126,7 @@ func (u *UpstreamRestRequest) setSelectors(selectors []RequestSelector) {
 // The length prefix makes the encoding injective, so the input families can
 // never alias - e.g. a query value "a=" and a body "a=" (or a path capture
 // "x" and a body "x") must not collide, which a bare separator would allow.
-func calculateRestHash(method string, params *RequestParams, body []byte) string {
+func calculateRestHash(method string, params *RequestParams, body []byte, selectors []RequestSelector) string {
 	var buf bytes.Buffer
 	writeSection := func(tag byte, data []byte) {
 		var hdr [9]byte
@@ -149,6 +146,12 @@ func calculateRestHash(method string, params *RequestParams, body []byte) string
 	}
 	if len(body) > 0 {
 		writeSection('b', body)
+	}
+	// The label key is the request's node-class identity (see LabelCacheKey), so
+	// a labeled request can't read another class's cached response. It is empty
+	// for class-unconstrained requests, leaving their hash unchanged.
+	if labelKey := LabelCacheKey(selectors); labelKey != "" {
+		writeSection('s', []byte(labelKey))
 	}
 	return calculateHash(buf.Bytes())
 }

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -149,7 +149,7 @@ func (s *GrpcBlockchainService) NativeSubscribe(request *dshackle.NativeSubscrib
 	}
 
 	jsonRpcRequestBody := protocol.JsonRpcRequestBody{Id: []byte("0"), Method: mappedMethod, Params: mappedPayload}
-	subscribeRequest := protocol.WithSelectors(protocol.NewUpstreamJsonRpcRequest("0", jsonRpcRequestBody, true, configuredChain.MethodSpec), mapDshackleSelectors([]*dshackle.Selector{request.GetSelector()}))
+	subscribeRequest := protocol.NewUpstreamJsonRpcRequest("0", jsonRpcRequestBody, true, configuredChain.MethodSpec, mapDshackleSelectors([]*dshackle.Selector{request.GetSelector()})...)
 	subCtx := flow.NewSubCtx().WithSubscriptionResultOnly(true)
 
 	executionFlow := flow.NewBaseExecutionFlow(

--- a/internal/server/emerald/native_call_adapter.go
+++ b/internal/server/emerald/native_call_adapter.go
@@ -79,9 +79,9 @@ func (jsonRpcNativeCallAdapter) BuildRequest(
 		return nil, nativeCallErrorItem(item.GetId(), protocol.ClientError(err), flow.NoUpstream, nil, nil)
 	}
 	if chunkSize > 0 {
-		return protocol.WithSelectors(protocol.NewStreamUpstreamJsonRpcRequest(requestID, body, chain.MethodSpec), selectors), nil
+		return protocol.NewStreamUpstreamJsonRpcRequest(requestID, body, chain.MethodSpec, selectors...), nil
 	}
-	return protocol.WithSelectors(protocol.NewUpstreamJsonRpcRequest(requestID, body, false, chain.MethodSpec), selectors), nil
+	return protocol.NewUpstreamJsonRpcRequest(requestID, body, false, chain.MethodSpec, selectors...), nil
 }
 
 func (jsonRpcNativeCallAdapter) SendReply(
@@ -138,9 +138,9 @@ func (restNativeCallAdapter) BuildRequest(
 		return nil, nativeCallErrorItem(item.GetId(), protocol.ClientError(err), flow.NoUpstream, nil, nil)
 	}
 	if chunkSize > 0 {
-		return protocol.WithSelectors(protocol.NewStreamUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec), selectors), nil
+		return protocol.NewStreamUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
 	}
-	return protocol.WithSelectors(protocol.NewUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec), selectors), nil
+	return protocol.NewUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
 }
 
 func (restNativeCallAdapter) SendReply(

--- a/internal/upstreams/flow/sub_aggregation_internal_test.go
+++ b/internal/upstreams/flow/sub_aggregation_internal_test.go
@@ -239,8 +239,8 @@ func TestHasEffectiveSelectors(t *testing.T) {
 	}))
 }
 
-func logsRequest(params string) protocol.RequestHolder {
-	return protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(params)}, true, "eth")
+func logsRequest(params string, selectors ...protocol.RequestSelector) protocol.RequestHolder {
+	return protocol.NewUpstreamJsonRpcRequest("1", protocol.JsonRpcRequestBody{Method: "eth_subscribe", Params: []byte(params)}, true, "eth", selectors...)
 }
 
 func logsSupervisor() *mocks.UpstreamSupervisorMock {
@@ -265,7 +265,7 @@ func TestResolveSourceUsesLocalLogsForAnySelector(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			req := protocol.WithSelectors(logsRequest(`["logs",{}]`), tc.selectors)
+			req := logsRequest(`["logs",{}]`, tc.selectors...)
 			key, _, _ := resolveSource(chains.ETHEREUM, logsSupervisor(), req, nil, nil, nil, allLocalSubs)
 			if tc.wantLocal {
 				assert.Equal(t, localLogsKey, key)


### PR DESCRIPTION
# Make cache keys node-class–aware (fold label selectors into `RequestHash`)

## Why

nodecore caches RPC responses keyed by `chain_ + hash(method + params)`
(`getCacheKey` in `internal/caches/cache_policies.go`). That assumes two requests
with the same method+params always deserve the same cached bytes.

That breaks on chains that expose **distinct node classes returning different
results for the same request**. The motivating case is **Hyperliquid**, which has
two node types: a client can pin a type via a **label selector**, and the two
types answer the same `method`+`params` differently. With a class-blind key:

1. a request pinned to node-class **A** caches its response under `chain_hash`;
2. a later request pinned to node-class **B** with the same method+params hits the
   same `chain_hash` → **B is served A's response.** Wrong.

**Root cause.** The label selector — the thing that chose the node class — is the
one input that affects the response but is **not** encoded in the cache key.
Labels come from routing/API-key/config, not from the params that get hashed.

## What

### 1. Reduce a selector tree to its node-class identity

New `LabelCacheKey(selectors)` in `internal/protocol/request_selector_key.go`.
A request can carry a tree of `RequestSelector`s (`internal/protocol/data.go`)
composed with AND/OR/NOT. Only **label**/**exists** selectors pin a node class;
every other selector is treated as **⊤** ("admits every class") and dropped.

Model each selector as the set of classes it admits and reduce over that
dimension:

| Selector | Reduction | Key fragment |
|----------|-----------|--------------|
| `RequestLabelSelector` | the labeled class | `label(name=v1\|v2)` (values sorted) |
| `RequestExistsSelector` | classes with that label | `exists(name)` |
| height / slot / block-tag / lower-bound / `Any` / unsupported / `nil` | ⊤ — every class | `""` (neutral) |
| `RequestAndSelector` | **intersection** (⊤ children drop) | `and(<keys>)`; all ⊤ → `""`; one survivor → that key |
| `RequestOrSelector` | **union** (any ⊤ child → whole thing ⊤) | `or(<keys>)`; any child ⊤ → `""`; one child → that key |
| `RequestNotSelector` | **complement** | `not(<key>)`; child ⊤ → `""` |

Top-level selectors combine as an implicit AND. An empty result means the request
doesn't pin a class, so it shares the default (class-free) cache entry.

**Height/tag/lower-bound selectors are deliberately excluded** — not just because
they don't change *node-class* content for cacheable (finalized) data, but
because their values aren't the literal params: a `RequestLowerHeightSelector`
with `Height == 0` resolves to a **predicted, chain-state-dependent** bound that
drifts, which would fragment the cache and make identical requests miss.

**Soundness of the ⊤ collapse.** Dropping a non-label leaf inside an `OR` would be
wrong — `OR(label(type=a), height≥100)` admits `{type=a} ∪ {any node ≥ height}`,
which includes other classes, so the request genuinely accepts any class →
collapsing the whole `OR` to `""` (shared cache) is correct. Inside an `AND`,
`{a} ∩ ⊤ = {a}`, so dropping is a no-op. The reduction is sound but **not**
canonicalizing (`and(a, or(a,b))` isn't simplified) — that only costs a little
cache sharing, never correctness.

### 2. Fold the class into `RequestHash()`

Rather than recompute selectors at every cache call site, the class is baked into
the request's hash once, so the cache (and the sub-dedup key in
`sub_aggregation.go`, which already appends full selectors) gets it for free:

- **JSON-RPC** (`calculateJsonRpcHash`): hashes `params ++ method ++
  LabelCacheKey(selectors)` in one digest.
- **REST** (`calculateRestHash`): adds a framed `'s'` selector section
  (`tag + length + data`) alongside the existing method/path/query/body sections.

The label key is **hashed in, not concatenated as a suffix**. Because
`LabelCacheKey` returns `""` for class-unconstrained requests, their hash input is
**byte-identical to before** — existing cache entries stay valid, no invalidation
on deploy. Only labeled requests get a different digest.

`getCacheKey` (`cache_policies.go`) is unchanged — it still keys on
`request.RequestHash()`, which now carries the class.

For the Hyperliquid scenario, the same `eth_getBalance` request pinned to type-a,
type-b, and unpinned yields three distinct keys (`K_a ≠ K_b ≠ K_0`, where `K_0`
equals the legacy key), so A's response is never served to B.

## Notes

- Behavior is unchanged for all class-free traffic (no label selector → `""` →
  same key as today). This is purely a correctness fix for class-pinned requests.
- The reduction caps the cache impact: only requests that actually carry a label
  selector get a class-namespaced key; everything else shares the existing entry.
