### PR TITLE
Lower bound fixes + gold lower bounds

### DIFF
--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
@@ -79,13 +79,13 @@ func archiveLabelsDetector(e *EvmChainSpecificObject) labels.LabelsDetector {
 
 func (e *EvmChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
 	detectors := []lower_bounds.LowerBoundDetector{
-		evm_bounds.NewEvmStateLowerBoundDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
-		evm_bounds.NewEvmBlockLowerBoundDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
-		evm_bounds.NewEvmTxLowerBoundDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
-		evm_bounds.NewEvmReceiptsLowerBoundDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector),
+		evm_bounds.NewEvmStateLowerBoundDetector(e.upstreamId, e.chain, e.options.InternalTimeout, e.connector),
+		evm_bounds.NewEvmBlockLowerBoundDetector(e.upstreamId, e.chain, e.options.InternalTimeout, e.connector),
+		evm_bounds.NewEvmTxLowerBoundDetector(e.upstreamId, e.chain, e.options.InternalTimeout, e.connector),
+		evm_bounds.NewEvmReceiptsLowerBoundDetector(e.upstreamId, e.chain, e.options.InternalTimeout, e.connector),
 	}
 	if e.hasMethod("eth_getProof") {
-		detectors = append(detectors, evm_bounds.NewEvmProofLowerBoundDetector(e.upstreamId, e.chain.Chain, e.options.InternalTimeout, e.connector))
+		detectors = append(detectors, evm_bounds.NewEvmProofLowerBoundDetector(e.upstreamId, e.chain, e.options.InternalTimeout, e.connector))
 	}
 	return lower_bounds.NewBaseLowerBoundProcessor(e.ctx, e.upstreamId, e.chain.AverageRemoveSpeed(), detectors)
 }

--- a/internal/upstreams/lower_bounds/algorand_bounds/algorand_lower_bound.go
+++ b/internal/upstreams/lower_bounds/algorand_bounds/algorand_lower_bound.go
@@ -44,8 +44,8 @@ func NewAlgorandLowerBoundDetector(
 	}
 }
 
-func (a *AlgorandLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	latest, err := a.fetchLatestRound()
+func (a *AlgorandLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	latest, err := a.fetchLatestRound(ctx)
 	if err != nil {
 		return a.fallback(fmt.Errorf("cannot fetch latest round: %w", err)), nil
 	}
@@ -54,7 +54,7 @@ func (a *AlgorandLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundDa
 	}
 
 	cached := a.lastBound.Load()
-	bound, err := a.locateBound(cached, latest)
+	bound, err := a.locateBound(ctx, cached, latest)
 	if err != nil {
 		return a.fallback(err), nil
 	}
@@ -96,18 +96,18 @@ func (a *AlgorandLowerBoundDetector) fallback(reason error) []protocol.LowerBoun
 	}
 }
 
-func (a *AlgorandLowerBoundDetector) locateBound(cached, latest int64) (int64, error) {
+func (a *AlgorandLowerBoundDetector) locateBound(ctx context.Context, cached, latest int64) (int64, error) {
 	if cached > 0 {
-		available, err := a.hasBlock(cached)
+		available, err := a.hasBlock(ctx, cached)
 		if err != nil {
 			return 0, err
 		}
 		if available {
 			return cached, nil
 		}
-		return a.binarySearchLower(cached+1, latest)
+		return a.binarySearchLower(ctx, cached+1, latest)
 	}
-	available, err := a.hasBlock(1)
+	available, err := a.hasBlock(ctx, 1)
 	if err != nil {
 		return 0, err
 	}
@@ -117,10 +117,10 @@ func (a *AlgorandLowerBoundDetector) locateBound(cached, latest int64) (int64, e
 	if latest < 2 {
 		return 0, fmt.Errorf("algorand upstream '%s' retains no blocks (last-round=%d)", a.upstreamId, latest)
 	}
-	return a.binarySearchLower(2, latest)
+	return a.binarySearchLower(ctx, 2, latest)
 }
 
-func (a *AlgorandLowerBoundDetector) binarySearchLower(lo, hi int64) (int64, error) {
+func (a *AlgorandLowerBoundDetector) binarySearchLower(ctx context.Context, lo, hi int64) (int64, error) {
 	if lo > hi {
 		return 0, fmt.Errorf("algorand upstream '%s' empty search range [%d, %d]", a.upstreamId, lo, hi)
 	}
@@ -128,7 +128,7 @@ func (a *AlgorandLowerBoundDetector) binarySearchLower(lo, hi int64) (int64, err
 	var result int64
 	for left <= right {
 		mid := left + (right-left)/2
-		available, err := a.hasBlock(mid)
+		available, err := a.hasBlock(ctx, mid)
 		if err != nil {
 			return 0, err
 		}
@@ -145,8 +145,8 @@ func (a *AlgorandLowerBoundDetector) binarySearchLower(lo, hi int64) (int64, err
 	return result, nil
 }
 
-func (a *AlgorandLowerBoundDetector) hasBlock(round int64) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+func (a *AlgorandLowerBoundDetector) hasBlock(ctx context.Context, round int64) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, a.internalTimeout)
 	defer cancel()
 
 	request := protocol.NewInternalUpstreamRestRequest(
@@ -188,8 +188,8 @@ func (a *AlgorandLowerBoundDetector) hasBlock(round int64) (bool, error) {
 	return false, fmt.Errorf("algorand upstream '%s' /v2/blocks/%d/hash returned an unrecognised body", a.upstreamId, round)
 }
 
-func (a *AlgorandLowerBoundDetector) fetchLatestRound() (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+func (a *AlgorandLowerBoundDetector) fetchLatestRound(ctx context.Context) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, a.internalTimeout)
 	defer cancel()
 
 	request := protocol.NewInternalUpstreamRestRequest("GET#/v2/status", nil, a.chain)

--- a/internal/upstreams/lower_bounds/aztec_bounds/aztec_lower_bound.go
+++ b/internal/upstreams/lower_bounds/aztec_bounds/aztec_lower_bound.go
@@ -49,8 +49,8 @@ func NewAztecLowerBoundDetector(
 	}
 }
 
-func (a *AztecLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	bound, err := a.fetchOldestHistoric()
+func (a *AztecLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	bound, err := a.fetchOldestHistoric(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +67,8 @@ func (a *AztecLowerBoundDetector) Period() time.Duration {
 	return aztecPeriod
 }
 
-func (a *AztecLowerBoundDetector) fetchOldestHistoric() (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), a.internalTimeout)
+func (a *AztecLowerBoundDetector) fetchOldestHistoric(ctx context.Context) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, a.internalTimeout)
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest(

--- a/internal/upstreams/lower_bounds/detector.go
+++ b/internal/upstreams/lower_bounds/detector.go
@@ -1,13 +1,14 @@
 package lower_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 )
 
 type LowerBoundDetector interface {
-	DetectLowerBound() ([]protocol.LowerBoundData, error)
+	DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error)
 	SupportedTypes() []protocol.LowerBoundType
 	Period() time.Duration
 }

--- a/internal/upstreams/lower_bounds/evm_bounds/block_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/block_bound.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -28,8 +29,8 @@ func NewEvmBlockLowerBoundDetector(
 	)
 }
 
-func (e *EvmLowerBoundDetector) hasBlock(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
+func (e *EvmLowerBoundDetector) hasBlock(ctx context.Context, height int64) (bool, error) {
+	raw, available, err := e.call(ctx, "eth_getBlockByNumber", []any{evmBlockTag(height), false})
 	if err != nil || !available {
 		return available, err
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/block_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/block_bound.go
@@ -1,0 +1,37 @@
+package evm_bounds
+
+import (
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// NewEvmBlockLowerBoundDetector detects the earliest available block. The same
+// search satisfies the logs lower bound (logs live on blocks), so both types are
+// reported.
+func NewEvmBlockLowerBoundDetector(
+	upstreamId string,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EvmLowerBoundDetector {
+	return newEvmLowerBoundDetectorWithSupportedTypes(
+		upstreamId,
+		chain,
+		internalTimeout,
+		connector,
+		protocol.BlockBound,
+		[]protocol.LowerBoundType{protocol.BlockBound, protocol.LogsBound},
+		0,
+	)
+}
+
+func (e *EvmLowerBoundDetector) hasBlock(height int64) (bool, error) {
+	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmNullResult(raw), nil
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
@@ -2,14 +2,10 @@ package evm_bounds
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
@@ -19,96 +15,47 @@ import (
 const (
 	evmLowerBoundPeriod = 3 * time.Minute
 
+	evmLowerBoundMaxOffset = 20
+
 	evmZeroAddress = "0x0000000000000000000000000000000000000000"
-
-	stateCheckerAddress  = "0x1111111111111111111111111111111111111111"
-	stateCheckerCallData = "0x1eaf190c"
-	stateCheckerBytecode = "0x6080604052348015600e575f5ffd5b50600436106026575f3560e01c80631eaf190c14602a575b5f5ffd5b60306044565b604051603b91906078565b60405180910390f35b5f5f73ffffffffffffffffffffffffffffffffffffffff1631905090565b5f819050919050565b6072816062565b82525050565b5f60208201905060895f830184606b565b9291505056fea2646970667358221220251f5b4d2ed1abe77f66fde198a57ada08562dc3b0afbc6bac0261d1bf516b5d64736f6c634300081e0033"
 )
 
-type evmStateOverrideSupport int32
-
-const (
-	evmStateOverrideUnknown evmStateOverrideSupport = iota
-	evmStateOverrideSupported
-	evmStateOverrideUnsupported
-)
-
+// EvmLowerBoundDetector detects the lower bound of a single data type (block,
+// state, tx, receipts or proof) for an EVM upstream. The concrete per-type probe
+// logic lives in the sibling *_bound.go files; this file holds the shared wiring:
+// construction, the probe dispatcher, and the JSON-RPC call helper.
 type EvmLowerBoundDetector struct {
 	*lower_bounds.LowerBoundSearchCalculator
 
 	connector       connectors.ApiConnector
-	chain           chains.Chain
+	chain           *chains.ConfiguredChain
 	internalTimeout time.Duration
 
 	stateOverrideSupport atomic.Int32
 }
 
-func NewEvmBlockLowerBoundDetector(
-	upstreamId string,
-	chain chains.Chain,
-	internalTimeout time.Duration,
-	connector connectors.ApiConnector,
-) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, protocol.BlockBound, []protocol.LowerBoundType{protocol.BlockBound, protocol.LogsBound})
-}
-
-func NewEvmStateLowerBoundDetector(
-	upstreamId string,
-	chain chains.Chain,
-	internalTimeout time.Duration,
-	connector connectors.ApiConnector,
-) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, protocol.StateBound, []protocol.LowerBoundType{protocol.StateBound, protocol.TraceBound})
-}
-
-func NewEvmTxLowerBoundDetector(
-	upstreamId string,
-	chain chains.Chain,
-	internalTimeout time.Duration,
-	connector connectors.ApiConnector,
-) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.TxBound)
-}
-
-func NewEvmReceiptsLowerBoundDetector(
-	upstreamId string,
-	chain chains.Chain,
-	internalTimeout time.Duration,
-	connector connectors.ApiConnector,
-) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.ReceiptsBound)
-}
-
-func NewEvmProofLowerBoundDetector(
-	upstreamId string,
-	chain chains.Chain,
-	internalTimeout time.Duration,
-	connector connectors.ApiConnector,
-) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, protocol.ProofBound, []protocol.LowerBoundType{protocol.ProofBound})
-}
-
 func newEvmLowerBoundDetector(
 	upstreamId string,
-	chain chains.Chain,
+	chain *chains.ConfiguredChain,
 	internalTimeout time.Duration,
 	connector connectors.ApiConnector,
 	boundType protocol.LowerBoundType,
+	maxOffset int,
 ) *EvmLowerBoundDetector {
-	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, boundType, []protocol.LowerBoundType{boundType})
+	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, boundType, []protocol.LowerBoundType{boundType}, maxOffset)
 }
 
 func newEvmLowerBoundDetectorWithSupportedTypes(
 	upstreamId string,
-	chain chains.Chain,
+	chain *chains.ConfiguredChain,
 	internalTimeout time.Duration,
 	connector connectors.ApiConnector,
 	boundType protocol.LowerBoundType,
 	supportedTypes []protocol.LowerBoundType,
+	maxOffset int,
 ) *EvmLowerBoundDetector {
 	return &EvmLowerBoundDetector{
-		LowerBoundSearchCalculator: lower_bounds.NewLowerBoundSearchCalculatorWithSupportedTypes(upstreamId, boundType, supportedTypes, evmLowerBoundPeriod),
+		LowerBoundSearchCalculator: lower_bounds.NewLowerBoundSearchCalculatorWithOffset(upstreamId, boundType, supportedTypes, evmLowerBoundPeriod, maxOffset),
 		connector:                  connector,
 		chain:                      chain,
 		internalTimeout:            internalTimeout,
@@ -116,6 +63,9 @@ func newEvmLowerBoundDetectorWithSupportedTypes(
 }
 
 func (e *EvmLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
+	if results, ok := e.detectFromGoldBound(); ok {
+		return results, nil
+	}
 	return e.LowerBoundSearchCalculator.DetectLowerBound(e.fetchLatestHeight, e.probe)
 }
 
@@ -147,112 +97,11 @@ func (e *EvmLowerBoundDetector) fetchLatestHeight() (int64, error) {
 	return parseHexInt(raw)
 }
 
-func (e *EvmLowerBoundDetector) hasBlock(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmNullResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) hasState(height int64) (bool, error) {
-	if e.supportsStateOverride() {
-		available, err := e.hasStateWithOverride(height)
-		if err == nil && available {
-			return true, nil
-		}
-		// Match dshackle behavior: state override is preferred, but a failed
-		// per-block override probe falls back to eth_getBalance.
-	}
-	return e.hasStateWithBalance(height)
-}
-
-func (e *EvmLowerBoundDetector) hasStateWithOverride(height int64) (bool, error) {
-	raw, available, err := e.call("eth_call", stateOverrideParams(evmBlockTag(height)))
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmEmptyHexResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) hasStateWithBalance(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getBalance", []any{evmZeroAddress, evmBlockTag(height)})
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmNullResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) hasTx(height int64) (bool, error) {
-	txHash, available, err := e.firstTxHash(height)
-	if err != nil || !available {
-		return available, err
-	}
-	raw, available, err := e.call("eth_getTransactionByHash", []any{txHash})
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmNullResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) hasReceipts(height int64) (bool, error) {
-	txHash, available, err := e.firstTxHash(height)
-	if err != nil || !available {
-		return available, err
-	}
-	raw, available, err := e.call("eth_getTransactionReceipt", []any{txHash})
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmNullResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) hasProof(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getProof", []any{evmZeroAddress, []string{}, evmBlockTag(height)})
-	if err != nil || !available {
-		return available, err
-	}
-	return !isEvmNullResult(raw), nil
-}
-
-func (e *EvmLowerBoundDetector) firstTxHash(height int64) (string, bool, error) {
-	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
-	if err != nil || !available || isEvmNullResult(raw) {
-		return "", available && !isEvmNullResult(raw), err
-	}
-	block := evmBlockEnvelope{}
-	if err := sonic.Unmarshal(raw, &block); err != nil {
-		return "", false, fmt.Errorf("EVM upstream '%s' block %d unparseable: %w", e.UpstreamId, height, err)
-	}
-	tx, ok := block.firstTxHash()
-	if !ok {
-		return "", false, nil
-	}
-	return tx, true, nil
-}
-
-func (e *EvmLowerBoundDetector) supportsStateOverride() bool {
-	switch evmStateOverrideSupport(e.stateOverrideSupport.Load()) {
-	case evmStateOverrideSupported:
-		return true
-	case evmStateOverrideUnsupported:
-		return false
-	}
-
-	raw, available, err := e.call("eth_call", stateOverrideParams("latest"))
-	if err == nil && available && !isEvmEmptyHexResult(raw) {
-		e.stateOverrideSupport.Store(int32(evmStateOverrideSupported))
-		return true
-	}
-	e.stateOverrideSupport.Store(int32(evmStateOverrideUnsupported))
-	return false
-}
-
 func (e *EvmLowerBoundDetector) call(method string, params any) ([]byte, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.internalTimeout)
 	defer cancel()
 
-	request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, params, e.chain)
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, params, e.chain.Chain)
 	if err != nil {
 		return nil, false, err
 	}
@@ -268,157 +117,6 @@ func (e *EvmLowerBoundDetector) call(method string, params any) ([]byte, bool, e
 		return response.ResponseResult(), false, nil
 	}
 	return response.ResponseResult(), true, nil
-}
-
-type evmBlockEnvelope struct {
-	Number       string            `json:"number"`
-	Hash         string            `json:"hash"`
-	Transactions []json.RawMessage `json:"transactions"`
-}
-
-type evmTxRef struct {
-	Hash string `json:"hash"`
-}
-
-func (b evmBlockEnvelope) firstTxHash() (string, bool) {
-	if len(b.Transactions) == 0 {
-		return "", false
-	}
-	first := strings.TrimSpace(string(b.Transactions[0]))
-	if first == "" || first == "null" {
-		return "", false
-	}
-	if strings.HasPrefix(first, `"`) {
-		var hash string
-		if err := sonic.Unmarshal(b.Transactions[0], &hash); err == nil && hash != "" {
-			return hash, true
-		}
-		return "", false
-	}
-	tx := evmTxRef{}
-	if err := sonic.Unmarshal(b.Transactions[0], &tx); err != nil || tx.Hash == "" {
-		return "", false
-	}
-	return tx.Hash, true
-}
-
-func stateOverrideParams(block string) []any {
-	return []any{
-		map[string]any{
-			"to":   stateCheckerAddress,
-			"data": stateCheckerCallData,
-		},
-		block,
-		map[string]any{
-			stateCheckerAddress: map[string]any{
-				"code": stateCheckerBytecode,
-			},
-		},
-	}
-}
-
-func evmBlockTag(height int64) string {
-	return fmt.Sprintf("0x%x", height)
-}
-
-func parseHexInt(raw []byte) (int64, error) {
-	var hexValue string
-	if err := sonic.Unmarshal(raw, &hexValue); err != nil {
-		hexValue = strings.Trim(string(raw), `"`)
-	}
-	hexValue = strings.TrimSpace(hexValue)
-	hexValue = strings.TrimPrefix(hexValue, "0x")
-	if hexValue == "" {
-		return 0, fmt.Errorf("empty hex value")
-	}
-	return strconv.ParseInt(hexValue, 16, 64)
-}
-
-func isEvmNullResult(raw []byte) bool {
-	return strings.TrimSpace(string(raw)) == "null" || len(strings.TrimSpace(string(raw))) == 0
-}
-
-func isEvmEmptyHexResult(raw []byte) bool {
-	var value string
-	if err := sonic.Unmarshal(raw, &value); err != nil {
-		value = strings.Trim(string(raw), `"`)
-	}
-	value = strings.ToLower(strings.TrimSpace(value))
-	return value == "" || value == "0x" || value == "0x0" || value == "null"
-}
-
-func isEvmNoDataError(err *protocol.ResponseError) bool {
-	if err == nil {
-		return false
-	}
-	message := strings.ToLower(err.Message)
-	for _, hint := range evmNoDataErrorHints {
-		if strings.Contains(message, hint) {
-			return true
-		}
-	}
-	return false
-}
-
-var evmNoDataErrorHints = []string{
-	"no state available for block",
-	"missing trie node",
-	"header not found",
-	"metadata is not found",
-	"distance to target block exceeds maximum proof window",
-	"node state is pruned",
-	"is not available, lowest height is",
-	"state already discarded for",
-	"your node is running with state pruning",
-	"failed to compute tipset state",
-	"bad tipset height",
-	"body not found for block",
-	"request beyond head block",
-	"block not found",
-	"could not find block",
-	"unknown block",
-	"header for hash not found",
-	"after last accepted block",
-	"version has either been pruned, or is for a future block",
-	"no historical rpc is available for this historical",
-	"historical backend error",
-	"load state tree: failed to load state tree",
-	"purged for block",
-	"no state data",
-	"state is not available",
-	"block with such an id is pruned",
-	"state at block",
-	"unsupported block number",
-	"unexpected state root",
-	"evm module does not exist on height",
-	"failed to load state at height",
-	"no state found for block",
-	"old data not available due",
-	"state not found for block",
-	"state does not maintain archive data",
-	"access to archival, debug, or trace data is not included in your current plan",
-	"empty reader set",
-	"request might be querying historical state that is not available",
-	"no receipts data",
-	"no tx data",
-	"no block data",
-	"historical state not available in path scheme yet",
-	"historical state is not available",
-	"required historical state unavailable",
-	"state histories haven't been fully indexed yet",
-	"but it out-of-bounds",
-	"has been pruned; earliest available is",
-	"error loading messages for tipset",
-	"height is not available",
-	"method handler crashed",
-	"unexpected error",
-	"invalid block height",
-	"pruned history unavailable",
-	"no transactions snapshot file for",
-	"could not find block for height",
-	"transaction indexing is in progress",
-	"old data not available due to pruning",
-	"requested epoch was a null round",
 }
 
 var _ lower_bounds.LowerBoundDetector = (*EvmLowerBoundDetector)(nil)

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound.go
@@ -62,32 +62,32 @@ func newEvmLowerBoundDetectorWithSupportedTypes(
 	}
 }
 
-func (e *EvmLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	if results, ok := e.detectFromGoldBound(); ok {
+func (e *EvmLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	if results, ok := e.detectFromGoldBound(ctx); ok {
 		return results, nil
 	}
-	return e.LowerBoundSearchCalculator.DetectLowerBound(e.fetchLatestHeight, e.probe)
+	return e.LowerBoundSearchCalculator.DetectLowerBound(ctx, e.fetchLatestHeight, e.probe)
 }
 
-func (e *EvmLowerBoundDetector) probe(height int64) (bool, error) {
+func (e *EvmLowerBoundDetector) probe(ctx context.Context, height int64) (bool, error) {
 	switch e.MainBoundType {
 	case protocol.StateBound:
-		return e.hasState(height)
+		return e.hasState(ctx, height)
 	case protocol.BlockBound:
-		return e.hasBlock(height)
+		return e.hasBlock(ctx, height)
 	case protocol.TxBound:
-		return e.hasTx(height)
+		return e.hasTx(ctx, height)
 	case protocol.ReceiptsBound:
-		return e.hasReceipts(height)
+		return e.hasReceipts(ctx, height)
 	case protocol.ProofBound:
-		return e.hasProof(height)
+		return e.hasProof(ctx, height)
 	default:
 		return false, fmt.Errorf("unsupported EVM lower-bound type %s", e.MainBoundType.String())
 	}
 }
 
-func (e *EvmLowerBoundDetector) fetchLatestHeight() (int64, error) {
-	raw, available, err := e.call("eth_blockNumber", []any{})
+func (e *EvmLowerBoundDetector) fetchLatestHeight(ctx context.Context) (int64, error) {
+	raw, available, err := e.call(ctx, "eth_blockNumber", []any{})
 	if err != nil {
 		return 0, err
 	}
@@ -97,8 +97,8 @@ func (e *EvmLowerBoundDetector) fetchLatestHeight() (int64, error) {
 	return parseHexInt(raw)
 }
 
-func (e *EvmLowerBoundDetector) call(method string, params any) ([]byte, bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e.internalTimeout)
+func (e *EvmLowerBoundDetector) call(ctx context.Context, method string, params any) ([]byte, bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, e.internalTimeout)
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, params, e.chain.Chain)

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound_test.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound_test.go
@@ -1,10 +1,12 @@
 package evm_bounds_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/evm_bounds"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -14,12 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func evmChain() chains.Chain {
-	return chains.GetChain("ethereum").Chain
+// evmChain returns a minimal configured chain with no gold lower bounds, so the
+// binary-search path is exercised. Gold short-circuit tests use evmChainWithGold.
+func evmChain() *chains.ConfiguredChain {
+	return &chains.ConfiguredChain{Chain: chains.GetChain("ethereum").Chain}
+}
+
+func evmChainWithGold(tx, receipts *chains.GoldLowerBound) *chains.ConfiguredChain {
+	return &chains.ConfiguredChain{
+		Chain:       chains.GetChain("ethereum").Chain,
+		LowerBounds: &chains.ChainLowerBounds{Tx: tx, Receipts: receipts},
+	}
 }
 
 func evmOK(body string) protocol.ResponseHolder {
 	return protocol.NewSimpleHttpUpstreamResponse("1", []byte(body), protocol.JsonRpc)
+}
+
+// fastEvm shrinks retry backoff so error-path tests stay quick.
+func fastEvm(d *evm_bounds.EvmLowerBoundDetector) *evm_bounds.EvmLowerBoundDetector {
+	d.SetSearchRetryPolicy(3, time.Millisecond, time.Millisecond)
+	return d
 }
 
 func matchEvmRequest(method string, contains ...string) func(protocol.RequestHolder) bool {
@@ -44,11 +61,62 @@ func matchEvmRequest(method string, contains ...string) func(protocol.RequestHol
 	}
 }
 
+// evmBlockHeight extracts the numeric block height from an eth_getBlockByNumber request.
+func evmBlockHeight(request protocol.RequestHolder) (int64, bool) {
+	if request.Method() != "eth_getBlockByNumber" {
+		return 0, false
+	}
+	body, err := request.Body()
+	if err != nil {
+		return 0, false
+	}
+	node, err := sonic.Get(body, "params", 0)
+	if err != nil {
+		return 0, false
+	}
+	raw, err := node.String()
+	if err != nil {
+		return 0, false
+	}
+	h, err := strconv.ParseInt(strings.TrimPrefix(raw, "0x"), 16, 64)
+	if err != nil {
+		return 0, false
+	}
+	return h, true
+}
+
+func matchBlockAtLeast(threshold int64) func(protocol.RequestHolder) bool {
+	return func(r protocol.RequestHolder) bool {
+		h, ok := evmBlockHeight(r)
+		return ok && h >= threshold
+	}
+}
+
+func matchBlockBelow(threshold int64) func(protocol.RequestHolder) bool {
+	return func(r protocol.RequestHolder) bool {
+		h, ok := evmBlockHeight(r)
+		return ok && h < threshold
+	}
+}
+
 func expectLatest(connector *mocks.ConnectorMock, latest string) {
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_blockNumber"))).
 		Return(evmOK(`"` + latest + `"`)).
 		Once()
+}
+
+// expectBlocksAbove wires eth_getBlockByNumber to return a block for heights >= threshold and null
+// below it, for any number of probes.
+func expectBlocksAbove(connector *mocks.ConnectorMock, threshold int64, block string) {
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBlockAtLeast(threshold))).
+		Return(evmOK(block)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBlockBelow(threshold))).
+		Return(evmOK(`null`)).
+		Maybe()
 }
 
 func TestEvmLowerBoundDetectorSupportedTypesAndPeriod(t *testing.T) {
@@ -72,22 +140,7 @@ func TestEvmLowerBoundDetectorSupportedTypesAndPeriod(t *testing.T) {
 func TestEvmBlockLowerBoundDetectorBinarySearchesEarliestAvailableBlock(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x5")
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`null`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x4"`))).
-		Return(evmOK(`{"number":"0x4","transactions":[]}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x3"`))).
-		Return(evmOK(`{"number":"0x3","transactions":[]}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x2"`))).
-		Return(evmOK(`null`)).
-		Once()
+	expectBlocksAbove(connector, 3, `{"number":"0x3","transactions":[]}`)
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
@@ -97,97 +150,12 @@ func TestEvmBlockLowerBoundDetectorBinarySearchesEarliestAvailableBlock(t *testi
 	require.NotEmpty(t, result)
 	assert.Equal(t, protocol.BlockBound, result[0].Type)
 	assert.Equal(t, int64(3), result[0].Bound)
-	connector.AssertExpectations(t)
-}
-
-func TestEvmStateLowerBoundDetectorFallsBackToBalanceWhenStateOverrideUnsupported(t *testing.T) {
-	connector := mocks.NewConnectorMock()
-	expectLatest(connector, "0x3")
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_call", `"latest"`))).
-		Return(evmOK(`"0x"`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBalance", `"0x1"`))).
-		Return(evmOK(`"0x0"`)).
-		Once()
-
-	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
-
-	result, err := detector.DetectLowerBound()
-
-	require.NoError(t, err)
-	require.NotEmpty(t, result)
-	assert.Equal(t, protocol.StateBound, result[0].Type)
-	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
-}
-
-func TestEvmTxLowerBoundDetectorChecksFirstTransactionHash(t *testing.T) {
-	connector := mocks.NewConnectorMock()
-	expectLatest(connector, "0x3")
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`{"number":"0x1","transactions":["0xabc"]}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"0xabc"`))).
-		Return(evmOK(`{"hash":"0xabc"}`)).
-		Once()
-
-	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
-
-	result, err := detector.DetectLowerBound()
-
-	require.NoError(t, err)
-	require.NotEmpty(t, result)
-	assert.Equal(t, protocol.TxBound, result[0].Type)
-	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
-}
-
-func TestEvmReceiptsLowerBoundDetectorChecksFirstTransactionObjectHash(t *testing.T) {
-	connector := mocks.NewConnectorMock()
-	expectLatest(connector, "0x3")
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`{"number":"0x1","transactions":[{"hash":"0xdef"}]}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionReceipt", `"0xdef"`))).
-		Return(evmOK(`{"transactionHash":"0xdef"}`)).
-		Once()
-
-	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", evmChain(), time.Second, connector)
-
-	result, err := detector.DetectLowerBound()
-
-	require.NoError(t, err)
-	require.NotEmpty(t, result)
-	assert.Equal(t, protocol.ReceiptsBound, result[0].Type)
-	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
 }
 
 func TestEvmBlockLowerBoundDetectorBinarySearchesMultipleSteps(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x8")
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`null`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x5"`))).
-		Return(evmOK(`{"number":"0x5","transactions":[]}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x3"`))).
-		Return(evmOK(`null`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x4"`))).
-		Return(evmOK(`{"number":"0x4","transactions":[]}`)).
-		Once()
+	expectBlocksAbove(connector, 4, `{"number":"0x4","transactions":[]}`)
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
@@ -197,21 +165,137 @@ func TestEvmBlockLowerBoundDetectorBinarySearchesMultipleSteps(t *testing.T) {
 	require.NotEmpty(t, result)
 	assert.Equal(t, protocol.BlockBound, result[0].Type)
 	assert.Equal(t, int64(4), result[0].Bound)
-	connector.AssertExpectations(t)
 }
 
-func TestEvmBlockLowerBoundDetectorReusesCachedBound(t *testing.T) {
+// The reported bug: genesis (block 1) is retained but there is a hole above it. The detector must
+// converge on the real upper boundary (block 6), not trust block 1.
+func TestEvmBlockLowerBoundDetectorIgnoresGenesisWhenHoleFollows(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	expectLatest(connector, "0xa")
+	// data at genesis (block 1) and from block 6 onward; hole in 2..5
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+			h, ok := evmBlockHeight(r)
+			return ok && (h == 1 || h >= 6)
+		})).
+		Return(evmOK(`{"number":"0x6","transactions":[]}`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+			h, ok := evmBlockHeight(r)
+			return ok && h >= 2 && h <= 5
+		})).
+		Return(evmOK(`null`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(func(r protocol.RequestHolder) bool {
+			h, ok := evmBlockHeight(r)
+			return ok && h == 0
+		})).
+		Return(evmOK(`null`)).
+		Maybe()
+
+	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, int64(6), result[0].Bound)
+}
+
+func TestEvmStateLowerBoundDetectorFallsBackToBalanceWhenStateOverrideUnsupported(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	expectLatest(connector, "0x3")
+	// state override probe reports unsupported ("0x"), so detection falls back to eth_getBalance.
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_call"))).
+		Return(evmOK(`"0x"`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBalance"))).
+		Return(evmOK(`"0x123"`)).
+		Maybe()
+
+	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, protocol.StateBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+func TestEvmStateLowerBoundDetectorParsesStateOverrideResult(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x3")
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`{"number":"0x1","transactions":[]}`)).
-		Once()
-	expectLatest(connector, "0x4")
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_call"))).
+		Return(evmOK(`"0x0000000000000000000000000000000000000000000002fea3085e96a90bf691"`)).
+		Maybe()
+
+	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, protocol.StateBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+func TestEvmTxLowerBoundDetectorChecksFirstTransactionHash(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	expectLatest(connector, "0x3")
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
-		Return(evmOK(`{"number":"0x1","transactions":[]}`)).
-		Once()
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
+		Return(evmOK(`{"number":"0x1","transactions":["0xabc"]}`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"0xabc"`))).
+		Return(evmOK(`{"hash":"0xabc"}`)).
+		Maybe()
+
+	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, protocol.TxBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+func TestEvmReceiptsLowerBoundDetectorChecksFirstTransactionObjectHash(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	expectLatest(connector, "0x3")
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
+		Return(evmOK(`{"number":"0x1","transactions":[{"hash":"0xdef"}]}`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionReceipt", `"0xdef"`))).
+		Return(evmOK(`{"transactionHash":"0xdef"}`)).
+		Maybe()
+
+	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", evmChain(), time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, protocol.ReceiptsBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+// Block detection (plain variant) stays stable across repeated runs: the second detection reuses
+// the cached bound as the left edge of its range and still reports 1.
+func TestEvmBlockLowerBoundDetectorStableAcrossRuns(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	expectLatest(connector, "0x3")
+	expectLatest(connector, "0x4")
+	expectBlocksAbove(connector, 0, `{"number":"0x1","transactions":[]}`)
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
@@ -224,43 +308,44 @@ func TestEvmBlockLowerBoundDetectorReusesCachedBound(t *testing.T) {
 	require.NotEmpty(t, second)
 	assert.Equal(t, int64(1), first[0].Bound)
 	assert.Equal(t, int64(1), second[0].Bound)
-	connector.AssertExpectations(t)
 }
 
-func TestEvmStateLowerBoundDetectorParsesStateOverrideResult(t *testing.T) {
+// The offset variant (Tx detector) confirms a previously found bound with a single probe.
+func TestEvmTxLowerBoundDetectorReusesCachedBoundWithSingleProbe(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x3")
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_call", `"latest"`))).
-		Return(evmOK(`"0x0000000000000000000000000000000000000000000002fea3085e96a90bf691"`)).
-		Once()
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
+		Return(evmOK(`{"number":"0x1","transactions":["0xabc"]}`)).
+		Maybe()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_call", `"0x1"`))).
-		Return(evmOK(`"0x0000000000000000000000000000000000000000000002fea3085e96a90bf691"`)).
-		Once()
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash"))).
+		Return(evmOK(`{"hash":"0xabc"}`)).
+		Maybe()
 
-	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
+	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
-
+	first, err := detector.DetectLowerBound()
 	require.NoError(t, err)
-	require.NotEmpty(t, result)
-	assert.Equal(t, protocol.StateBound, result[0].Type)
-	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
+	assert.Equal(t, int64(1), first[0].Bound)
+
+	expectLatest(connector, "0x4")
+	second, err := detector.DetectLowerBound()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), second[0].Bound)
 }
 
 func TestEvmTxLowerBoundDetectorParsesLiveBlockAndTransactionShapes(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x100000")
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
 		Return(evmOK(liveEvmBlockWithHashTransactions)).
-		Once()
+		Maybe()
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"0x01c5a8461d06c2c195035c148af0f871c7679841d86ae5bb98676bb2d8e68dfa"`))).
 		Return(evmOK(liveEvmTransaction)).
-		Once()
+		Maybe()
 
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
 
@@ -270,20 +355,19 @@ func TestEvmTxLowerBoundDetectorParsesLiveBlockAndTransactionShapes(t *testing.T
 	require.NotEmpty(t, result)
 	assert.Equal(t, protocol.TxBound, result[0].Type)
 	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
 }
 
 func TestEvmReceiptsLowerBoundDetectorParsesObjectTransactionsAndReceiptShape(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x3")
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
 		Return(evmOK(`{"number":"0x1","transactions":[{"hash":"0x01c5a8461d06c2c195035c148af0f871c7679841d86ae5bb98676bb2d8e68dfa"}]}`)).
-		Once()
+		Maybe()
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionReceipt", `"0x01c5a8461d06c2c195035c148af0f871c7679841d86ae5bb98676bb2d8e68dfa"`))).
 		Return(evmOK(liveEvmReceipt)).
-		Once()
+		Maybe()
 
 	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", evmChain(), time.Second, connector)
 
@@ -293,46 +377,117 @@ func TestEvmReceiptsLowerBoundDetectorParsesObjectTransactionsAndReceiptShape(t 
 	require.NotEmpty(t, result)
 	assert.Equal(t, protocol.ReceiptsBound, result[0].Type)
 	assert.Equal(t, int64(1), result[0].Bound)
-	connector.AssertExpectations(t)
 }
 
-func TestEvmLowerBoundDetectorReturnsUnexpectedErrors(t *testing.T) {
+// A persistent (unclassified) error is now treated as "no data, search higher"; on a tall chain
+// where nothing is ever confirmed, the convergence guard fails detection so the cached bound is kept.
+func TestEvmLowerBoundDetectorFailsWhenEverythingErrorsOnTallChain(t *testing.T) {
 	connector := mocks.NewConnectorMock()
-	expectLatest(connector, "0x3")
+	expectLatest(connector, "0x64") // 100
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
 		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithMessage("boom"))).
-		Times(3)
+		Maybe()
 
-	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
+	detector := fastEvm(evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector))
 
 	result, err := detector.DetectLowerBound()
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	connector.AssertExpectations(t)
 }
 
-func TestEvmLowerBoundDetectorRetriesUnexpectedErrors(t *testing.T) {
+func TestEvmLowerBoundDetectorRetriesTransientErrors(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	expectLatest(connector, "0x3")
+	// first block probe errors once, then every probe succeeds -> detection completes.
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
 		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithMessage("temporary"))).
 		Once()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber", `"0x1"`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
 		Return(evmOK(`{"number":"0x1","transactions":[]}`)).
-		Once()
+		Maybe()
 
-	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
+	detector := fastEvm(evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector))
 
 	result, err := detector.DetectLowerBound()
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+const goldTxHash = "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+
+// When the chain has a gold tx hash and the upstream serves that ancient tx, the
+// detector short-circuits to bound 1 with a single probe and never fetches blocks.
+func TestEvmTxLowerBoundDetectorShortCircuitsOnGoldBound(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"`+goldTxHash+`"`))).
+		Return(evmOK(`{"hash":"` + goldTxHash + `"}`)).
+		Once()
+
+	chain := evmChainWithGold(&chains.GoldLowerBound{Block: 46147, Hash: goldTxHash}, nil)
+	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", chain, time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, protocol.TxBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
 	connector.AssertExpectations(t)
+}
+
+func TestEvmReceiptsLowerBoundDetectorShortCircuitsOnGoldBound(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionReceipt", `"`+goldTxHash+`"`))).
+		Return(evmOK(`{"transactionHash":"` + goldTxHash + `"}`)).
+		Once()
+
+	chain := evmChainWithGold(nil, &chains.GoldLowerBound{Block: 46147, Hash: goldTxHash})
+	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", chain, time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, protocol.ReceiptsBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
+	connector.AssertExpectations(t)
+}
+
+// When the gold probe returns null (upstream pruned that tx), the detector falls
+// back to the normal binary search.
+func TestEvmTxLowerBoundDetectorFallsBackWhenGoldBoundMissing(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"`+goldTxHash+`"`))).
+		Return(evmOK(`null`)).
+		Once()
+	expectLatest(connector, "0x3")
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getBlockByNumber"))).
+		Return(evmOK(`{"number":"0x1","transactions":["0xabc"]}`)).
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchEvmRequest("eth_getTransactionByHash", `"0xabc"`))).
+		Return(evmOK(`{"hash":"0xabc"}`)).
+		Maybe()
+
+	chain := evmChainWithGold(&chains.GoldLowerBound{Block: 46147, Hash: goldTxHash}, nil)
+	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", chain, time.Second, connector)
+
+	result, err := detector.DetectLowerBound()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, protocol.TxBound, result[0].Type)
+	assert.Equal(t, int64(1), result[0].Bound)
 }
 
 const liveEvmBlockWithHashTransactions = `{

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound_test.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_lower_bound_test.go
@@ -1,6 +1,7 @@
 package evm_bounds_test
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -144,7 +145,7 @@ func TestEvmBlockLowerBoundDetectorBinarySearchesEarliestAvailableBlock(t *testi
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -159,7 +160,7 @@ func TestEvmBlockLowerBoundDetectorBinarySearchesMultipleSteps(t *testing.T) {
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -197,7 +198,7 @@ func TestEvmBlockLowerBoundDetectorIgnoresGenesisWhenHoleFollows(t *testing.T) {
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -219,7 +220,7 @@ func TestEvmStateLowerBoundDetectorFallsBackToBalanceWhenStateOverrideUnsupporte
 
 	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -237,7 +238,7 @@ func TestEvmStateLowerBoundDetectorParsesStateOverrideResult(t *testing.T) {
 
 	detector := evm_bounds.NewEvmStateLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -259,7 +260,7 @@ func TestEvmTxLowerBoundDetectorChecksFirstTransactionHash(t *testing.T) {
 
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -281,7 +282,7 @@ func TestEvmReceiptsLowerBoundDetectorChecksFirstTransactionObjectHash(t *testin
 
 	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -299,9 +300,9 @@ func TestEvmBlockLowerBoundDetectorStableAcrossRuns(t *testing.T) {
 
 	detector := evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	first, err := detector.DetectLowerBound()
+	first, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
-	second, err := detector.DetectLowerBound()
+	second, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 
 	require.NotEmpty(t, first)
@@ -325,12 +326,12 @@ func TestEvmTxLowerBoundDetectorReusesCachedBoundWithSingleProbe(t *testing.T) {
 
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	first, err := detector.DetectLowerBound()
+	first, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), first[0].Bound)
 
 	expectLatest(connector, "0x4")
-	second, err := detector.DetectLowerBound()
+	second, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), second[0].Bound)
 }
@@ -349,7 +350,7 @@ func TestEvmTxLowerBoundDetectorParsesLiveBlockAndTransactionShapes(t *testing.T
 
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -371,7 +372,7 @@ func TestEvmReceiptsLowerBoundDetectorParsesObjectTransactionsAndReceiptShape(t 
 
 	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", evmChain(), time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -391,7 +392,7 @@ func TestEvmLowerBoundDetectorFailsWhenEverythingErrorsOnTallChain(t *testing.T)
 
 	detector := fastEvm(evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector))
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -412,7 +413,7 @@ func TestEvmLowerBoundDetectorRetriesTransientErrors(t *testing.T) {
 
 	detector := fastEvm(evm_bounds.NewEvmBlockLowerBoundDetector("id", evmChain(), time.Second, connector))
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -433,7 +434,7 @@ func TestEvmTxLowerBoundDetectorShortCircuitsOnGoldBound(t *testing.T) {
 	chain := evmChainWithGold(&chains.GoldLowerBound{Block: 46147, Hash: goldTxHash}, nil)
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", chain, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -452,7 +453,7 @@ func TestEvmReceiptsLowerBoundDetectorShortCircuitsOnGoldBound(t *testing.T) {
 	chain := evmChainWithGold(nil, &chains.GoldLowerBound{Block: 46147, Hash: goldTxHash})
 	detector := evm_bounds.NewEvmReceiptsLowerBoundDetector("id", chain, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -482,7 +483,7 @@ func TestEvmTxLowerBoundDetectorFallsBackWhenGoldBoundMissing(t *testing.T) {
 	chain := evmChainWithGold(&chains.GoldLowerBound{Block: 46147, Hash: goldTxHash}, nil)
 	detector := evm_bounds.NewEvmTxLowerBoundDetector("id", chain, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_util.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_util.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -12,8 +13,8 @@ import (
 // firstTxHash fetches a block and returns its first transaction hash, used by the
 // tx and receipts probes. It handles both eth_getBlockByNumber transaction shapes
 // (array of hash strings, or array of tx objects).
-func (e *EvmLowerBoundDetector) firstTxHash(height int64) (string, bool, error) {
-	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
+func (e *EvmLowerBoundDetector) firstTxHash(ctx context.Context, height int64) (string, bool, error) {
+	raw, available, err := e.call(ctx, "eth_getBlockByNumber", []any{evmBlockTag(height), false})
 	if err != nil || !available || isEvmNullResult(raw) {
 		return "", available && !isEvmNullResult(raw), err
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/evm_util.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/evm_util.go
@@ -1,0 +1,91 @@
+package evm_bounds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bytedance/sonic"
+)
+
+// firstTxHash fetches a block and returns its first transaction hash, used by the
+// tx and receipts probes. It handles both eth_getBlockByNumber transaction shapes
+// (array of hash strings, or array of tx objects).
+func (e *EvmLowerBoundDetector) firstTxHash(height int64) (string, bool, error) {
+	raw, available, err := e.call("eth_getBlockByNumber", []any{evmBlockTag(height), false})
+	if err != nil || !available || isEvmNullResult(raw) {
+		return "", available && !isEvmNullResult(raw), err
+	}
+	block := evmBlockEnvelope{}
+	if err := sonic.Unmarshal(raw, &block); err != nil {
+		return "", false, fmt.Errorf("EVM upstream '%s' block %d unparseable: %w", e.UpstreamId, height, err)
+	}
+	tx, ok := block.firstTxHash()
+	if !ok {
+		return "", false, nil
+	}
+	return tx, true, nil
+}
+
+type evmBlockEnvelope struct {
+	Number       string            `json:"number"`
+	Hash         string            `json:"hash"`
+	Transactions []json.RawMessage `json:"transactions"`
+}
+
+type evmTxRef struct {
+	Hash string `json:"hash"`
+}
+
+func (b evmBlockEnvelope) firstTxHash() (string, bool) {
+	if len(b.Transactions) == 0 {
+		return "", false
+	}
+	first := strings.TrimSpace(string(b.Transactions[0]))
+	if first == "" || first == "null" {
+		return "", false
+	}
+	if strings.HasPrefix(first, `"`) {
+		var hash string
+		if err := sonic.Unmarshal(b.Transactions[0], &hash); err == nil && hash != "" {
+			return hash, true
+		}
+		return "", false
+	}
+	tx := evmTxRef{}
+	if err := sonic.Unmarshal(b.Transactions[0], &tx); err != nil || tx.Hash == "" {
+		return "", false
+	}
+	return tx.Hash, true
+}
+
+func evmBlockTag(height int64) string {
+	return fmt.Sprintf("0x%x", height)
+}
+
+func parseHexInt(raw []byte) (int64, error) {
+	var hexValue string
+	if err := sonic.Unmarshal(raw, &hexValue); err != nil {
+		hexValue = strings.Trim(string(raw), `"`)
+	}
+	hexValue = strings.TrimSpace(hexValue)
+	hexValue = strings.TrimPrefix(hexValue, "0x")
+	if hexValue == "" {
+		return 0, fmt.Errorf("empty hex value")
+	}
+	return strconv.ParseInt(hexValue, 16, 64)
+}
+
+func isEvmNullResult(raw []byte) bool {
+	return strings.TrimSpace(string(raw)) == "null" || len(strings.TrimSpace(string(raw))) == 0
+}
+
+func isEvmEmptyHexResult(raw []byte) bool {
+	var value string
+	if err := sonic.Unmarshal(raw, &value); err != nil {
+		value = strings.Trim(string(raw), `"`)
+	}
+	value = strings.ToLower(strings.TrimSpace(value))
+	return value == "" || value == "0x" || value == "0x0" || value == "null"
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/gold_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/gold_bound.go
@@ -1,0 +1,35 @@
+package evm_bounds
+
+import (
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// detectFromGoldBound ports dshackle's GoldLowerBounds short-circuit for tx and
+// receipts: if the chain has a configured gold hash for this bound type, a single
+// RPC probe for that ancient tx/receipt tells us whether the upstream is fully
+// archival. A hit resolves the bound to 1 without a binary search; a miss (null
+// result, no-data error, or any other error) falls back to the normal search.
+func (e *EvmLowerBoundDetector) detectFromGoldBound() ([]protocol.LowerBoundData, bool) {
+	if e.chain == nil || e.chain.LowerBounds == nil {
+		return nil, false
+	}
+	var method string
+	var gold *chains.GoldLowerBound
+	switch e.MainBoundType {
+	case protocol.TxBound:
+		method, gold = "eth_getTransactionByHash", e.chain.LowerBounds.Tx
+	case protocol.ReceiptsBound:
+		method, gold = "eth_getTransactionReceipt", e.chain.LowerBounds.Receipts
+	default:
+		return nil, false
+	}
+	if gold == nil || gold.Hash == "" {
+		return nil, false
+	}
+	raw, available, err := e.call(method, []any{gold.Hash})
+	if err != nil || !available || isEvmNullResult(raw) {
+		return nil, false
+	}
+	return e.LowerBoundResults(1), true
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/gold_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/gold_bound.go
@@ -1,6 +1,8 @@
 package evm_bounds
 
 import (
+	"context"
+
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/pkg/chains"
 )
@@ -10,7 +12,7 @@ import (
 // RPC probe for that ancient tx/receipt tells us whether the upstream is fully
 // archival. A hit resolves the bound to 1 without a binary search; a miss (null
 // result, no-data error, or any other error) falls back to the normal search.
-func (e *EvmLowerBoundDetector) detectFromGoldBound() ([]protocol.LowerBoundData, bool) {
+func (e *EvmLowerBoundDetector) detectFromGoldBound(ctx context.Context) ([]protocol.LowerBoundData, bool) {
 	if e.chain == nil || e.chain.LowerBounds == nil {
 		return nil, false
 	}
@@ -27,7 +29,7 @@ func (e *EvmLowerBoundDetector) detectFromGoldBound() ([]protocol.LowerBoundData
 	if gold == nil || gold.Hash == "" {
 		return nil, false
 	}
-	raw, available, err := e.call(method, []any{gold.Hash})
+	raw, available, err := e.call(ctx, method, []any{gold.Hash})
 	if err != nil || !available || isEvmNullResult(raw) {
 		return nil, false
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/no_data_errors.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/no_data_errors.go
@@ -1,0 +1,85 @@
+package evm_bounds
+
+import (
+	"strings"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+)
+
+// isEvmNoDataError reports whether an upstream error means "this historical data
+// isn't available here" (pruned/archival gaps) rather than a genuine failure. A
+// no-data error is treated as "no data at this height" so the search moves on
+// instead of aborting.
+func isEvmNoDataError(err *protocol.ResponseError) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Message)
+	for _, hint := range evmNoDataErrorHints {
+		if strings.Contains(message, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+var evmNoDataErrorHints = []string{
+	"no state available for block",
+	"missing trie node",
+	"header not found",
+	"metadata is not found",
+	"distance to target block exceeds maximum proof window",
+	"node state is pruned",
+	"is not available, lowest height is",
+	"state already discarded for",
+	"your node is running with state pruning",
+	"failed to compute tipset state",
+	"bad tipset height",
+	"body not found for block",
+	"request beyond head block",
+	"block not found",
+	"could not find block",
+	"unknown block",
+	"header for hash not found",
+	"after last accepted block",
+	"version has either been pruned, or is for a future block",
+	"no historical rpc is available for this historical",
+	"historical backend error",
+	"load state tree: failed to load state tree",
+	"purged for block",
+	"no state data",
+	"state is not available",
+	"block with such an id is pruned",
+	"state at block",
+	"unsupported block number",
+	"unexpected state root",
+	"evm module does not exist on height",
+	"failed to load state at height",
+	"no state found for block",
+	"old data not available due",
+	"state not found for block",
+	"state does not maintain archive data",
+	"access to archival, debug, or trace data is not included in your current plan",
+	"empty reader set",
+	"request might be querying historical state that is not available",
+	"no receipts data",
+	"no tx data",
+	"no block data",
+	"historical state not available in path scheme yet",
+	"historical state is not available",
+	"required historical state unavailable",
+	"state histories haven't been fully indexed yet",
+	"but it out-of-bounds",
+	"has been pruned; earliest available is",
+	"error loading messages for tipset",
+	"height is not available",
+	"method handler crashed",
+	"unexpected error",
+	"invalid block height",
+	"pruned history unavailable",
+	"no transactions snapshot file for",
+	"could not find block for height",
+	"transaction indexing is in progress",
+	"old data not available due to pruning",
+	"requested epoch was a null round",
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/proof_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/proof_bound.go
@@ -1,0 +1,28 @@
+package evm_bounds
+
+import (
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// NewEvmProofLowerBoundDetector detects the earliest block for which eth_getProof
+// still returns data.
+func NewEvmProofLowerBoundDetector(
+	upstreamId string,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EvmLowerBoundDetector {
+	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, protocol.ProofBound, []protocol.LowerBoundType{protocol.ProofBound}, 0)
+}
+
+func (e *EvmLowerBoundDetector) hasProof(height int64) (bool, error) {
+	raw, available, err := e.call("eth_getProof", []any{evmZeroAddress, []string{}, evmBlockTag(height)})
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmNullResult(raw), nil
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/proof_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/proof_bound.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -19,8 +20,8 @@ func NewEvmProofLowerBoundDetector(
 	return newEvmLowerBoundDetectorWithSupportedTypes(upstreamId, chain, internalTimeout, connector, protocol.ProofBound, []protocol.LowerBoundType{protocol.ProofBound}, 0)
 }
 
-func (e *EvmLowerBoundDetector) hasProof(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getProof", []any{evmZeroAddress, []string{}, evmBlockTag(height)})
+func (e *EvmLowerBoundDetector) hasProof(ctx context.Context, height int64) (bool, error) {
+	raw, available, err := e.call(ctx, "eth_getProof", []any{evmZeroAddress, []string{}, evmBlockTag(height)})
 	if err != nil || !available {
 		return available, err
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/receipts_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/receipts_bound.go
@@ -1,0 +1,33 @@
+package evm_bounds
+
+import (
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// NewEvmReceiptsLowerBoundDetector detects the earliest block whose first
+// transaction receipt is still retrievable. Like the tx detector it uses the
+// offset search to tolerate transaction-less historical blocks.
+func NewEvmReceiptsLowerBoundDetector(
+	upstreamId string,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EvmLowerBoundDetector {
+	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.ReceiptsBound, evmLowerBoundMaxOffset)
+}
+
+func (e *EvmLowerBoundDetector) hasReceipts(height int64) (bool, error) {
+	txHash, available, err := e.firstTxHash(height)
+	if err != nil || !available {
+		return available, err
+	}
+	raw, available, err := e.call("eth_getTransactionReceipt", []any{txHash})
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmNullResult(raw), nil
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/receipts_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/receipts_bound.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -20,12 +21,12 @@ func NewEvmReceiptsLowerBoundDetector(
 	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.ReceiptsBound, evmLowerBoundMaxOffset)
 }
 
-func (e *EvmLowerBoundDetector) hasReceipts(height int64) (bool, error) {
-	txHash, available, err := e.firstTxHash(height)
+func (e *EvmLowerBoundDetector) hasReceipts(ctx context.Context, height int64) (bool, error) {
+	txHash, available, err := e.firstTxHash(ctx, height)
 	if err != nil || !available {
 		return available, err
 	}
-	raw, available, err := e.call("eth_getTransactionReceipt", []any{txHash})
+	raw, available, err := e.call(ctx, "eth_getTransactionReceipt", []any{txHash})
 	if err != nil || !available {
 		return available, err
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/state_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/state_bound.go
@@ -1,0 +1,102 @@
+package evm_bounds
+
+import (
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const (
+	stateCheckerAddress  = "0x1111111111111111111111111111111111111111"
+	stateCheckerCallData = "0x1eaf190c"
+	stateCheckerBytecode = "0x6080604052348015600e575f5ffd5b50600436106026575f3560e01c80631eaf190c14602a575b5f5ffd5b60306044565b604051603b91906078565b60405180910390f35b5f5f73ffffffffffffffffffffffffffffffffffffffff1631905090565b5f819050919050565b6072816062565b82525050565b5f60208201905060895f830184606b565b9291505056fea2646970667358221220251f5b4d2ed1abe77f66fde198a57ada08562dc3b0afbc6bac0261d1bf516b5d64736f6c634300081e0033"
+)
+
+type evmStateOverrideSupport int32
+
+const (
+	evmStateOverrideUnknown evmStateOverrideSupport = iota
+	evmStateOverrideSupported
+	evmStateOverrideUnsupported
+)
+
+// NewEvmStateLowerBoundDetector detects the earliest block with available state.
+// The same search satisfies the trace lower bound, so both types are reported.
+func NewEvmStateLowerBoundDetector(
+	upstreamId string,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EvmLowerBoundDetector {
+	return newEvmLowerBoundDetectorWithSupportedTypes(
+		upstreamId,
+		chain,
+		internalTimeout,
+		connector,
+		protocol.StateBound,
+		[]protocol.LowerBoundType{protocol.StateBound, protocol.TraceBound},
+		0,
+	)
+}
+
+func (e *EvmLowerBoundDetector) hasState(height int64) (bool, error) {
+	if e.supportsStateOverride() {
+		available, err := e.hasStateWithOverride(height)
+		if err == nil && available {
+			return true, nil
+		}
+		// Match dshackle behavior: state override is preferred, but a failed
+		// per-block override probe falls back to eth_getBalance.
+	}
+	return e.hasStateWithBalance(height)
+}
+
+func (e *EvmLowerBoundDetector) hasStateWithOverride(height int64) (bool, error) {
+	raw, available, err := e.call("eth_call", stateOverrideParams(evmBlockTag(height)))
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmEmptyHexResult(raw), nil
+}
+
+func (e *EvmLowerBoundDetector) hasStateWithBalance(height int64) (bool, error) {
+	raw, available, err := e.call("eth_getBalance", []any{evmZeroAddress, evmBlockTag(height)})
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmNullResult(raw), nil
+}
+
+func (e *EvmLowerBoundDetector) supportsStateOverride() bool {
+	switch evmStateOverrideSupport(e.stateOverrideSupport.Load()) {
+	case evmStateOverrideSupported:
+		return true
+	case evmStateOverrideUnsupported:
+		return false
+	}
+
+	raw, available, err := e.call("eth_call", stateOverrideParams("latest"))
+	if err == nil && available && !isEvmEmptyHexResult(raw) {
+		e.stateOverrideSupport.Store(int32(evmStateOverrideSupported))
+		return true
+	}
+	e.stateOverrideSupport.Store(int32(evmStateOverrideUnsupported))
+	return false
+}
+
+func stateOverrideParams(block string) []any {
+	return []any{
+		map[string]any{
+			"to":   stateCheckerAddress,
+			"data": stateCheckerCallData,
+		},
+		block,
+		map[string]any{
+			stateCheckerAddress: map[string]any{
+				"code": stateCheckerBytecode,
+			},
+		},
+	}
+}

--- a/internal/upstreams/lower_bounds/evm_bounds/state_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/state_bound.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -41,35 +42,35 @@ func NewEvmStateLowerBoundDetector(
 	)
 }
 
-func (e *EvmLowerBoundDetector) hasState(height int64) (bool, error) {
-	if e.supportsStateOverride() {
-		available, err := e.hasStateWithOverride(height)
+func (e *EvmLowerBoundDetector) hasState(ctx context.Context, height int64) (bool, error) {
+	if e.supportsStateOverride(ctx) {
+		available, err := e.hasStateWithOverride(ctx, height)
 		if err == nil && available {
 			return true, nil
 		}
 		// Match dshackle behavior: state override is preferred, but a failed
 		// per-block override probe falls back to eth_getBalance.
 	}
-	return e.hasStateWithBalance(height)
+	return e.hasStateWithBalance(ctx, height)
 }
 
-func (e *EvmLowerBoundDetector) hasStateWithOverride(height int64) (bool, error) {
-	raw, available, err := e.call("eth_call", stateOverrideParams(evmBlockTag(height)))
+func (e *EvmLowerBoundDetector) hasStateWithOverride(ctx context.Context, height int64) (bool, error) {
+	raw, available, err := e.call(ctx, "eth_call", stateOverrideParams(evmBlockTag(height)))
 	if err != nil || !available {
 		return available, err
 	}
 	return !isEvmEmptyHexResult(raw), nil
 }
 
-func (e *EvmLowerBoundDetector) hasStateWithBalance(height int64) (bool, error) {
-	raw, available, err := e.call("eth_getBalance", []any{evmZeroAddress, evmBlockTag(height)})
+func (e *EvmLowerBoundDetector) hasStateWithBalance(ctx context.Context, height int64) (bool, error) {
+	raw, available, err := e.call(ctx, "eth_getBalance", []any{evmZeroAddress, evmBlockTag(height)})
 	if err != nil || !available {
 		return available, err
 	}
 	return !isEvmNullResult(raw), nil
 }
 
-func (e *EvmLowerBoundDetector) supportsStateOverride() bool {
+func (e *EvmLowerBoundDetector) supportsStateOverride(ctx context.Context) bool {
 	switch evmStateOverrideSupport(e.stateOverrideSupport.Load()) {
 	case evmStateOverrideSupported:
 		return true
@@ -77,7 +78,7 @@ func (e *EvmLowerBoundDetector) supportsStateOverride() bool {
 		return false
 	}
 
-	raw, available, err := e.call("eth_call", stateOverrideParams("latest"))
+	raw, available, err := e.call(ctx, "eth_call", stateOverrideParams("latest"))
 	if err == nil && available && !isEvmEmptyHexResult(raw) {
 		e.stateOverrideSupport.Store(int32(evmStateOverrideSupported))
 		return true

--- a/internal/upstreams/lower_bounds/evm_bounds/tx_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/tx_bound.go
@@ -1,6 +1,7 @@
 package evm_bounds
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -20,12 +21,12 @@ func NewEvmTxLowerBoundDetector(
 	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.TxBound, evmLowerBoundMaxOffset)
 }
 
-func (e *EvmLowerBoundDetector) hasTx(height int64) (bool, error) {
-	txHash, available, err := e.firstTxHash(height)
+func (e *EvmLowerBoundDetector) hasTx(ctx context.Context, height int64) (bool, error) {
+	txHash, available, err := e.firstTxHash(ctx, height)
 	if err != nil || !available {
 		return available, err
 	}
-	raw, available, err := e.call("eth_getTransactionByHash", []any{txHash})
+	raw, available, err := e.call(ctx, "eth_getTransactionByHash", []any{txHash})
 	if err != nil || !available {
 		return available, err
 	}

--- a/internal/upstreams/lower_bounds/evm_bounds/tx_bound.go
+++ b/internal/upstreams/lower_bounds/evm_bounds/tx_bound.go
@@ -1,0 +1,33 @@
+package evm_bounds
+
+import (
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// NewEvmTxLowerBoundDetector detects the earliest block whose first transaction
+// is still retrievable. It uses the offset search because historical blocks may
+// legitimately have no transactions.
+func NewEvmTxLowerBoundDetector(
+	upstreamId string,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *EvmLowerBoundDetector {
+	return newEvmLowerBoundDetector(upstreamId, chain, internalTimeout, connector, protocol.TxBound, evmLowerBoundMaxOffset)
+}
+
+func (e *EvmLowerBoundDetector) hasTx(height int64) (bool, error) {
+	txHash, available, err := e.firstTxHash(height)
+	if err != nil || !available {
+		return available, err
+	}
+	raw, available, err := e.call("eth_getTransactionByHash", []any{txHash})
+	if err != nil || !available {
+		return available, err
+	}
+	return !isEvmNullResult(raw), nil
+}

--- a/internal/upstreams/lower_bounds/lower_bound_processor.go
+++ b/internal/upstreams/lower_bounds/lower_bound_processor.go
@@ -113,14 +113,14 @@ func (b *BaseLowerBoundProcessor) detectLowerBound(
 		defer close(boundsChan)
 		// delay detection the first bound
 		time.Sleep(b.initialDelay)
-		b.processBounds(detector, boundsChan)
+		b.processBounds(ctx, detector, boundsChan)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(detector.Period()):
-				b.processBounds(detector, boundsChan)
+				b.processBounds(ctx, detector, boundsChan)
 			}
 		}
 	}()
@@ -129,10 +129,11 @@ func (b *BaseLowerBoundProcessor) detectLowerBound(
 }
 
 func (b *BaseLowerBoundProcessor) processBounds(
+	ctx context.Context,
 	detector LowerBoundDetector,
 	boundsChan chan protocol.LowerBoundData,
 ) {
-	bounds, err := detector.DetectLowerBound()
+	bounds, err := detector.DetectLowerBound(ctx)
 	if err != nil {
 		log.
 			Error().

--- a/internal/upstreams/lower_bounds/lower_bound_processor_test.go
+++ b/internal/upstreams/lower_bounds/lower_bound_processor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
 	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,7 +99,7 @@ func TestBaseLowerBoundServiceSubscribeReturnsSubscription(t *testing.T) {
 
 func TestBaseLowerBoundServiceUsesCustomInitialDelay(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(100, 1000, protocol.StateBound),
 	}, nil).Once()
 	detector.On("Period").Return(time.Hour).Maybe()
@@ -121,7 +122,7 @@ func TestBaseLowerBoundServiceUsesCustomInitialDelay(t *testing.T) {
 func TestBaseLowerBoundServicePublishesBoundsAndPredictsThem(t *testing.T) {
 	now := time.Now().Unix()
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(100, now, protocol.StateBound),
 		protocol.NewLowerBoundData(200, now, protocol.SlotBound),
 	}, nil).Once()
@@ -149,7 +150,7 @@ func TestBaseLowerBoundServicePublishesBoundsAndPredictsThem(t *testing.T) {
 func TestBaseLowerBoundServicePredictLowerBoundUsesOffset(t *testing.T) {
 	now := time.Now().Unix()
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(100, now, protocol.StateBound),
 	}, nil).Once()
 	detector.On("Period").Return(time.Hour).Maybe()
@@ -171,11 +172,11 @@ func TestBaseLowerBoundServicePredictLowerBoundUsesOffset(t *testing.T) {
 
 func TestBaseLowerBoundServiceIgnoresDetectorErrorAndPublishesOnRetry(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return(nil, errors.New("temporary")).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return(nil, errors.New("temporary")).Once()
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(101, 1001, protocol.StateBound),
 	}, nil).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData(nil), nil).Maybe()
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData(nil), nil).Maybe()
 	detector.On("SupportedTypes").Return([]protocol.LowerBoundType{protocol.StateBound}).Maybe()
 	detector.On("Period").Return(20 * time.Millisecond).Maybe()
 
@@ -195,13 +196,13 @@ func TestBaseLowerBoundServiceIgnoresDetectorErrorAndPublishesOnRetry(t *testing
 
 func TestBaseLowerBoundServiceIgnoresLowerBoundThatMovesBackwards(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(100, 1000, protocol.StateBound),
 	}, nil).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(99, 1001, protocol.StateBound),
 	}, nil).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData(nil), nil).Maybe()
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData(nil), nil).Maybe()
 	detector.On("Period").Return(20 * time.Millisecond).Maybe()
 
 	service := lower_bounds.NewBaseLowerBoundProcessorWithDelay(context.Background(), "up-1", 0, time.Millisecond, []lower_bounds.LowerBoundDetector{detector})
@@ -221,13 +222,13 @@ func TestBaseLowerBoundServiceIgnoresLowerBoundThatMovesBackwards(t *testing.T) 
 
 func TestBaseLowerBoundServiceAcceptsArchivalBoundOne(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(100, 1000, protocol.StateBound),
 	}, nil).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(1, 1001, protocol.StateBound),
 	}, nil).Once()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData(nil), nil).Maybe()
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData(nil), nil).Maybe()
 	detector.On("Period").Return(20 * time.Millisecond).Maybe()
 
 	service := lower_bounds.NewBaseLowerBoundProcessorWithDelay(context.Background(), "up-1", 0, time.Millisecond, []lower_bounds.LowerBoundDetector{detector})
@@ -248,13 +249,13 @@ func TestBaseLowerBoundServiceAcceptsArchivalBoundOne(t *testing.T) {
 
 func TestBaseLowerBoundServicePublishesBoundsFromMultipleDetectors(t *testing.T) {
 	d1 := mocks.NewLowerBoundDetectorMock()
-	d1.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	d1.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(50, 1000, protocol.StateBound),
 	}, nil).Once()
 	d1.On("Period").Return(time.Hour).Maybe()
 
 	d2 := mocks.NewLowerBoundDetectorMock()
-	d2.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	d2.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(70, 1000, protocol.SlotBound),
 	}, nil).Once()
 	d2.On("Period").Return(time.Hour).Maybe()
@@ -282,7 +283,7 @@ func TestBaseLowerBoundServicePublishesBoundsFromMultipleDetectors(t *testing.T)
 
 func TestBaseLowerBoundServiceStopStopsLifecycle(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(10, 1000, protocol.StateBound),
 	}, nil).Maybe()
 	detector.On("Period").Return(time.Hour).Maybe()
@@ -298,7 +299,7 @@ func TestBaseLowerBoundServiceStopStopsLifecycle(t *testing.T) {
 
 func TestBaseLowerBoundServiceSecondStartDoesNotDuplicatePublishing(t *testing.T) {
 	detector := mocks.NewLowerBoundDetectorMock()
-	detector.On("DetectLowerBound").Return([]protocol.LowerBoundData{
+	detector.On("DetectLowerBound", mock.Anything).Return([]protocol.LowerBoundData{
 		protocol.NewLowerBoundData(77, 1000, protocol.StateBound),
 	}, nil).Once()
 	detector.On("Period").Return(time.Hour).Maybe()

--- a/internal/upstreams/lower_bounds/lower_bound_search.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search.go
@@ -3,12 +3,15 @@ package lower_bounds
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/failsafe-go/failsafe-go"
 	"github.com/failsafe-go/failsafe-go/retrypolicy"
+	"github.com/rs/zerolog/log"
+	"github.com/samber/lo"
 )
 
 const (
@@ -264,24 +267,32 @@ func (c *LowerBoundSearchCalculator) shiftLeftAndSearch(
 }
 
 func (c *LowerBoundSearchCalculator) withRetryLatestHeight(ctx context.Context, fetchLatestHeight LowerBoundLatestHeightFetcher) (int64, error) {
-	executor := failsafe.NewExecutor(c.createRetryPolicy()).WithContext(ctx)
+	executor := failsafe.NewExecutor(c.createRetryPolicy("")).WithContext(ctx)
 	return executor.GetWithExecution(func(exec failsafe.Execution[int64]) (int64, error) {
 		return fetchLatestHeight(ctx)
 	})
 }
 
 func (c *LowerBoundSearchCalculator) withRetryProbe(ctx context.Context, height int64, probe LowerBoundProbe) (bool, error) {
-	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay)).WithContext(ctx)
+	message := fmt.Sprintf("unable to get data on block %d to calculate lower bounds for upstream '%s'", height, c.UpstreamId)
+	retryPolicy := createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay, message, c.allSupportedTypes)
+	executor := failsafe.NewExecutor(retryPolicy).WithContext(ctx)
 	return executor.GetWithExecution(func(exec failsafe.Execution[bool]) (bool, error) {
 		return probe(ctx, height)
 	})
 }
 
-func (c *LowerBoundSearchCalculator) createRetryPolicy() failsafe.Policy[int64] {
-	return createLowerBoundSearchRetryPolicy[int64](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay)
+func (c *LowerBoundSearchCalculator) createRetryPolicy(onExceedsMessage string) failsafe.Policy[int64] {
+	return createLowerBoundSearchRetryPolicy[int64](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay, onExceedsMessage, c.allSupportedTypes)
 }
 
-func createLowerBoundSearchRetryPolicy[T any](attempts int, baseDelay, maxDelay time.Duration) failsafe.Policy[T] {
+func createLowerBoundSearchRetryPolicy[T any](
+	attempts int,
+	baseDelay,
+	maxDelay time.Duration,
+	onExceedsMessage string,
+	types []protocol.LowerBoundType,
+) failsafe.Policy[T] {
 	if attempts <= 0 {
 		attempts = 1
 	}
@@ -297,6 +308,14 @@ func createLowerBoundSearchRetryPolicy[T any](attempts int, baseDelay, maxDelay 
 	retryPolicy.WithBackoff(baseDelay, maxDelay)
 	retryPolicy.HandleIf(func(result T, err error) bool {
 		return err != nil
+	})
+	retryPolicy.OnRetriesExceeded(func(f failsafe.ExecutionEvent[T]) {
+		if f.LastError() != nil && onExceedsMessage != "" {
+			stringTypes := lo.Map(types, func(item protocol.LowerBoundType, index int) string {
+				return item.String()
+			})
+			log.Warn().Msgf("%s, bound types %s, cause - %s", onExceedsMessage, strings.Join(stringTypes, ","), f.LastError())
+		}
 	})
 	retryPolicy.ReturnLastFailure()
 

--- a/internal/upstreams/lower_bounds/lower_bound_search.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search.go
@@ -155,6 +155,12 @@ func (c *LowerBoundSearchCalculator) initialRange(cached, latest int64) boundRan
 }
 
 func (c *LowerBoundSearchCalculator) detectPlain(cached, latest int64, hasData func(int64) bool) (int64, error) {
+	// Confirm the cached bound with a single probe first: the lower bound only moves up, so if
+	// cached still has data it is still the bound. Keeps steady-state cost at one probe per cycle.
+	if cached > 0 && hasData(cached) {
+		return cached, nil
+	}
+
 	state := c.initialRange(cached, latest)
 	for !state.found {
 		if state.left > state.right {

--- a/internal/upstreams/lower_bounds/lower_bound_search.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search.go
@@ -2,7 +2,6 @@ package lower_bounds
 
 import (
 	"fmt"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -12,13 +11,21 @@ import (
 )
 
 const (
-	defaultLowerBoundSearchRetryAttempts = 3
-	defaultLowerBoundSearchRetryDelay    = 100 * time.Millisecond
+	defaultLowerBoundSearchRetryAttempts  = 30
+	defaultLowerBoundSearchRetryBaseDelay = 1 * time.Second
+	defaultLowerBoundSearchRetryMaxDelay  = 1 * time.Minute
 )
 
 type LowerBoundProbe func(height int64) (bool, error)
 
 type LowerBoundLatestHeightFetcher func() (int64, error)
+
+type boundRange struct {
+	left    int64
+	right   int64
+	current int64
+	found   bool
+}
 
 type LowerBoundSearchCalculator struct {
 	UpstreamId    string
@@ -27,8 +34,11 @@ type LowerBoundSearchCalculator struct {
 	allSupportedTypes []protocol.LowerBoundType
 	period            time.Duration
 
-	retryAttempts int
-	retryDelay    time.Duration
+	maxOffset int
+
+	retryAttempts  int
+	retryBaseDelay time.Duration
+	retryMaxDelay  time.Duration
 
 	lastBound atomic.Int64
 }
@@ -38,14 +48,7 @@ func NewLowerBoundSearchCalculator(
 	boundType protocol.LowerBoundType,
 	period time.Duration,
 ) *LowerBoundSearchCalculator {
-	return &LowerBoundSearchCalculator{
-		UpstreamId:        upstreamId,
-		MainBoundType:     boundType,
-		period:            period,
-		retryAttempts:     defaultLowerBoundSearchRetryAttempts,
-		retryDelay:        defaultLowerBoundSearchRetryDelay,
-		allSupportedTypes: []protocol.LowerBoundType{boundType},
-	}
+	return NewLowerBoundSearchCalculatorWithOffset(upstreamId, boundType, []protocol.LowerBoundType{boundType}, period, 0)
 }
 
 func NewLowerBoundSearchCalculatorWithSupportedTypes(
@@ -54,12 +57,24 @@ func NewLowerBoundSearchCalculatorWithSupportedTypes(
 	allSupportedTypes []protocol.LowerBoundType,
 	period time.Duration,
 ) *LowerBoundSearchCalculator {
+	return NewLowerBoundSearchCalculatorWithOffset(upstreamId, boundType, allSupportedTypes, period, 0)
+}
+
+func NewLowerBoundSearchCalculatorWithOffset(
+	upstreamId string,
+	boundType protocol.LowerBoundType,
+	allSupportedTypes []protocol.LowerBoundType,
+	period time.Duration,
+	maxOffset int,
+) *LowerBoundSearchCalculator {
 	return &LowerBoundSearchCalculator{
 		UpstreamId:        upstreamId,
 		MainBoundType:     boundType,
 		period:            period,
+		maxOffset:         maxOffset,
 		retryAttempts:     defaultLowerBoundSearchRetryAttempts,
-		retryDelay:        defaultLowerBoundSearchRetryDelay,
+		retryBaseDelay:    defaultLowerBoundSearchRetryBaseDelay,
+		retryMaxDelay:     defaultLowerBoundSearchRetryMaxDelay,
 		allSupportedTypes: allSupportedTypes,
 	}
 }
@@ -76,7 +91,19 @@ func (c *LowerBoundSearchCalculator) DetectLowerBound(
 		return nil, fmt.Errorf("upstream '%s' returned non-positive latest height %d", c.UpstreamId, latest)
 	}
 
-	bound, err := c.locateBound(c.lastBound.Load(), latest, probe)
+	hasData := func(height int64) bool {
+		available, err := c.withRetryProbe(height, probe)
+		return err == nil && available
+	}
+
+	cached := c.lastBound.Load()
+
+	var bound int64
+	if c.maxOffset > 0 {
+		bound, err = c.detectWithOffset(cached, latest, hasData)
+	} else {
+		bound, err = c.detectPlain(cached, latest, hasData)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -87,6 +114,21 @@ func (c *LowerBoundSearchCalculator) DetectLowerBound(
 
 func (c *LowerBoundSearchCalculator) SupportedTypes() []protocol.LowerBoundType {
 	return c.allSupportedTypes
+}
+
+// SetSearchRetryPolicy overrides the retry behavior applied to each probe and latest-height fetch.
+// Production relies on the defaults; this exists mainly to let tests run with negligible backoff.
+func (c *LowerBoundSearchCalculator) SetSearchRetryPolicy(attempts int, baseDelay, maxDelay time.Duration) {
+	c.retryAttempts = attempts
+	c.retryBaseDelay = baseDelay
+	c.retryMaxDelay = maxDelay
+}
+
+// LowerBoundResults builds the fanned-out result set for an externally determined
+// bound (e.g. a gold-bound short-circuit), reusing the same per-supported-type
+// expansion the search uses.
+func (c *LowerBoundSearchCalculator) LowerBoundResults(bound int64) []protocol.LowerBoundData {
+	return c.lowerBoundResults(bound)
 }
 
 func (c *LowerBoundSearchCalculator) lowerBoundResults(bound int64) []protocol.LowerBoundData {
@@ -104,84 +146,147 @@ func (c *LowerBoundSearchCalculator) Period() time.Duration {
 	return c.period
 }
 
-func (c *LowerBoundSearchCalculator) locateBound(cached, latest int64, probe LowerBoundProbe) (int64, error) {
+func (c *LowerBoundSearchCalculator) initialRange(cached, latest int64) boundRange {
+	left := int64(0)
 	if cached > 0 {
-		available, err := c.withRetryProbe(cached, probe)
-		if err != nil {
-			return 0, err
-		}
-		if available {
-			return cached, nil
-		}
-		return c.binarySearchLower(cached+1, latest, probe)
+		left = cached
 	}
-
-	available, err := c.withRetryProbe(1, probe)
-	if err != nil {
-		return 0, err
-	}
-	if available {
-		return 1, nil
-	}
-	if latest < 2 {
-		return 0, fmt.Errorf("upstream '%s' retains no %s data (latest=%d)", c.UpstreamId, c.MainBoundType.String(), latest)
-	}
-	return c.binarySearchLower(2, latest, probe)
+	return boundRange{left: left, right: latest, current: 0}
 }
 
-func (c *LowerBoundSearchCalculator) binarySearchLower(lo, hi int64, probe LowerBoundProbe) (int64, error) {
-	if lo > hi {
-		return 0, fmt.Errorf("upstream '%s' empty %s lower-bound range [%d, %d]", c.UpstreamId, c.MainBoundType.String(), lo, hi)
-	}
-
-	var searchErr error
-	searchRange := int(hi - lo + 1)
-	idx := sort.Search(searchRange, func(i int) bool {
-		if searchErr != nil {
-			return true
+func (c *LowerBoundSearchCalculator) detectPlain(cached, latest int64, hasData func(int64) bool) (int64, error) {
+	state := c.initialRange(cached, latest)
+	for !state.found {
+		if state.left > state.right {
+			converged, err := c.converge(state, hasData)
+			if err != nil {
+				return 0, err
+			}
+			state = converged
+			continue
 		}
 
-		available, err := c.withRetryProbe(lo+int64(i), probe)
-		if err != nil {
-			searchErr = err
-			return true
+		middle := state.left + (state.right-state.left)/2
+		if hasData(middle) {
+			state = boundRange{left: state.left, right: middle - 1, current: middle}
+		} else {
+			state = boundRange{left: middle + 1, right: state.right, current: state.current}
 		}
-		return available
-	})
-	if searchErr != nil {
-		return 0, searchErr
 	}
-	if idx == searchRange {
-		return 0, fmt.Errorf("upstream '%s' has no retained %s data in [%d, %d]", c.UpstreamId, c.MainBoundType.String(), lo, hi)
+	return state.current, nil
+}
+
+// detectWithOffset ports RecursiveLowerBound.recursiveDetectLowerBoundWithOffset: it first
+// re-checks the cached bound, then binary-searches with shiftLeftAndSearch to tolerate sporadic
+// missing blocks below a probed middle.
+func (c *LowerBoundSearchCalculator) detectWithOffset(cached, latest int64, hasData func(int64) bool) (int64, error) {
+	// First, try to confirm the cached bound to avoid a full re-search.
+	if cached > 0 && hasData(cached) {
+		return cached, nil
 	}
-	return lo + int64(idx), nil
+
+	visited := make(map[int64]struct{})
+	state := c.initialRange(cached, latest)
+	for !state.found {
+		if state.left > state.right {
+			converged, err := c.converge(state, hasData)
+			if err != nil {
+				return 0, err
+			}
+			state = converged
+			continue
+		}
+
+		middle := state.left + (state.right-state.left)/2
+		if hasData(middle) {
+			state = boundRange{left: state.left, right: middle - 1, current: middle}
+		} else if middle < 0 {
+			state = boundRange{left: middle + 1, right: state.right, current: state.current}
+		} else {
+			state = c.shiftLeftAndSearch(state, middle, visited, hasData)
+		}
+	}
+	return state.current, nil
+}
+
+// converge handles the left > right terminal step: it re-probes the best candidate (coercing the
+// genesis floor to 1) and, if that fails on a non-trivial chain where nothing was ever confirmed,
+// reports failure so the processor keeps the previously cached bound instead of a bogus 1.
+func (c *LowerBoundSearchCalculator) converge(state boundRange, hasData func(int64) bool) (boundRange, error) {
+	current := state.current
+	if current == 0 {
+		current = 1
+	}
+	if hasData(current) {
+		return boundRange{current: current, found: true}, nil
+	}
+	if current == 1 && state.right > 10 {
+		return boundRange{}, fmt.Errorf("upstream '%s' could not detect %s lower bound", c.UpstreamId, c.MainBoundType.String())
+	}
+	return boundRange{current: current, found: true}, nil
+}
+
+// shiftLeftAndSearch ports RecursiveLowerBound.shiftLeftAndSearch: starting just below a no-data
+// middle, it scans downward up to maxOffset blocks looking for nearby data. Finding data narrows
+// the window left to that block; exhausting the window (or hitting an already-visited block) gives
+// up and moves the main search higher. The returned range has found=false so the caller continues.
+func (c *LowerBoundSearchCalculator) shiftLeftAndSearch(
+	currentData boundRange,
+	currentMiddle int64,
+	visited map[int64]struct{},
+	hasData func(int64) bool,
+) boundRange {
+	moveRight := boundRange{left: currentMiddle + 1, right: currentData.right, current: currentData.current}
+	count := 0
+	block := currentMiddle - 1
+	for {
+		if _, seen := visited[block]; seen || block < 0 {
+			return moveRight
+		}
+		if hasData(block) {
+			return boundRange{left: currentData.left, right: block - 1, current: block}
+		}
+		count++
+		if count > c.maxOffset {
+			return moveRight
+		}
+		visited[block] = struct{}{}
+		block--
+	}
 }
 
 func (c *LowerBoundSearchCalculator) withRetryLatestHeight(fetchLatestHeight LowerBoundLatestHeightFetcher) (int64, error) {
-	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[int64](c.retryAttempts, c.retryDelay))
+	executor := failsafe.NewExecutor(c.createRetryPolicy())
 	return executor.GetWithExecution(func(exec failsafe.Execution[int64]) (int64, error) {
 		return fetchLatestHeight()
 	})
 }
 
 func (c *LowerBoundSearchCalculator) withRetryProbe(height int64, probe LowerBoundProbe) (bool, error) {
-	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryDelay))
+	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay))
 	return executor.GetWithExecution(func(exec failsafe.Execution[bool]) (bool, error) {
 		return probe(height)
 	})
 }
 
-func createLowerBoundSearchRetryPolicy[T any](attempts int, delay time.Duration) failsafe.Policy[T] {
+func (c *LowerBoundSearchCalculator) createRetryPolicy() failsafe.Policy[int64] {
+	return createLowerBoundSearchRetryPolicy[int64](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay)
+}
+
+func createLowerBoundSearchRetryPolicy[T any](attempts int, baseDelay, maxDelay time.Duration) failsafe.Policy[T] {
 	if attempts <= 0 {
 		attempts = 1
 	}
-	if delay <= 0 {
-		delay = defaultLowerBoundSearchRetryDelay
+	if baseDelay <= 0 {
+		baseDelay = defaultLowerBoundSearchRetryBaseDelay
+	}
+	if maxDelay < baseDelay {
+		maxDelay = baseDelay
 	}
 
 	retryPolicy := retrypolicy.Builder[T]()
 	retryPolicy.WithMaxAttempts(attempts)
-	retryPolicy.WithBackoff(delay, delay)
+	retryPolicy.WithBackoff(baseDelay, maxDelay)
 	retryPolicy.HandleIf(func(result T, err error) bool {
 		return err != nil
 	})

--- a/internal/upstreams/lower_bounds/lower_bound_search.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search.go
@@ -1,6 +1,7 @@
 package lower_bounds
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -16,9 +17,9 @@ const (
 	defaultLowerBoundSearchRetryMaxDelay  = 1 * time.Minute
 )
 
-type LowerBoundProbe func(height int64) (bool, error)
+type LowerBoundProbe func(ctx context.Context, height int64) (bool, error)
 
-type LowerBoundLatestHeightFetcher func() (int64, error)
+type LowerBoundLatestHeightFetcher func(ctx context.Context) (int64, error)
 
 type boundRange struct {
 	left    int64
@@ -80,10 +81,11 @@ func NewLowerBoundSearchCalculatorWithOffset(
 }
 
 func (c *LowerBoundSearchCalculator) DetectLowerBound(
+	ctx context.Context,
 	fetchLatestHeight LowerBoundLatestHeightFetcher,
 	probe LowerBoundProbe,
 ) ([]protocol.LowerBoundData, error) {
-	latest, err := c.withRetryLatestHeight(fetchLatestHeight)
+	latest, err := c.withRetryLatestHeight(ctx, fetchLatestHeight)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch latest height for upstream '%s': %w", c.UpstreamId, err)
 	}
@@ -92,7 +94,7 @@ func (c *LowerBoundSearchCalculator) DetectLowerBound(
 	}
 
 	hasData := func(height int64) bool {
-		available, err := c.withRetryProbe(height, probe)
+		available, err := c.withRetryProbe(ctx, height, probe)
 		return err == nil && available
 	}
 
@@ -261,17 +263,17 @@ func (c *LowerBoundSearchCalculator) shiftLeftAndSearch(
 	}
 }
 
-func (c *LowerBoundSearchCalculator) withRetryLatestHeight(fetchLatestHeight LowerBoundLatestHeightFetcher) (int64, error) {
-	executor := failsafe.NewExecutor(c.createRetryPolicy())
+func (c *LowerBoundSearchCalculator) withRetryLatestHeight(ctx context.Context, fetchLatestHeight LowerBoundLatestHeightFetcher) (int64, error) {
+	executor := failsafe.NewExecutor(c.createRetryPolicy()).WithContext(ctx)
 	return executor.GetWithExecution(func(exec failsafe.Execution[int64]) (int64, error) {
-		return fetchLatestHeight()
+		return fetchLatestHeight(ctx)
 	})
 }
 
-func (c *LowerBoundSearchCalculator) withRetryProbe(height int64, probe LowerBoundProbe) (bool, error) {
-	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay))
+func (c *LowerBoundSearchCalculator) withRetryProbe(ctx context.Context, height int64, probe LowerBoundProbe) (bool, error) {
+	executor := failsafe.NewExecutor(createLowerBoundSearchRetryPolicy[bool](c.retryAttempts, c.retryBaseDelay, c.retryMaxDelay)).WithContext(ctx)
 	return executor.GetWithExecution(func(exec failsafe.Execution[bool]) (bool, error) {
-		return probe(height)
+		return probe(ctx, height)
 	})
 }
 

--- a/internal/upstreams/lower_bounds/lower_bound_search_test.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search_test.go
@@ -1,7 +1,9 @@
 package lower_bounds_test
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,8 +34,9 @@ func TestLowerBoundSearchBinarySearchesEarliestAvailable(t *testing.T) {
 	calls := make([]int64, 0)
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 8, nil },
-		func(height int64) (bool, error) {
+		context.Background(),
+		func(context.Context) (int64, error) { return 8, nil },
+		func(_ context.Context, height int64) (bool, error) {
 			calls = append(calls, height)
 			return height >= 4, nil
 		},
@@ -54,8 +57,9 @@ func TestLowerBoundSearchIgnoresGenesisWhenHoleFollows(t *testing.T) {
 	calls := make([]int64, 0)
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 10, nil },
-		func(height int64) (bool, error) {
+		context.Background(),
+		func(context.Context) (int64, error) { return 10, nil },
+		func(_ context.Context, height int64) (bool, error) {
 			calls = append(calls, height)
 			// data at genesis and from 6 onward, hole in 2..5
 			return height == 1 || height >= 6, nil
@@ -74,8 +78,9 @@ func TestLowerBoundSearchTreatsPersistentErrorAsNoData(t *testing.T) {
 	calculator := plainCalculator()
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 8, nil },
-		func(height int64) (bool, error) {
+		context.Background(),
+		func(context.Context) (int64, error) { return 8, nil },
+		func(_ context.Context, height int64) (bool, error) {
 			if height < 4 {
 				return false, errors.New("boom")
 			}
@@ -93,8 +98,9 @@ func TestLowerBoundSearchRetriesTransientErrorThenSucceeds(t *testing.T) {
 	attempts := 0
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 1, nil },
-		func(height int64) (bool, error) {
+		context.Background(),
+		func(context.Context) (int64, error) { return 1, nil },
+		func(_ context.Context, height int64) (bool, error) {
 			attempts++
 			if attempts == 1 {
 				return false, errors.New("temporary")
@@ -114,8 +120,9 @@ func TestLowerBoundSearchFailsWhenNothingRetainedOnTallChain(t *testing.T) {
 	calculator := plainCalculator()
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 100, nil },
-		func(height int64) (bool, error) { return false, nil },
+		context.Background(),
+		func(context.Context) (int64, error) { return 100, nil },
+		func(_ context.Context, height int64) (bool, error) { return false, nil },
 	)
 
 	require.Error(t, err)
@@ -127,8 +134,9 @@ func TestLowerBoundSearchReturnsOneOnTinyChain(t *testing.T) {
 
 	// latest is small (<=10), so the convergence guard does not fire and block 1 is reported.
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 1, nil },
-		func(height int64) (bool, error) { return true, nil },
+		context.Background(),
+		func(context.Context) (int64, error) { return 1, nil },
+		func(_ context.Context, height int64) (bool, error) { return true, nil },
 	)
 
 	require.NoError(t, err)
@@ -140,17 +148,17 @@ func TestLowerBoundSearchReturnsOneOnTinyChain(t *testing.T) {
 func TestLowerBoundSearchPlainReusesCachedBound(t *testing.T) {
 	calculator := plainCalculator()
 	calls := make([]int64, 0)
-	probe := func(height int64) (bool, error) {
+	probe := func(_ context.Context, height int64) (bool, error) {
 		calls = append(calls, height)
 		return height >= 5, nil
 	}
 
-	first, err := calculator.DetectLowerBound(func() (int64, error) { return 8, nil }, probe)
+	first, err := calculator.DetectLowerBound(context.Background(), func(context.Context) (int64, error) { return 8, nil }, probe)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), first[0].Bound)
 
 	callsAfterFirst := len(calls)
-	second, err := calculator.DetectLowerBound(func() (int64, error) { return 9, nil }, probe)
+	second, err := calculator.DetectLowerBound(context.Background(), func(context.Context) (int64, error) { return 9, nil }, probe)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), second[0].Bound)
 	assert.Equal(t, []int64{5}, calls[callsAfterFirst:])
@@ -160,17 +168,17 @@ func TestLowerBoundSearchPlainReusesCachedBound(t *testing.T) {
 func TestLowerBoundSearchOffsetReusesCachedBound(t *testing.T) {
 	calculator := offsetCalculator(20)
 	calls := make([]int64, 0)
-	probe := func(height int64) (bool, error) {
+	probe := func(_ context.Context, height int64) (bool, error) {
 		calls = append(calls, height)
 		return height >= 5, nil
 	}
 
-	first, err := calculator.DetectLowerBound(func() (int64, error) { return 8, nil }, probe)
+	first, err := calculator.DetectLowerBound(context.Background(), func(context.Context) (int64, error) { return 8, nil }, probe)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), first[0].Bound)
 
 	callsAfterFirst := len(calls)
-	second, err := calculator.DetectLowerBound(func() (int64, error) { return 9, nil }, probe)
+	second, err := calculator.DetectLowerBound(context.Background(), func(context.Context) (int64, error) { return 9, nil }, probe)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), second[0].Bound)
 	// Second run confirms the cached bound with exactly one probe.
@@ -184,8 +192,9 @@ func TestLowerBoundSearchOffsetToleratesHoleWithinLimit(t *testing.T) {
 	// Data everywhere from 3 up, except a single hole at 6. A plain search probing middle 6
 	// would wrongly move higher; the offset scan finds data at 5 just below it.
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 12, nil },
-		func(height int64) (bool, error) {
+		context.Background(),
+		func(context.Context) (int64, error) { return 12, nil },
+		func(_ context.Context, height int64) (bool, error) {
 			if height == 6 {
 				return false, nil
 			}
@@ -205,11 +214,43 @@ func TestLowerBoundSearchOffsetAbandonsHoleBeyondLimit(t *testing.T) {
 	// Genuine bound is 9; blocks below it are missing. With maxOffset=2 the downward scan from a
 	// no-data middle gives up quickly and the search proceeds upward to the real boundary.
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 12, nil },
-		func(height int64) (bool, error) { return height >= 9, nil },
+		context.Background(),
+		func(context.Context) (int64, error) { return 12, nil },
+		func(_ context.Context, height int64) (bool, error) { return height >= 9, nil },
 	)
 
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, int64(9), result[0].Bound)
+}
+
+// A cancelled context stops the retry loop between attempts instead of exhausting all
+// configured attempts: the probe keeps erroring, but once ctx is cancelled the search
+// returns promptly rather than retrying up to the (default 30) attempt ceiling.
+func TestLowerBoundSearchStopsRetryingOnContextCancellation(t *testing.T) {
+	// Use the production retry defaults (30 attempts, 1s base delay): without cancellation
+	// this fetch would keep retrying for a long time. With ctx cancelled after the first
+	// attempt, failsafe must abort quickly.
+	calculator := lower_bounds.NewLowerBoundSearchCalculator("up-1", protocol.BlockBound, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts atomic.Int64
+
+	start := time.Now()
+	result, err := calculator.DetectLowerBound(
+		ctx,
+		func(context.Context) (int64, error) {
+			attempts.Add(1)
+			cancel() // cancel right after the first attempt
+			return 0, errors.New("boom")
+		},
+		func(_ context.Context, height int64) (bool, error) { return false, nil },
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	// The retry loop must not have run anywhere near the 30-attempt ceiling, and it must
+	// have returned well before the first 1s backoff would have elapsed had it continued.
+	assert.LessOrEqual(t, attempts.Load(), int64(2))
+	assert.Less(t, time.Since(start), time.Second)
 }

--- a/internal/upstreams/lower_bounds/lower_bound_search_test.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search_test.go
@@ -136,6 +136,26 @@ func TestLowerBoundSearchReturnsOneOnTinyChain(t *testing.T) {
 	assert.Equal(t, int64(1), result[0].Bound)
 }
 
+// Plain variant: a previously found bound is confirmed with a single probe (no full re-search).
+func TestLowerBoundSearchPlainReusesCachedBound(t *testing.T) {
+	calculator := plainCalculator()
+	calls := make([]int64, 0)
+	probe := func(height int64) (bool, error) {
+		calls = append(calls, height)
+		return height >= 5, nil
+	}
+
+	first, err := calculator.DetectLowerBound(func() (int64, error) { return 8, nil }, probe)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), first[0].Bound)
+
+	callsAfterFirst := len(calls)
+	second, err := calculator.DetectLowerBound(func() (int64, error) { return 9, nil }, probe)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), second[0].Bound)
+	assert.Equal(t, []int64{5}, calls[callsAfterFirst:])
+}
+
 // Offset variant: a previously found bound is confirmed with a single probe.
 func TestLowerBoundSearchOffsetReusesCachedBound(t *testing.T) {
 	calculator := offsetCalculator(20)

--- a/internal/upstreams/lower_bounds/lower_bound_search_test.go
+++ b/internal/upstreams/lower_bounds/lower_bound_search_test.go
@@ -11,8 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLowerBoundSearchCalculatorBinarySearchIntegration(t *testing.T) {
-	calculator := lower_bounds.NewLowerBoundSearchCalculator("up-1", protocol.BlockBound, time.Minute)
+// fastRetries makes the retry backoff negligible so error-path tests stay quick.
+func fastRetries(c *lower_bounds.LowerBoundSearchCalculator) *lower_bounds.LowerBoundSearchCalculator {
+	c.SetSearchRetryPolicy(3, time.Millisecond, time.Millisecond)
+	return c
+}
+
+func plainCalculator() *lower_bounds.LowerBoundSearchCalculator {
+	return fastRetries(lower_bounds.NewLowerBoundSearchCalculator("up-1", protocol.BlockBound, time.Minute))
+}
+
+func offsetCalculator(maxOffset int) *lower_bounds.LowerBoundSearchCalculator {
+	return fastRetries(lower_bounds.NewLowerBoundSearchCalculatorWithOffset(
+		"up-1", protocol.BlockBound, []protocol.LowerBoundType{protocol.BlockBound}, time.Minute, maxOffset,
+	))
+}
+
+func TestLowerBoundSearchBinarySearchesEarliestAvailable(t *testing.T) {
+	calculator := plainCalculator()
 	calls := make([]int64, 0)
 
 	result, err := calculator.DetectLowerBound(
@@ -27,11 +43,53 @@ func TestLowerBoundSearchCalculatorBinarySearchIntegration(t *testing.T) {
 	require.Len(t, result, 1)
 	assert.Equal(t, protocol.BlockBound, result[0].Type)
 	assert.Equal(t, int64(4), result[0].Bound)
-	assert.Equal(t, []int64{1, 5, 3, 4}, calls)
+	// No block-1 short-circuit: the search runs from the midpoint over [0, 8].
+	assert.Equal(t, []int64{4, 1, 2, 3, 4}, calls)
 }
 
-func TestLowerBoundSearchCalculatorRetriesUnexpectedProbeErrors(t *testing.T) {
-	calculator := lower_bounds.NewLowerBoundSearchCalculator("up-1", protocol.BlockBound, time.Minute)
+// The reported bug: genesis (block 1) is retained but there is a hole above it. The search must
+// converge on the real upper boundary, not trust block 1.
+func TestLowerBoundSearchIgnoresGenesisWhenHoleFollows(t *testing.T) {
+	calculator := plainCalculator()
+	calls := make([]int64, 0)
+
+	result, err := calculator.DetectLowerBound(
+		func() (int64, error) { return 10, nil },
+		func(height int64) (bool, error) {
+			calls = append(calls, height)
+			// data at genesis and from 6 onward, hole in 2..5
+			return height == 1 || height >= 6, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(6), result[0].Bound)
+	assert.NotContains(t, calls, int64(1)) // never even needs to probe block 1
+}
+
+// A transient error that survives all retries is treated as "no data, search higher" rather than
+// aborting the whole detection.
+func TestLowerBoundSearchTreatsPersistentErrorAsNoData(t *testing.T) {
+	calculator := plainCalculator()
+
+	result, err := calculator.DetectLowerBound(
+		func() (int64, error) { return 8, nil },
+		func(height int64) (bool, error) {
+			if height < 4 {
+				return false, errors.New("boom")
+			}
+			return true, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(4), result[0].Bound)
+}
+
+func TestLowerBoundSearchRetriesTransientErrorThenSucceeds(t *testing.T) {
+	calculator := plainCalculator()
 	attempts := 0
 
 	result, err := calculator.DetectLowerBound(
@@ -48,22 +106,90 @@ func TestLowerBoundSearchCalculatorRetriesUnexpectedProbeErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, int64(1), result[0].Bound)
-	assert.Equal(t, 2, attempts)
 }
 
-func TestLowerBoundSearchCalculatorDoesNotRetryUnavailableResult(t *testing.T) {
-	calculator := lower_bounds.NewLowerBoundSearchCalculator("up-1", protocol.BlockBound, time.Minute)
-	calls := 0
+// Convergence guard: on a non-trivial chain where nothing is ever confirmed, detection fails so
+// the caller keeps the cached bound instead of a bogus 1.
+func TestLowerBoundSearchFailsWhenNothingRetainedOnTallChain(t *testing.T) {
+	calculator := plainCalculator()
 
 	result, err := calculator.DetectLowerBound(
-		func() (int64, error) { return 1, nil },
-		func(height int64) (bool, error) {
-			calls++
-			return false, nil
-		},
+		func() (int64, error) { return 100, nil },
+		func(height int64) (bool, error) { return false, nil },
 	)
 
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.Equal(t, 1, calls)
+}
+
+func TestLowerBoundSearchReturnsOneOnTinyChain(t *testing.T) {
+	calculator := plainCalculator()
+
+	// latest is small (<=10), so the convergence guard does not fire and block 1 is reported.
+	result, err := calculator.DetectLowerBound(
+		func() (int64, error) { return 1, nil },
+		func(height int64) (bool, error) { return true, nil },
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(1), result[0].Bound)
+}
+
+// Offset variant: a previously found bound is confirmed with a single probe.
+func TestLowerBoundSearchOffsetReusesCachedBound(t *testing.T) {
+	calculator := offsetCalculator(20)
+	calls := make([]int64, 0)
+	probe := func(height int64) (bool, error) {
+		calls = append(calls, height)
+		return height >= 5, nil
+	}
+
+	first, err := calculator.DetectLowerBound(func() (int64, error) { return 8, nil }, probe)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), first[0].Bound)
+
+	callsAfterFirst := len(calls)
+	second, err := calculator.DetectLowerBound(func() (int64, error) { return 9, nil }, probe)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), second[0].Bound)
+	// Second run confirms the cached bound with exactly one probe.
+	assert.Equal(t, []int64{5}, calls[callsAfterFirst:])
+}
+
+// Offset variant: shiftLeftAndSearch tolerates a sporadic missing block below a probed middle.
+func TestLowerBoundSearchOffsetToleratesHoleWithinLimit(t *testing.T) {
+	calculator := offsetCalculator(20)
+
+	// Data everywhere from 3 up, except a single hole at 6. A plain search probing middle 6
+	// would wrongly move higher; the offset scan finds data at 5 just below it.
+	result, err := calculator.DetectLowerBound(
+		func() (int64, error) { return 12, nil },
+		func(height int64) (bool, error) {
+			if height == 6 {
+				return false, nil
+			}
+			return height >= 3, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(3), result[0].Bound)
+}
+
+// Offset variant: a hole wider than maxOffset is abandoned and the search moves higher.
+func TestLowerBoundSearchOffsetAbandonsHoleBeyondLimit(t *testing.T) {
+	calculator := offsetCalculator(2)
+
+	// Genuine bound is 9; blocks below it are missing. With maxOffset=2 the downward scan from a
+	// no-data middle gives up quickly and the search proceeds upward to the real boundary.
+	result, err := calculator.DetectLowerBound(
+		func() (int64, error) { return 12, nil },
+		func(height int64) (bool, error) { return height >= 9, nil },
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(9), result[0].Bound)
 }

--- a/internal/upstreams/lower_bounds/solana_bounds/solana_slot_bound.go
+++ b/internal/upstreams/lower_bounds/solana_bounds/solana_slot_bound.go
@@ -25,15 +25,15 @@ type SolanaLowerBoundDetector struct {
 	executor failsafe.Executor[solanaLowerBound]
 }
 
-func (s *SolanaLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	result, err := s.executor.GetWithExecution(func(exec failsafe.Execution[solanaLowerBound]) (solanaLowerBound, error) {
+func (s *SolanaLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	result, err := s.executor.WithContext(ctx).GetWithExecution(func(exec failsafe.Execution[solanaLowerBound]) (solanaLowerBound, error) {
 		var zero solanaLowerBound
-		slot, err := s.getFirstAvailableBlock()
+		slot, err := s.getFirstAvailableBlock(ctx)
 		if err != nil {
 			return zero, err
 		}
 
-		block, err := s.getBlock(slot)
+		block, err := s.getBlock(ctx, slot)
 		if err != nil {
 			return zero, err
 		}
@@ -57,8 +57,8 @@ func (s *SolanaLowerBoundDetector) Period() time.Duration {
 	return period
 }
 
-func (s *SolanaLowerBoundDetector) getFirstAvailableBlock() (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.internalTimeout)
+func (s *SolanaLowerBoundDetector) getFirstAvailableBlock(ctx context.Context) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.internalTimeout)
 	defer cancel()
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest("getFirstAvailableBlock", nil, chains.SOLANA)
@@ -77,8 +77,8 @@ func (s *SolanaLowerBoundDetector) getFirstAvailableBlock() (int64, error) {
 	return int64(max(number, 1)), nil
 }
 
-func (s *SolanaLowerBoundDetector) getBlock(number int64) (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.internalTimeout)
+func (s *SolanaLowerBoundDetector) getBlock(ctx context.Context, number int64) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.internalTimeout)
 	defer cancel()
 
 	params := map[string]any{

--- a/internal/upstreams/lower_bounds/solana_bounds/solana_slot_bound_test.go
+++ b/internal/upstreams/lower_bounds/solana_bounds/solana_slot_bound_test.go
@@ -1,6 +1,7 @@
 package solana_bounds_test
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -70,7 +71,7 @@ func TestSolanaLowerBoundDetectorDetectLowerBound(t *testing.T) {
 
 	detector := solana_bounds.NewSolanaLowerBoundDetector("id", time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
@@ -95,7 +96,7 @@ func TestSolanaLowerBoundDetectorDetectLowerBoundDoesNotReturnZeroValues(t *test
 
 	detector := solana_bounds.NewSolanaLowerBoundDetector("id", time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
@@ -124,7 +125,7 @@ func TestSolanaLowerBoundDetectorDetectLowerBoundRetriesAfterFirstAvailableBlock
 
 	detector := solana_bounds.NewSolanaLowerBoundDetector("id", time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, []protocol.LowerBoundType{protocol.SlotBound, protocol.StateBound}, []protocol.LowerBoundType{result[0].Type, result[1].Type})
@@ -150,7 +151,7 @@ func TestSolanaLowerBoundDetectorDetectLowerBoundRetriesAfterGetBlockError(t *te
 
 	detector := solana_bounds.NewSolanaLowerBoundDetector("id", time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, []protocol.LowerBoundType{protocol.SlotBound, protocol.StateBound}, []protocol.LowerBoundType{result[0].Type, result[1].Type})

--- a/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound.go
+++ b/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound.go
@@ -49,8 +49,8 @@ func NewTronLowerBoundDetector(
 	}
 }
 
-func (t *TronLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	bounds, err := t.LowerBoundSearchCalculator.DetectLowerBound(t.fetchLatestHeight, t.probe)
+func (t *TronLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	bounds, err := t.LowerBoundSearchCalculator.DetectLowerBound(ctx, t.fetchLatestHeight, t.probe)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +69,8 @@ func (t *TronLowerBoundDetector) DetectLowerBound() ([]protocol.LowerBoundData, 
 	return expanded, nil
 }
 
-func (t *TronLowerBoundDetector) fetchLatestHeight() (int64, error) {
-	raw, err := t.callGetBlock(nil)
+func (t *TronLowerBoundDetector) fetchLatestHeight(ctx context.Context) (int64, error) {
+	raw, err := t.callGetBlock(ctx, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -84,9 +84,9 @@ func (t *TronLowerBoundDetector) fetchLatestHeight() (int64, error) {
 	return number, nil
 }
 
-func (t *TronLowerBoundDetector) probe(height int64) (bool, error) {
+func (t *TronLowerBoundDetector) probe(ctx context.Context, height int64) (bool, error) {
 	body := []byte(fmt.Sprintf(`{"id_or_num":"%d","detail":false}`, height))
-	raw, err := t.callGetBlock(body)
+	raw, err := t.callGetBlock(ctx, body)
 	if err != nil {
 		return false, err
 	}
@@ -102,8 +102,8 @@ func (t *TronLowerBoundDetector) probe(height int64) (bool, error) {
 	return parsed.BlockID != "", nil
 }
 
-func (t *TronLowerBoundDetector) callGetBlock(body []byte) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), t.internalTimeout)
+func (t *TronLowerBoundDetector) callGetBlock(ctx context.Context, body []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, t.internalTimeout)
 	defer cancel()
 
 	request := protocol.NewInternalUpstreamRestRequestWithBody("POST#/wallet/getblock", nil, body, t.chain)

--- a/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound_test.go
+++ b/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound_test.go
@@ -2,9 +2,11 @@ package tron_bounds_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/tron_bounds"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -29,6 +31,12 @@ func tronEmptyBlock() string {
 	return `{}`
 }
 
+// fastTron shrinks retry backoff so error-path tests stay quick.
+func fastTron(d *tron_bounds.TronLowerBoundDetector) *tron_bounds.TronLowerBoundDetector {
+	d.SetSearchRetryPolicy(3, time.Millisecond, time.Millisecond)
+	return d
+}
+
 // matchTronRequest verifies the request is a POST to /wallet/getblock with
 // an exact body (use "" to match a nil/empty body for the "latest" fetch).
 func matchTronRequest(expectedBody string) func(protocol.RequestHolder) bool {
@@ -44,6 +52,44 @@ func matchTronRequest(expectedBody string) func(protocol.RequestHolder) bool {
 			return false
 		}
 		return string(body) == expectedBody
+	}
+}
+
+// tronProbeHeight extracts the requested block height from a /wallet/getblock probe body.
+func tronProbeHeight(req protocol.RequestHolder) (int64, bool) {
+	if req.Method() != "POST#/wallet/getblock" {
+		return 0, false
+	}
+	body, err := req.Body()
+	if err != nil {
+		return 0, false
+	}
+	node, err := sonic.Get(body, "id_or_num")
+	if err != nil {
+		return 0, false
+	}
+	raw, err := node.String()
+	if err != nil {
+		return 0, false
+	}
+	h, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return h, true
+}
+
+func matchTronAtLeast(threshold int64) func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		h, ok := tronProbeHeight(req)
+		return ok && h >= threshold
+	}
+}
+
+func matchTronBelow(threshold int64) func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		h, ok := tronProbeHeight(req)
+		return ok && h < threshold
 	}
 }
 
@@ -65,28 +111,19 @@ func TestTronLowerBoundDetector_SupportedTypesAndPeriod(t *testing.T) {
 
 func TestTronLowerBoundDetector_FansOutOneSearchToAllFourBoundTypes(t *testing.T) {
 	connector := mocks.NewConnectorMock()
-	// latest = 5; expected bound = 3.
-	// Probe order under sort.Search([2,5]): 1 (initial), 4, 3, 2.
+	// latest = 5; blocks >= 3 present -> expected bound = 3.
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(tronOK(tronBlockJSON(5))).
 		Once()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"1","detail":false}`))).
-		Return(tronOK(tronEmptyBlock())).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"4","detail":false}`))).
-		Return(tronOK(tronBlockJSON(4))).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"3","detail":false}`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronAtLeast(3))).
 		Return(tronOK(tronBlockJSON(3))).
-		Once()
+		Maybe()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"2","detail":false}`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronBelow(3))).
 		Return(tronOK(tronEmptyBlock())).
-		Once()
+		Maybe()
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
@@ -103,20 +140,18 @@ func TestTronLowerBoundDetector_FansOutOneSearchToAllFourBoundTypes(t *testing.T
 	assert.Equal(t, int64(3), got[protocol.StateBound])
 	assert.Equal(t, int64(3), got[protocol.TxBound])
 	assert.Equal(t, int64(3), got[protocol.ReceiptsBound])
-
-	connector.AssertExpectations(t)
 }
 
-func TestTronLowerBoundDetector_HeightOneAvailableReturnsOneForAllTypes(t *testing.T) {
+func TestTronLowerBoundDetector_AllAvailableReturnsOneForAllTypes(t *testing.T) {
 	connector := mocks.NewConnectorMock()
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(tronOK(tronBlockJSON(100))).
 		Once()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"1","detail":false}`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronAtLeast(0))).
 		Return(tronOK(tronBlockJSON(1))).
-		Once()
+		Maybe()
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
@@ -126,7 +161,6 @@ func TestTronLowerBoundDetector_HeightOneAvailableReturnsOneForAllTypes(t *testi
 	for _, b := range result {
 		assert.Equal(t, int64(1), b.Bound)
 	}
-	connector.AssertExpectations(t)
 }
 
 func TestTronLowerBoundDetector_LatestEmptyBodyFails(t *testing.T) {
@@ -135,7 +169,7 @@ func TestTronLowerBoundDetector_LatestEmptyBodyFails(t *testing.T) {
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(tronOK(tronEmptyBlock()))
 
-	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
+	detector := fastTron(tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector))
 
 	_, err := detector.DetectLowerBound()
 	require.Error(t, err)
@@ -147,27 +181,27 @@ func TestTronLowerBoundDetector_LatestConnectorErrorPropagates(t *testing.T) {
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ServerError()))
 
-	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
+	detector := fastTron(tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector))
 
 	_, err := detector.DetectLowerBound()
 	require.Error(t, err)
 }
 
 func TestTronLowerBoundDetector_EmptyBodyOnProbeMeansBlockMissing(t *testing.T) {
-	// Latest = 2, height 1 missing, height 2 present → bound is 2.
+	// Latest = 2, blocks below 2 missing, height 2 present → bound is 2.
 	connector := mocks.NewConnectorMock()
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(tronOK(tronBlockJSON(2))).
 		Once()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"1","detail":false}`))).
-		Return(tronOK(tronEmptyBlock())).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"2","detail":false}`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronAtLeast(2))).
 		Return(tronOK(tronBlockJSON(2))).
-		Once()
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronBelow(2))).
+		Return(tronOK(tronEmptyBlock())).
+		Maybe()
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
@@ -177,26 +211,25 @@ func TestTronLowerBoundDetector_EmptyBodyOnProbeMeansBlockMissing(t *testing.T) 
 	for _, b := range result {
 		assert.Equal(t, int64(2), b.Bound)
 	}
-	connector.AssertExpectations(t)
 }
 
 func TestTronLowerBoundDetector_BodyWithoutBlockIDCountsAsMissing(t *testing.T) {
 	// A malformed payload (no blockID) is treated as missing — defensive
 	// against unexpected error envelopes that don't trip HasError().
-	// Latest=2, height 1 returns {"Error":"..."}, height 2 returns a real block.
+	// Latest=2, blocks below 2 return {"Error":"..."}, height 2 returns a real block.
 	connector := mocks.NewConnectorMock()
 	connector.
 		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(""))).
 		Return(tronOK(tronBlockJSON(2))).
 		Once()
 	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"1","detail":false}`))).
-		Return(tronOK(`{"Error":"validate signature error"}`)).
-		Once()
-	connector.
-		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronRequest(`{"id_or_num":"2","detail":false}`))).
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronAtLeast(2))).
 		Return(tronOK(tronBlockJSON(2))).
-		Once()
+		Maybe()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTronBelow(2))).
+		Return(tronOK(`{"Error":"validate signature error"}`)).
+		Maybe()
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
@@ -206,5 +239,4 @@ func TestTronLowerBoundDetector_BodyWithoutBlockIDCountsAsMissing(t *testing.T) 
 	for _, b := range result {
 		assert.Equal(t, int64(2), b.Bound)
 	}
-	connector.AssertExpectations(t)
 }

--- a/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound_test.go
+++ b/internal/upstreams/lower_bounds/tron_bounds/tron_lower_bound_test.go
@@ -1,6 +1,7 @@
 package tron_bounds_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -127,7 +128,7 @@ func TestTronLowerBoundDetector_FansOutOneSearchToAllFourBoundTypes(t *testing.T
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 
 	// One search returns one bound, the detector fans it out to all four types.
@@ -155,7 +156,7 @@ func TestTronLowerBoundDetector_AllAvailableReturnsOneForAllTypes(t *testing.T) 
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 	require.Len(t, result, 4)
 	for _, b := range result {
@@ -171,7 +172,7 @@ func TestTronLowerBoundDetector_LatestEmptyBodyFails(t *testing.T) {
 
 	detector := fastTron(tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector))
 
-	_, err := detector.DetectLowerBound()
+	_, err := detector.DetectLowerBound(context.Background())
 	require.Error(t, err)
 }
 
@@ -183,7 +184,7 @@ func TestTronLowerBoundDetector_LatestConnectorErrorPropagates(t *testing.T) {
 
 	detector := fastTron(tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector))
 
-	_, err := detector.DetectLowerBound()
+	_, err := detector.DetectLowerBound(context.Background())
 	require.Error(t, err)
 }
 
@@ -205,7 +206,7 @@ func TestTronLowerBoundDetector_EmptyBodyOnProbeMeansBlockMissing(t *testing.T) 
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 	require.Len(t, result, 4)
 	for _, b := range result {
@@ -233,7 +234,7 @@ func TestTronLowerBoundDetector_BodyWithoutBlockIDCountsAsMissing(t *testing.T) 
 
 	detector := tron_bounds.NewTronLowerBoundDetector("id", chains.TRON, time.Second, connector)
 
-	result, err := detector.DetectLowerBound()
+	result, err := detector.DetectLowerBound(context.Background())
 	require.NoError(t, err)
 	require.Len(t, result, 4)
 	for _, b := range result {

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -62,6 +62,22 @@ type ChainData struct {
 	NetVersion           string                 `yaml:"net-version"`
 	CallValidateContract string                 `yaml:"call-validate-contract"`
 	GasPriceCondition    []string               `yaml:"gas-price-condition"`
+	LowerBounds          *ChainLowerBounds      `yaml:"lower-bounds"`
+}
+
+// GoldLowerBound is a known-oldest data point for a chain, sourced from the
+// bundled chains.yaml. It is used to quickly detect whether an upstream is
+// fully archival for tx/receipts data without a full binary search.
+type GoldLowerBound struct {
+	Block uint64 `yaml:"block"`
+	Hash  string `yaml:"hash"`
+}
+
+// ChainLowerBounds holds the per-chain gold lower bounds. Only tx and receipts
+// carry a hash and are consulted during lower-bound detection.
+type ChainLowerBounds struct {
+	Tx       *GoldLowerBound `yaml:"tx"`
+	Receipts *GoldLowerBound `yaml:"receipts"`
 }
 
 type Protocol struct {
@@ -95,6 +111,7 @@ type ConfiguredChain struct {
 	MethodSpec           string
 	CallValidateContract string
 	GasPriceCondition    []string
+	LowerBounds          *ChainLowerBounds
 }
 
 var UnknownChain = &ConfiguredChain{
@@ -300,6 +317,7 @@ func configureChainsFromBytes(rawYaml []byte) (map[string]*ConfiguredChain, map[
 				MethodSpec:           methodSpec,
 				CallValidateContract: chain.CallValidateContract,
 				GasPriceCondition:    append([]string(nil), chain.GasPriceCondition...),
+				LowerBounds:          chain.LowerBounds,
 			}
 
 			for _, shortName := range chain.ShortNames {

--- a/pkg/chains/chains_test.go
+++ b/pkg/chains/chains_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetChainByGrpcId(t *testing.T) {
@@ -20,4 +21,21 @@ func TestGetChainByGrpcId(t *testing.T) {
 func TestGetChainByGrpcIdUnknown(t *testing.T) {
 	unknown := GetChainByGrpcId(-1)
 	assert.Equal(t, UnknownChain, unknown)
+}
+
+func TestGoldLowerBoundsParsedFromConfig(t *testing.T) {
+	ethereum := GetChain("ethereum")
+	require.NotNil(t, ethereum.LowerBounds)
+	require.NotNil(t, ethereum.LowerBounds.Tx)
+	require.NotNil(t, ethereum.LowerBounds.Receipts)
+
+	const expectedHash = "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+	assert.Equal(t, expectedHash, ethereum.LowerBounds.Tx.Hash)
+	assert.Equal(t, uint64(46147), ethereum.LowerBounds.Tx.Block)
+	assert.Equal(t, expectedHash, ethereum.LowerBounds.Receipts.Hash)
+}
+
+func TestGoldLowerBoundsAbsentWhenNotConfigured(t *testing.T) {
+	// Bitcoin has no lower-bounds section in chains.yaml.
+	assert.Nil(t, GetChain("bitcoin").LowerBounds)
 }

--- a/pkg/test_utils/mocks/lower_bound.go
+++ b/pkg/test_utils/mocks/lower_bound.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -16,8 +17,8 @@ func NewLowerBoundDetectorMock() *LowerBoundDetectorMock {
 	return &LowerBoundDetectorMock{}
 }
 
-func (m *LowerBoundDetectorMock) DetectLowerBound() ([]protocol.LowerBoundData, error) {
-	args := m.Called()
+func (m *LowerBoundDetectorMock) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	args := m.Called(ctx)
 	var bounds []protocol.LowerBoundData
 	if args.Get(0) != nil {
 		bounds = args.Get(0).([]protocol.LowerBoundData)


### PR DESCRIPTION
# Gold lower bounds + lower-bound detection fixes

## Summary

This PR fixes several correctness bugs in EVM lower-bound detection and adds a fast
"gold lower bound" short-circuit that lets us skip the binary search entirely when a
chain ships a known-oldest data point. It also splits the monolithic EVM detector into
per-type files and hardens the retry behaviour of the shared search.

## Gold lower bounds

`chains.yaml` now carries an optional `lower-bounds` section per chain, parsed into new
`ChainLowerBounds` / `GoldLowerBound` types (`pkg/chains/chains.go`) and threaded through
`ConfiguredChain`. A gold bound is a known-oldest `{block, hash}` pair for a chain. This
data already ships in the bundled `chains.yaml` submodule — it was simply never parsed, so
the change is purely additive (`bitcoin` and other chains without the section stay `nil`).

When a chain has a gold hash for `tx` or `receipts`, the detector issues a **single**
`eth_getTransactionByHash` / `eth_getTransactionReceipt` probe for that ancient hash:

- **Hit** → the upstream serves that oldest datum, so it is fully archival and the bound
  resolves to `1` with no binary search.
- **Miss** (null result, no-data error, or any other error) → falls back to the normal
  search path.

This is implemented in the new `gold_bound.go` and short-circuits at the top of
`DetectLowerBound`. EVM detectors now receive the full `*chains.ConfiguredChain` (instead
of just `chains.Chain`) so they can read the configured bounds; `LowerBoundResults` was
exported so the short-circuit reuses the same per-supported-type fan-out as the search.

## Lower-bound search fixes

The shared `LowerBoundSearchCalculator` (`lower_bound_search.go`) was rewritten to fix
real detection bugs:

- **Genesis-hole bug.** The old search trusted block 1 whenever it was retained. If a node
  retained genesis but had a hole above it, it reported a bogus bound of 1. The search now
  converges on the real lower boundary of the contiguous retained range regardless of
  whether genesis happens to be present.
- **Offset search for tx/receipts.** Historical blocks may legitimately contain no
  transactions, which made a naive "first tx of the middle block" probe give up too early.
  A new offset variant (`detectWithOffset` / `shiftLeftAndSearch`) scans downward up to
  `maxOffset` (20) blocks from a no-data midpoint to tolerate sporadic empty/missing blocks;
  a hole wider than the offset is abandoned and the search moves higher. Tx and receipts
  detectors use this variant; block/state/proof use the plain binary search.
- **No-data errors treated as "no data here".** Archival/pruning gaps surface as a wide
  range of upstream error messages. These are now classified (`no_data_errors.go`) and
  treated as "no data at this height, search higher" rather than aborting the whole
  detection. Only genuinely unexpected failures propagate.
- **Convergence guard.** On a non-trivial chain (latest > 10) where nothing is ever
  confirmed, detection now fails cleanly so the processor keeps the previously cached
  bound instead of publishing a bogus `1`. Tiny chains still resolve to `1`.
- **Cached-bound reuse.** A previously found bound is re-confirmed with a single probe
  before any re-search, keeping steady-state cost to one call per cycle.
- **Retry policy.** Probes and latest-height fetches now retry with exponential backoff
  (up to 30 attempts, 1s → 1m) instead of the previous fixed 3× / 100ms, so transient
  upstream errors no longer poison a detection cycle. `SetSearchRetryPolicy` lets tests
  run with negligible backoff.

## Refactor: split `evm_bounds` by bound type

`evm_lower_bound.go` was ~470 lines mixing construction, five per-type probes, JSON
helpers, and the error-hint list. It is now split into focused files so each bound type
reads as a self-contained unit, with the shared wiring left behind:

- `block_bound.go`, `state_bound.go`, `tx_bound.go`, `receipts_bound.go`, `proof_bound.go`
  — one constructor + probe per data type.
- `evm_util.go` — block/tx envelope parsing and hex/JSON helpers.
- `no_data_errors.go` — the no-data error classification and hint list.
- `gold_bound.go` — the gold short-circuit.
- `evm_lower_bound.go` — construction, probe dispatch, `fetchLatestHeight`, and the
  JSON-RPC `call` helper.

