### PR TITLE
chore: bump node from 22-alpine to 24-alpine in hardhat e2e image

### DIFF
--- a/test/e2e/internal/hardhat/Dockerfile
+++ b/test/e2e/internal/hardhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev


### PR DESCRIPTION
Replaces #258 (node 26-alpine), which was closed because Node 26 doesn't reach LTS until October 2026 and hardhat 2.22.18 hasn't been validated on it.

Node 24 is the current Active LTS, so this keeps the hardhat e2e fixture on a supported, well-tested runtime. Blast radius is limited to the e2e test image — nothing in the production build uses this Dockerfile.