### PR TITLE
chore: update go to 1.26.5 in ci workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,14 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.26.0"
+        default: "1.26.5"
   pull_request: null
   push:
     branches:
       - main
 
 env:
-  GO_VERSION: ${{ inputs.go-version || '1.26.0' }}
+  GO_VERSION: ${{ inputs.go-version || '1.26.5' }}
 
 jobs:
   build:
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ["1.26.0"]
+        go-version: ["1.26.5"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,29 +14,29 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: drpcorg/nodecore
-  GO_VERSION: "1.26.0"
+  GO_VERSION: "1.26.5"
 
 jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
-      go-version: "1.26.0"
+      go-version: "1.26.5"
 
   lint:
     uses: ./.github/workflows/lint.yml
     with:
-      go-version: "1.26.0"
+      go-version: "1.26.5"
 
   e2e:
     uses: ./.github/workflows/e2e.yml
     with:
-      go-version: "1.26.0"
+      go-version: "1.26.5"
     secrets:
       NODECORE_E2E_DRPC_KEY: ${{ secrets.NODECORE_E2E_DRPC_KEY }}
   build:
     uses: ./.github/workflows/build.yml
     with:
-      go-version: "1.26.0"
+      go-version: "1.26.5"
 
   upload-release-assets:
     if: github.event_name == 'release'
@@ -52,13 +52,13 @@ jobs:
       - name: Download Ubuntu artifacts
         uses: actions/download-artifact@v4
         with:
-          name: nodecore-ubuntu-latest-1.26.0-${{ steps.short_sha.outputs.sha }}
+          name: nodecore-ubuntu-latest-1.26.5-${{ steps.short_sha.outputs.sha }}
           path: ./artifacts/ubuntu
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
         with:
-          name: nodecore-macos-latest-1.26.0-${{ steps.short_sha.outputs.sha }}
+          name: nodecore-macos-latest-1.26.5-${{ steps.short_sha.outputs.sha }}
           path: ./artifacts/macos
 
       - name: Prepare release assets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.26.0"
+        default: "1.26.5"
     secrets:
       NODECORE_E2E_DRPC_KEY:
         required: false
@@ -18,7 +18,7 @@ on:
       - 'chart/nodecore/**'
 
 env:
-  GO_VERSION: ${{ inputs.go-version || '1.26.0' }}
+  GO_VERSION: ${{ inputs.go-version || '1.26.5' }}
 
 jobs:
   e2e:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,14 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.26.0"
+        default: "1.26.5"
   pull_request:
   push:
     branches:
       - main
 
 env:
-  GO_VERSION: ${{ inputs.go-version || '1.26.0' }}
+  GO_VERSION: ${{ inputs.go-version || '1.26.5' }}
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.26.0"
+        default: "1.26.5"
   pull_request:
     paths-ignore:
       - 'chart/**'
@@ -21,7 +21,7 @@ on:
       - 'chart/nodecore/**'
 
 env:
-  GO_VERSION: ${{ inputs.go-version || '1.26.0' }}
+  GO_VERSION: ${{ inputs.go-version || '1.26.5' }}
 
 jobs:
   test:


### PR DESCRIPTION
Aligns the CI Go toolchain with the Docker builder image, which was bumped to golang:1.26.5-alpine in #254. Updates all `GO_VERSION` pins, workflow input defaults, and the build matrix from 1.26.0 to 1.26.5 across build, lint, test, e2e, and docker-release workflows.

The hardcoded artifact names in docker-release.yml (`nodecore-<os>-1.26.0-<sha>`) are updated in the same commit so download-artifact keeps matching what build.yml uploads.

Go 1.26.1–1.26.5 are security/bugfix point releases (crypto/tls, os.Root symlink escape, crypto/x509, module checksum validation). The `go 1.26.0` directive in go.mod is left as-is — it's the minimum language version and builds unchanged under the 1.26.5 toolchain.