### PR TITLE
fix: drop method label from upstream request duration histogram to bound /metrics cardinality

### DIFF
--- a/docs/nodecore/08-prometheus-metrics.md
+++ b/docs/nodecore/08-prometheus-metrics.md
@@ -219,7 +219,6 @@ This document describes all Prometheus metrics exposed by nodecore on the `metri
 **Labels:**
 
 - `chain` - The blockchain network
-- `method` - The RPC method name
 - `upstream` - The upstream ID
 
 **Buckets:** [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50]
@@ -227,6 +226,8 @@ This document describes all Prometheus metrics exposed by nodecore on the `metri
 **Source:** `internal/dimensions/tracker.go`
 
 **Use Case:** Measure latency distribution for requests to specific upstreams.
+
+> **Note:** unlike the request counters, this histogram deliberately has no `method` label — each histogram label combination produces a series per bucket, so a per-method histogram would make the `/metrics` exposition grow with the number of methods × upstreams and eventually exceed scrapers' response-size limits. Per-method latency quantiles are still tracked internally and used for upstream rating.
 
 ---
 

--- a/internal/dimensions/dims.go
+++ b/internal/dimensions/dims.go
@@ -74,7 +74,7 @@ func (d *UpstreamDimensions) TrackSuccessfulRetries() {
 func (d *UpstreamDimensions) TrackRequestDuration(duration float64) {
 	d.quantileTracker.add(duration)
 	key := d.key.Load()
-	requestDurationMetric.WithLabelValues(key.chain.String(), key.method, key.upstreamId).Observe(duration)
+	requestDurationMetric.WithLabelValues(key.chain.String(), key.upstreamId).Observe(duration)
 }
 
 func (d *UpstreamDimensions) TrackTotalRequests() {

--- a/internal/dimensions/tracker.go
+++ b/internal/dimensions/tracker.go
@@ -39,6 +39,11 @@ var errorTotalMetric = prometheus.NewCounterVec(
 	[]string{"chain", "method", "upstream"},
 )
 
+// requestDurationMetric intentionally has no `method` label: histogram buckets
+// multiply every label combination by len(DefBuckets)+2 series, so a per-method
+// histogram makes the /metrics exposition grow with (methods x upstreams) until
+// scrapers hit their response-size limits. Per-method latency quantiles are still
+// tracked internally (see quantileTracker) and used for upstream rating.
 var requestDurationMetric = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Namespace: config.AppName,
@@ -47,7 +52,7 @@ var requestDurationMetric = prometheus.NewHistogramVec(
 		Buckets:   DefBuckets,
 		Help:      "The duration of RPC requests to upstreams",
 	},
-	[]string{"chain", "method", "upstream"},
+	[]string{"chain", "upstream"},
 )
 
 var headLagMetric = prometheus.NewGaugeVec(


### PR DESCRIPTION
## Problem

`nodecore_upstream_request_duration` is a histogram labeled by `(chain, method, upstream)`. Every `(chain, method, upstream)` combination that gets exercised creates **14 series** (12 buckets + `+Inf` + `_sum`/`_count`), and the Prometheus client never expires a label combination once observed. On a deployment with many upstreams, the exposition grows roughly with `methods × upstreams × 14` as traffic gradually exercises more method/upstream combinations. In a large deployment this histogram alone accounted for about half of all exposed series, and the `/metrics` response eventually exceeded the scraper's max response size — at which point the scraper drops the **whole target** and the service silently disappears from monitoring while being perfectly healthy.

## Fix

Drop the `method` label from the duration histogram, keeping `(chain, upstream)`. This caps the histogram's cardinality at `chains × upstreams × 14` regardless of how many methods are exercised, and removes the dominant unbounded-growth term from the exposition.

What is preserved:

- Per-method **request/error/retry counters** (`nodecore_upstream_requests_total`, `nodecore_upstream_errors_total`, `nodecore_upstream_successful_retries_total`) are unchanged — per-method traffic and error visibility stays.
- Per-method **latency quantiles** are still tracked internally by the in-memory `quantileTracker` and used by the rating registry (`latencyP90/95/99` in the score function input), so upstream scoring is unaffected.

What changes for dashboards: latency histogram queries can no longer group by `method` — per-upstream latency distribution is now aggregated across methods.

## Changes

- `internal/dimensions/tracker.go` — remove `method` from `requestDurationMetric` labels, with a comment explaining why it must stay off.
- `internal/dimensions/dims.go` — update the `Observe` call site.
- `docs/nodecore/08-prometheus-metrics.md` — update the label list and document the rationale.

## Testing

- `go build ./...` and full `go test ./...` pass.
- No dashboards or alerts in this repo reference the `method` label of this metric.