### PR TITLE
fix: don't forward hop-by-hop and Accept-Encoding client headers upstream on REST

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,15 @@ env:
   GO_VERSION: ${{ inputs.go-version || '1.26.5' }}
 
 jobs:
+  # The go version is intentionally NOT part of the matrix: it would end up in
+  # the check name (build (ubuntu-latest, 1.26.0)), and the required status
+  # contexts in the main ruleset break on every version bump. GO_VERSION env
+  # (fed by the workflow_call input) is the single source instead.
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ["1.26.5"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -34,7 +37,7 @@ jobs:
       - name: Setup Go project
         uses: ./.github/actions/setup-go-project
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
           cache-key-suffix: "build-${{ matrix.os }}"
 
       - name: Get version metadata
@@ -53,6 +56,6 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
-          name: nodecore-${{ matrix.os }}-${{ matrix.go-version }}-${{ steps.version_meta.outputs.sha }}
+          name: nodecore-${{ matrix.os }}-${{ env.GO_VERSION }}-${{ steps.version_meta.outputs.sha }}
           path: nodecore
           retention-days: 7

--- a/internal/upstreams/connectors/http_connector.go
+++ b/internal/upstreams/connectors/http_connector.go
@@ -53,6 +53,28 @@ var defaultResponseHeaderDeny = []string{
 	"Server",
 }
 
+// defaultRequestHeaderDeny is the request-side mirror of the response deny
+// list: RFC 7230 §6.1 hop-by-hop headers plus Host and Content-Length (both
+// owned by the transport for the *outgoing* request) and Accept-Encoding.
+// Accept-Encoding must stay with the transport: forwarding the client's value
+// disables Go's transparent decompression, so a gzip upstream body would ride
+// through unmarked (Content-Encoding is stripped from responses) and get
+// compressed a second time by the server gzip middleware (issue #268).
+var defaultRequestHeaderDeny = mapset.NewThreadUnsafeSet(
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+	"Host",
+	"Content-Length",
+	"Accept-Encoding",
+)
+
 func (h *HttpConnector) Unsubscribe(_ string) {
 }
 
@@ -245,14 +267,20 @@ func (h *HttpConnector) applyConfigHeaders(req *http.Request) {
 
 // applyClientHeaders forwards per-request client headers onto the upstream
 // request, except keys the connector config already owns - those are
-// typically auth tokens that a curious client must not be able to override.
-// HTTP headers are case-insensitive, so the conflict check canonicalises
-// both sides via http.CanonicalHeaderKey; without this, a config
+// typically auth tokens that a curious client must not be able to override -
+// and keys in defaultRequestHeaderDeny, which belong to the nodecore<->upstream
+// hop rather than to the client.
+// HTTP headers are case-insensitive, so both checks canonicalise
+// via http.CanonicalHeaderKey; without this, a config
 // "Authorization" + a client "authorization" would slip past as distinct
 // strings and both end up on the wire after req.Header.Add canonicalises.
 func (h *HttpConnector) applyClientHeaders(req *http.Request, headers map[string][]string) {
 	for k, vs := range headers {
-		if _, taken := h.additionalHeaders[http.CanonicalHeaderKey(k)]; taken {
+		canonical := http.CanonicalHeaderKey(k)
+		if defaultRequestHeaderDeny.Contains(canonical) {
+			continue
+		}
+		if _, taken := h.additionalHeaders[canonical]; taken {
 			continue
 		}
 		for _, v := range vs {

--- a/internal/upstreams/connectors/http_connector_test.go
+++ b/internal/upstreams/connectors/http_connector_test.go
@@ -1,10 +1,13 @@
 package connectors_test
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/drpcorg/nodecore/internal/config"
@@ -495,6 +498,100 @@ func TestRestRequest_ConfigHeadersWinAcrossCasing(t *testing.T) {
 				tc.configKey, tc.clientKey)
 		})
 	}
+}
+
+// Hop-by-hop headers (RFC 7230 §6.1) and Accept-Encoding must not be
+// forwarded from the client to the upstream. Forwarding Accept-Encoding is
+// how double-gzip happens (issue #268): an explicit Accept-Encoding on the
+// outgoing request disables Go's transparent decompression, the compressed
+// body then loses its Content-Encoding in the response deny list, and the
+// server-side gzip middleware compresses it a second time.
+func TestRestRequest_HopByHopClientHeadersNotForwarded(t *testing.T) {
+	httpmock.Activate(t)
+	defer httpmock.Deactivate()
+
+	var gotHeaders http.Header
+	httpmock.RegisterResponder("POST", "=~^http://localhost:8080/.*",
+		func(req *http.Request) (*http.Response, error) {
+			gotHeaders = req.Header.Clone()
+			return httpmock.NewBytesResponse(200, []byte(`{}`)), nil
+		})
+
+	connector := newRestConnector(t, &config.ApiConnectorConfig{Url: "http://localhost:8080"})
+	req := protocol.NewUpstreamRestRequest(
+		"1",
+		"POST#/exchange",
+		&protocol.RequestParams{
+			Headers: map[string][]string{
+				"Accept-Encoding":     {"gzip"},
+				"Connection":          {"keep-alive"},
+				"Keep-Alive":          {"timeout=5"},
+				"Proxy-Authorization": {"Basic abc"},
+				"Te":                  {"trailers"},
+				"Trailer":             {"X-Checksum"},
+				"Transfer-Encoding":   {"chunked"},
+				"Upgrade":             {"websocket"},
+				"Host":                {"evil.example.com"},
+				"Content-Length":      {"999"},
+				"X-Custom":            {"hello"},
+			},
+		},
+		nil, "",
+	)
+
+	r := connector.SendRequest(context.Background(), req)
+
+	require.False(t, r.HasError())
+	for _, denied := range []string{
+		"Accept-Encoding", "Connection", "Keep-Alive", "Proxy-Authorization",
+		"Te", "Trailer", "Transfer-Encoding", "Upgrade", "Host", "Content-Length",
+	} {
+		assert.Empty(t, gotHeaders.Values(denied),
+			"client %s must not be forwarded to the upstream", denied)
+	}
+	assert.Equal(t, []string{"hello"}, gotHeaders.Values("X-Custom"),
+		"non-denied client headers must still pass through")
+}
+
+// End-to-end regression test for issue #268: a client asking for gzip must
+// not leave the upstream's compressed bytes in the body. With the client's
+// Accept-Encoding stripped, Go's transport negotiates gzip itself and
+// transparently decompresses, so the framework sees plain JSON and the
+// server middleware compresses exactly once.
+func TestRestRequest_UpstreamGzipBodyReachesFrameworkDecompressed(t *testing.T) {
+	plain := []byte(`{"version":"fulu"}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			_, _ = gz.Write(plain)
+			_ = gz.Close()
+			return
+		}
+		_, _ = w.Write(plain)
+	}))
+	defer srv.Close()
+
+	connector, err := connectors.NewHttpConnector(
+		&config.ApiConnectorConfig{Url: srv.URL},
+		specs.RestConnector,
+		"",
+	)
+	require.NoError(t, err)
+	req := protocol.NewUpstreamRestRequest(
+		"1",
+		"GET#/eth/v1/node/syncing",
+		&protocol.RequestParams{
+			Headers: map[string][]string{"Accept-Encoding": {"gzip"}},
+		},
+		nil, "",
+	)
+
+	r := connector.SendRequest(context.Background(), req)
+
+	require.False(t, r.HasError())
+	assert.Equal(t, plain, r.ResponseResult(),
+		"body must be plain JSON, not the upstream's gzip bytes")
 }
 
 // REST treats anything in 2xx as success - 200, 201, 204 etc. Earlier


### PR DESCRIPTION
## Problem

Fixes #268 — REST passthrough double-gzips responses when the client sends `Accept-Encoding: gzip`.

The REST flow (`applyClientHeaders`) forwarded every client header to the upstream, including `Accept-Encoding`. An explicit `Accept-Encoding` on the outgoing request disables Go's transparent decompression, so the upstream's gzip body rode through the connector still compressed while `defaultResponseHeaderDeny` stripped its `Content-Encoding`; the server gzip middleware then compressed it a second time under a single `Content-Encoding: gzip` header. Standard clients decompress one layer and get raw gzip bytes instead of JSON.

## Fix

Add `defaultRequestHeaderDeny` — a request-side mirror of the response deny list — applied in `applyClientHeaders`: RFC 7230 §6.1 hop-by-hop headers plus `Host`, `Content-Length` and `Accept-Encoding` (all owned by the nodecore↔upstream hop, not the client).

With the client's `Accept-Encoding` no longer pinned on the outgoing request, Go's transport negotiates gzip itself and transparently decompresses, so bodies reach the framework plain and are compressed exactly once — the same behavior the JSON-RPC flow already has.

Side effects, all intentional:
- quorum signatures and REST body parsing no longer see gzip bytes when a client asks for compression
- client `Host`/`Connection`/other hop-by-hop headers no longer leak to upstreams
- connector-config headers are untouched, so the `Accept-Encoding: identity` workaround from the issue keeps working

## Tests

- `TestRestRequest_HopByHopClientHeadersNotForwarded` — denied client headers don't reach the upstream, custom headers still do
- `TestRestRequest_UpstreamGzipBodyReachesFrameworkDecompressed` — end-to-end regression for #268 against a real gzip-serving httptest server; fails on main with the gzip magic `1f 8b` in the body