### PR TITLE
fix: make chain-status stream self-healing and re-add recovered upstreams deterministically

### DIFF
--- a/docs/superpowers/specs/2026-07-16-chain-status-resync-design.md
+++ b/docs/superpowers/specs/2026-07-16-chain-status-resync-design.md
@@ -1,0 +1,214 @@
+# Self-healing chain-status stream — design
+
+- **Date:** 2026-07-16
+- **Status:** Implemented — branch `fix/chain-status-resync`
+- **Area:** `internal/server/emerald` (`sub_chain_status.go`), `internal/upstreams` (`chain_supervisor.go`, `upstream_events.go`), `internal/protocol` (`data.go`)
+
+## 1. Problem
+
+The `SubscribeChainStatus` gRPC stream is **delta-based**: one `FullResponse`
+per chain at subscription time, then only change events. Delta delivery is not
+reliable end-to-end, and there is no reconciliation mechanism — so a single
+lost delta desynchronizes the consumer **forever**.
+
+Production incident that surfaced it: a settings validator
+(`eth_log_index_validator`) stopped an upstream that served corrupt `logIndex`
+data (upstream-node bug, erigontech/erigon#22504). After the node was fixed,
+nodecore re-validated the upstream and logged `statuses=[AVAILABLE/1]`
+continuously — while a stream consumer kept reporting the chain **Unavailable
+for 75 more minutes**, until its connection was rebuilt. A second episode the
+next morning showed per-connection divergence across identical subscribers of
+the same instance (most stale, a few healthy) — direct proof of
+per-connection delta loss rather than a state bug on either end.
+
+Two independent defects compound:
+
+1. **Lossy fan-out under a delta-only protocol.** The subscription manager
+   (`pkg/utils/subscriptions.go` `Publish`) intentionally drops an event when
+   a subscriber channel is full — back-pressure protection; a busy instance
+   logs hundreds of such drops per day. Consumers have equivalent lossy hops
+   on their side. One dropped `Status: Available` wrapper = permanently stale
+   subscriber.
+
+2. **Chain supervisor ignores `ValidUpstreamEvent`.**
+   `RemoveUpstreamEvent` (emitted on `FatalSettingError`) deletes the
+   upstream from the chain map, but the recovery event has no handler in
+   `processEvents`. The upstream is re-added only when a later
+   `StateUpstreamEvent` happens to fire — and those are suppressed by a
+   `Same()` check unless some sub-state actually changed. A node that comes
+   back identical to how it left is never re-added. (In both production
+   episodes re-add worked only because restarting the upstream node changed
+   its lower bounds.)
+
+## 2. Goal
+
+A consumer of `SubscribeChainStatus` converges to nodecore's actual chain
+state within a **bounded time** (one resync interval), no matter what happens
+to individual deltas on either side of the stream; and a recovered upstream
+re-enters its chain **deterministically**, not as a side effect of incidental
+state churn.
+
+### Non-goals
+
+- **No lossless fan-out.** The `Publish` drop is deliberate back-pressure;
+  with resync in place, per-event reliability is unnecessary. Rejected also
+  because it touches the hot path of every subscription in the process.
+- **No consumer-side changes.** The producer-side resync repairs every
+  consumer at once; requiring consumer deploys was rejected.
+- **No resync-interval configuration.** A constant is enough until proven
+  otherwise.
+- No changes to the initial-handshake semantics (`FullResponse`, wait-for-head).
+
+## 3. Key decisions (settled → implemented)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Repair mechanism | Periodic state snapshot from the producer, not reliability per event |
+| 2 | Snapshot framing | Regular delta-style response, `FullResponse` **not** set — consumers use that flag only to (re)create per-chain objects on reconnect |
+| 3 | Snapshot content | All state wrappers: status, methods, lower bounds, finalization blocks, sub-methods, labels — **deliberately no head** (§6) |
+| 4 | Interval | `defaultChainStateResyncInterval = 1 minute`, per chain, per connection |
+| 5 | Before first full | No snapshots (`fullSent` gate): consumers create their per-chain object only from a full response and skip earlier state updates |
+| 6 | Recovery re-add | `ValidUpstreamEvent` carries the upstream-state snapshot; chain supervisor applies it symmetrically to `RemoveUpstreamEvent` |
+| 7 | Head on re-add | Re-registered in fork choice only when the snapshot head is non-empty, so a stale snapshot cannot zero the chain head |
+| 8 | Nil-state `ValidUpstreamEvent` | Ignored (defensive) |
+
+## 4. Terminology
+
+- **Delta** — a `SubscribeChainStatusResponse` carrying only changed state
+  wrappers, produced by `ChainSupervisorState.Compare` after `updateState()`.
+- **Wrapper** — one typed state fragment (`StatusWrapper`, `MethodsWrapper`,
+  `LowerBoundsWrapper`, `BlocksWrapper`, `LabelsWrapper`, `SubMethodsWrapper`,
+  `HeadWrapper`) mapped 1:1 to a `ChainEvent` on the wire.
+- **Snapshot** — the periodic resync response: the full current state as a
+  wrapper list, minus the head (§6).
+- **Settings validators** — per-upstream data-quality checks (chain id, log
+  index, call limit, …); `FatalSettingError` → `RemoveUpstreamEvent`,
+  recovery → `ValidUpstreamEvent`.
+
+## 5. Architecture
+
+```
+ settings validator ──► upstream event loop ──► chain supervisor ──► per-connection
+ (Fatal/Valid)          (upstream_events.go)    (chain_supervisor.go)  subscription      ⚠ lossy
+                                                    │ updateState()    (subscriptions.go)
+                                                    ▼                        │
+                                              Compare → deltas               ▼
+                                                                   per-chain goroutine
+                                                                   (sub_chain_status.go)
+                                                                     │  deltas as-is
+                                                                     │  + snapshot every 60s   ◄── NEW
+                                                                     ▼
+                                                              responses chan → gRPC Send ──► consumer
+                                                              (blocking, not lossy)          (own lossy hops ⚠)
+```
+
+Any `⚠` hop may drop a delta; the snapshot repairs the consumer within one
+interval regardless of where the loss happened.
+
+## 6. Periodic resync (`sub_chain_status.go`)
+
+Each per-chain goroutine gets a `time.Ticker`. On tick (only after the
+initial full response went out):
+
+```go
+state = chainSupervisor.GetChainState()
+sendResponse(ctx, responses, stateWrappersToResponse(grpcId, snapshotStateWrappers(state)))
+```
+
+`snapshotStateWrappers` rebuilds the wrapper list from the current state —
+status, methods, lower bounds, blocks, sub-methods, labels — **without the
+head**, for two reasons:
+
+- head freshness is already guaranteed by the per-block head events;
+- known consumers reduce any response that carries a head to a *head-only*
+  update for an already-known chain — a snapshot with a head would lose
+  exactly the state it is meant to repair. A head-less response routes into
+  their state-update path, which provably works.
+
+Cost: one small message per chain per connection per minute.
+
+## 7. Deterministic re-add (`chain_supervisor.go`, `upstream_events.go`, `protocol/data.go`)
+
+`ValidUpstreamEvent` gains a `State *UpstreamState` field, filled by the
+upstream event loop from the snapshot it already holds. The chain supervisor
+handles the event symmetrically to removal:
+
+```go
+case *protocol.ValidUpstreamEvent:
+    if eventType.State != nil {
+        availabilityMetric.Set(...)
+        b.upstreamStates.Store(event.Id, eventType.State)
+        b.updateState()                       // recomputes + publishes the delta
+        if !eventType.State.HeadData.IsEmptyByHeight() {
+            b.updateHead(...)                 // re-register in fork choice
+        }
+    }
+```
+
+## 8. Edge cases
+
+- **Consumer without the per-chain object on a live stream** (never got the
+  initial full, e.g. chain had no head at subscribe time): it skips state-only
+  responses; unchanged behavior — the per-chain goroutine still sends the
+  full response first once a head appears, snapshots only after.
+- **Chain with zero upstreams:** snapshot truthfully carries
+  `Status: Unavailable`, empty methods/bounds.
+- **`ValidUpstreamEvent` with empty head in the snapshot:** state re-added,
+  fork-choice head left to the upstream's next head event (decision #7).
+- **Repeated remove/re-add flapping:** each cycle publishes its deltas as
+  before; snapshots bound the damage of any lost one.
+
+## 9. Testing
+
+- `TestChainSupervisorValidUpstreamEventRestoresRemovedUpstream` — remove →
+  valid restores the upstream state, chain status, head, and emits a
+  `StatusWrapper(Available)` delta to subscribers.
+- `TestChainSupervisorValidUpstreamEventWithoutStateIsIgnored` — defensive
+  nil-state case.
+- `TestSubscribeChainStatus_PeriodicResyncResendsStateWithoutHead` — simulates
+  the lost delta (state mutated with no event reaching the stream) and
+  verifies the snapshot repairs it: non-full response, carries status and
+  methods, no head event present.
+- `TestSubscribeChainStatus_NoResyncBeforeFirstFullResponse` — no snapshots
+  before the initial full response.
+
+## 10. Live validation
+
+A/B harness: mock EVM upstream with toggleable logIndex corruption
+(`first log index is 200 instead of 0` — the exact signature of
+erigontech/erigon#22504) + a gRPC client on `SubscribeChainStatus`, strict
+mode, `validation-interval: 1s`.
+
+```
+09:37:13  STATUS=AVAIL_UNAVAILABLE   <- validator stops the upstream
+09:37:33  STATUS=AVAIL_OK            <- recovery propagates
+09:37:59  STATUS=AVAIL_OK methods=61 bounds=0 finalization subs=0 nodes=1   <- snapshot
+09:38:59  STATUS=AVAIL_OK methods=61 bounds=0 finalization subs=0 nodes=1   <- snapshot, 60s later
+```
+
+Snapshots carry no head; heads keep flowing as separate per-block events.
+On the pre-fix binary the same scenario recovers only when incidental state
+churn (restarted detectors) happens to fire a `StateUpstreamEvent`, and a
+lost delta is never repaired.
+
+## 11. Key code references
+
+- `internal/server/emerald/sub_chain_status.go` — `SubscribeChainStatusWithResync`,
+  `snapshotStateWrappers`, the `fullSent` gate.
+- `internal/upstreams/chain_supervisor.go` — `processEvents` (`ValidUpstreamEvent`
+  case), `updateState`, `updateHead`.
+- `internal/upstreams/upstream_events.go` — `processStateEvents`
+  (`ValidUpstreamStateEvent` → `ValidUpstreamEvent{State}`).
+- `pkg/utils/subscriptions.go` — `Publish` (the deliberate drop this design
+  routes around).
+
+## 12. Open questions / future
+
+- Consumers that reduce a head-carrying response to a head-only update would
+  still lose state if a head ever gets batched together with state wrappers;
+  worth fixing on the consumer side eventually, though this design never
+  produces such a batch.
+- If minute-scale staleness ever matters, the interval can become a server
+  config knob; not needed today.
+- The same resync pattern could cover `NativeSubscribe`-style streams if they
+  grow state semantics.

--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -346,7 +346,14 @@ type RemoveUpstreamEvent struct{}
 
 func (r RemoveUpstreamEvent) eventData() {}
 
-type ValidUpstreamEvent struct{}
+// ValidUpstreamEvent carries the upstream-state snapshot taken at the moment
+// the settings validators declared the upstream healthy again. The chain
+// supervisor uses it to re-register the upstream immediately; without the
+// snapshot the re-add would have to wait for a later StateUpstreamEvent,
+// which only fires when some sub-state actually changes.
+type ValidUpstreamEvent struct {
+	State *UpstreamState
+}
 
 func (r ValidUpstreamEvent) eventData() {}
 

--- a/internal/server/emerald/sub_chain_status.go
+++ b/internal/server/emerald/sub_chain_status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/drpcorg/nodecore/internal/buildinfo"
 	"github.com/drpcorg/nodecore/internal/upstreams"
@@ -17,9 +18,25 @@ import (
 
 var errNilUpstreamSupervisor = errors.New("upstream supervisor cannot be nil")
 
+// The chain-status protocol is delta-based, and deltas travel over lossy hops
+// (buffered-channel fan-outs on both ends drop events under pressure). A lost
+// delta used to leave the subscriber permanently stale until it rebuilt the
+// connection. The periodic resync bounds that staleness by one interval.
+const defaultChainStateResyncInterval = time.Minute
+
 func SubscribeChainStatus(
 	upstreamSupervisor upstreams.UpstreamSupervisor,
 	stream dshackle.Blockchain_SubscribeChainStatusServer,
+) error {
+	return SubscribeChainStatusWithResync(upstreamSupervisor, stream, defaultChainStateResyncInterval)
+}
+
+// SubscribeChainStatusWithResync is SubscribeChainStatus with a caller-chosen
+// state-resync interval; tests use it to shrink the wait.
+func SubscribeChainStatusWithResync(
+	upstreamSupervisor upstreams.UpstreamSupervisor,
+	stream dshackle.Blockchain_SubscribeChainStatusServer,
+	resyncInterval time.Duration,
 ) error {
 	if upstreamSupervisor == nil {
 		return errNilUpstreamSupervisor
@@ -38,7 +55,7 @@ func SubscribeChainStatus(
 	}()
 
 	for _, chainSupervisor := range upstreamSupervisor.GetChainSupervisors() {
-		subscribeChainSupervisorStates(ctx, chainSupervisor, chainSubs, responses)
+		subscribeChainSupervisorStates(ctx, chainSupervisor, chainSubs, responses, resyncInterval)
 	}
 
 	for {
@@ -49,7 +66,7 @@ func SubscribeChainStatus(
 			if ok {
 				switch c := chainSupervisorEvent.(type) {
 				case *upstreams.AddChainSupervisorEvent:
-					subscribeChainSupervisorStates(ctx, c.ChainSupervisor, chainSubs, responses)
+					subscribeChainSupervisorStates(ctx, c.ChainSupervisor, chainSubs, responses, resyncInterval)
 				}
 			}
 		case response, ok := <-responses:
@@ -68,6 +85,7 @@ func subscribeChainSupervisorStates(
 	chainSupervisor upstreams.ChainSupervisor,
 	chainSubs map[chains.Chain]*utils.Subscription[*upstreams.ChainSupervisorStateWrapperEvent],
 	responses chan *dshackle.SubscribeChainStatusResponse,
+	resyncInterval time.Duration,
 ) {
 	if chainSupervisor == nil {
 		return
@@ -95,10 +113,24 @@ func subscribeChainSupervisorStates(
 			fullSent = true
 		}
 
+		resyncTicker := time.NewTicker(resyncInterval)
+		defer resyncTicker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-resyncTicker.C:
+				// Nothing to resync until the initial full response went out:
+				// the consumer creates its per-chain object only from a full
+				// response and silently skips state updates before that.
+				if !fullSent {
+					continue
+				}
+				state = chainSupervisor.GetChainState()
+				if !sendResponse(ctx, responses, stateWrappersToResponse(grpcId, snapshotStateWrappers(state))) {
+					return
+				}
 			case event, ok := <-chainSupervisorStatesSub.Events:
 				if ok {
 					if len(event.Wrappers) == 0 {
@@ -135,6 +167,22 @@ func sendResponse(
 		return false
 	case responses <- resp:
 		return true
+	}
+}
+
+// snapshotStateWrappers rebuilds the full current state as a wrapper list,
+// deliberately WITHOUT the head. Head freshness is already guaranteed by the
+// per-block head events; more importantly, consumers reduce any response that
+// carries a head to a head-only update for an existing upstream, so a
+// snapshot with a head would lose exactly the state it is meant to repair.
+func snapshotStateWrappers(state upstreams.ChainSupervisorState) []upstreams.ChainSupervisorStateWrapper {
+	return []upstreams.ChainSupervisorStateWrapper{
+		upstreams.NewStatusWrapper(state.Status),
+		upstreams.NewMethodsWrapper(state.Methods.GetSupportedMethods().ToSlice()),
+		upstreams.NewLowerBoundsWrapper(lo.Values(state.LowerBounds)),
+		upstreams.NewBlocksWrapper(state.Blocks),
+		upstreams.NewSubMethodsWrapper(state.SubMethods.ToSlice()),
+		upstreams.NewLabelsWrapper(state.ChainLabels),
 	}
 }
 

--- a/internal/server/emerald/sub_chain_status_resync_test.go
+++ b/internal/server/emerald/sub_chain_status_resync_test.go
@@ -1,0 +1,114 @@
+package emerald_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/server/emerald"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/dshackle"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/mock"
+)
+
+const testResyncInterval = 50 * time.Millisecond
+
+// The chain-status protocol is delta-based over lossy hops (buffered channel
+// fan-outs on both the nodecore and the consumer side drop events under
+// pressure), so a single lost delta used to leave a subscriber permanently
+// stale - e.g. a consumer kept showing a recovered chain as Unavailable until the
+// TCP connection was rebuilt. The periodic state resync repairs any lost
+// delta within one interval.
+func TestSubscribeChainStatus_PeriodicResyncResendsStateWithoutHead(t *testing.T) {
+	loadMethodSpecs(t)
+
+	head := protocol.NewBlockWithHeight(123)
+	chainSupervisor := newFakeChainSupervisor(chains.ARBITRUM, newChainState(chains.ARBITRUM, head, []string{"eth_call"}))
+
+	manager := utils.NewSubscriptionManager[upstreams.ChainSupervisorEvent]("chain-supervisors")
+	upstreamSupervisor := mocks.NewUpstreamSupervisorMock()
+	upstreamSupervisor.On("SubscribeChainSupervisor", mock.Anything).Return(manager.Subscribe("sub"))
+	upstreamSupervisor.On("GetChainSupervisors").Return([]upstreams.ChainSupervisor{chainSupervisor})
+
+	stream := newSubscribeChainStatusStream()
+	done := make(chan error, 1)
+	go func() {
+		done <- emerald.SubscribeChainStatusWithResync(upstreamSupervisor, stream, testResyncInterval)
+	}()
+
+	require.Eventually(t, func() bool {
+		return stream.Count() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, stream.ResponseAt(0).FullResponse)
+
+	// Simulate a lost delta: the state changes but no event reaches the
+	// stream. Only the periodic resync can repair the subscriber's view.
+	updatedState := newChainState(chains.ARBITRUM, head, []string{"eth_call", "eth_getBalance"})
+	updatedState.Status = protocol.Unavailable
+	chainSupervisor.SetState(updatedState)
+
+	require.Eventually(t, func() bool {
+		return stream.Count() >= 2
+	}, time.Second, 10*time.Millisecond)
+
+	resync := stream.ResponseAt(1)
+	assert.False(t, resync.FullResponse, "resync must be a regular delta-style response")
+	assert.Nil(t, resync.BuildInfo)
+
+	events := resync.GetChainDescription().GetChainEvent()
+	require.NotEmpty(t, events)
+
+	var statusEvent *dshackle.ChainStatus
+	for _, event := range events {
+		require.Nil(t, event.GetHead(),
+			"resync must not carry a head: consumers reduce a response with a head to a head-only update, losing the state")
+		if event.GetStatus() != nil {
+			statusEvent = event.GetStatus()
+		}
+	}
+	require.NotNil(t, statusEvent, "resync must carry the chain status")
+	assert.Equal(t, dshackle.AvailabilityEnum_AVAIL_UNAVAILABLE, statusEvent.Availability,
+		"resync must reflect the current state, repairing the lost delta")
+
+	methodsSeen := false
+	for _, event := range events {
+		if methodsEvent := event.GetSupportedMethodsEvent(); methodsEvent != nil {
+			methodsSeen = true
+			assert.ElementsMatch(t, []string{"eth_call", "eth_getBalance"}, methodsEvent.Methods)
+		}
+	}
+	assert.True(t, methodsSeen, "resync must carry the supported methods")
+
+	stream.cancel()
+	require.NoError(t, <-done)
+}
+
+// Before the first full response (no head yet) there is nothing to resync:
+// consumers create their per-chain object only from a FullResponse, so a
+// state-only snapshot would be silently skipped on its side anyway.
+func TestSubscribeChainStatus_NoResyncBeforeFirstFullResponse(t *testing.T) {
+	chainSupervisor := newFakeChainSupervisor(chains.ARBITRUM, newChainState(chains.ARBITRUM, protocol.Block{}, []string{"eth_call"}))
+
+	manager := utils.NewSubscriptionManager[upstreams.ChainSupervisorEvent]("chain-supervisors")
+	upstreamSupervisor := mocks.NewUpstreamSupervisorMock()
+	upstreamSupervisor.On("SubscribeChainSupervisor", mock.Anything).Return(manager.Subscribe("sub"))
+	upstreamSupervisor.On("GetChainSupervisors").Return([]upstreams.ChainSupervisor{chainSupervisor})
+
+	stream := newSubscribeChainStatusStream()
+	done := make(chan error, 1)
+	go func() {
+		done <- emerald.SubscribeChainStatusWithResync(upstreamSupervisor, stream, testResyncInterval)
+	}()
+
+	assert.Never(t, func() bool {
+		return stream.Count() > 0
+	}, 5*testResyncInterval, 10*time.Millisecond)
+
+	stream.cancel()
+	require.NoError(t, <-done)
+}

--- a/internal/upstreams/chain_supervisor.go
+++ b/internal/upstreams/chain_supervisor.go
@@ -183,6 +183,20 @@ func (b *BaseChainSupervisor) processEvents() {
 					availabilityMetric.WithLabelValues(b.chain.String(), event.Id).Set(float64(eventType.State.Status))
 					b.upstreamStates.Store(event.Id, eventType.State)
 					b.updateState()
+				case *protocol.ValidUpstreamEvent:
+					// Symmetric to RemoveUpstreamEvent: a recovered upstream is
+					// re-registered right away from the event's state snapshot.
+					// Relying on a later StateUpstreamEvent instead would leave a
+					// node that came back unchanged out of the chain forever -
+					// those events are suppressed unless some sub-state differs.
+					if eventType.State != nil {
+						availabilityMetric.WithLabelValues(b.chain.String(), event.Id).Set(float64(eventType.State.Status))
+						b.upstreamStates.Store(event.Id, eventType.State)
+						b.updateState()
+						if !eventType.State.HeadData.IsEmptyByHeight() {
+							b.updateHead(event.Id, &protocol.HeadUpstreamEvent{Status: eventType.State.Status, Head: eventType.State.HeadData})
+						}
+					}
 				}
 			}
 		}

--- a/internal/upstreams/chain_supervisor_valid_event_test.go
+++ b/internal/upstreams/chain_supervisor_valid_event_test.go
@@ -1,0 +1,100 @@
+package upstreams_test
+
+import (
+	"context"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/fork_choice"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createValidEvent(id string, status protocol.AvailabilityStatus, head protocol.Block, methods *mocks.MethodsMock) protocol.UpstreamEvent {
+	state := protocol.DefaultUpstreamState(
+		methods,
+		mapset.NewThreadUnsafeSet[protocol.Cap](),
+		"",
+		nil,
+		nil,
+	)
+	state.Status = status
+	state.HeadData = head
+
+	return protocol.UpstreamEvent{
+		Id:        id,
+		EventType: &protocol.ValidUpstreamEvent{State: &state},
+	}
+}
+
+// A ValidUpstreamEvent must restore a previously removed upstream on its own.
+// Before this behavior existed, a removed-then-recovered upstream re-entered
+// the chain map only when a later StateUpstreamEvent happened to fire, which
+// requires some sub-state to actually change - a node that comes back
+// identical to how it left would never be re-added.
+func TestChainSupervisorValidUpstreamEventRestoresRemovedUpstream(t *testing.T) {
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ARBITRUM, fork_choice.NewHeightForkChoice(), nil)
+	methodsMock := mocks.NewMethodsMock()
+	methodsMock.On("GetSupportedMethods").Return(mapset.NewThreadUnsafeSet[string]("method"))
+
+	go chainSupervisor.Start()
+
+	head := protocol.NewBlockWithHeight(100)
+	chainSupervisor.PublishUpstreamEvent(test_utils.CreateEvent("id", protocol.Available, head, methodsMock))
+	publishHeadEvent(chainSupervisor, "id", protocol.Available, head)
+	assertEventuallyEqual(t, protocol.Available, func() any { return chainSupervisor.GetChainState().Status })
+
+	chainSupervisor.PublishUpstreamEvent(test_utils.CreateRemoveEvent("id"))
+	assertEventuallyEqual(t, protocol.Unavailable, func() any { return chainSupervisor.GetChainState().Status })
+	require.Nil(t, chainSupervisor.GetUpstreamState("id"))
+
+	// the recovery delta must be observable by stream subscribers
+	sub := chainSupervisor.SubscribeState("valid-event-test")
+	defer sub.Unsubscribe()
+
+	chainSupervisor.PublishUpstreamEvent(createValidEvent("id", protocol.Available, head, methodsMock))
+
+	assertEventuallyEqual(t, protocol.Available, func() any { return chainSupervisor.GetChainState().Status })
+	require.NotNil(t, chainSupervisor.GetUpstreamState("id"))
+	assert.Equal(t, protocol.Available, chainSupervisor.GetUpstreamState("id").Status)
+	assertEventuallyEqual(t, head, func() any { return chainSupervisor.GetChainState().HeadData.Head })
+
+	statusRestored := func() bool {
+		for {
+			select {
+			case event := <-sub.Events:
+				for _, wrapper := range event.Wrappers {
+					if statusWrapper, ok := wrapper.(*upstreams.StatusWrapper); ok && statusWrapper.Status == protocol.Available {
+						return true
+					}
+				}
+			default:
+				return false
+			}
+		}
+	}
+	assert.Eventually(t, statusRestored, eventuallyWait, eventuallyTick,
+		"subscribers must receive a StatusWrapper(Available) delta on recovery")
+}
+
+// A ValidUpstreamEvent without a state snapshot (defensive case) must not
+// panic or register a nil state.
+func TestChainSupervisorValidUpstreamEventWithoutStateIsIgnored(t *testing.T) {
+	chainSupervisor := upstreams.NewBaseChainSupervisor(context.Background(), chains.ARBITRUM, fork_choice.NewHeightForkChoice(), nil)
+
+	go chainSupervisor.Start()
+
+	chainSupervisor.PublishUpstreamEvent(protocol.UpstreamEvent{
+		Id:        "id",
+		EventType: &protocol.ValidUpstreamEvent{},
+	})
+
+	assert.Never(t, func() bool {
+		return chainSupervisor.GetUpstreamState("id") != nil
+	}, 100*eventuallyTick, eventuallyTick)
+}

--- a/internal/upstreams/upstream_events.go
+++ b/internal/upstreams/upstream_events.go
@@ -37,7 +37,7 @@ func (u *BaseUpstream) processStateEvents(ctx context.Context, initialValid bool
 					continue
 				}
 				log.Warn().Msgf("upstream '%s' settings are valid", u.id)
-				eventType = &protocol.ValidUpstreamEvent{}
+				eventType = &protocol.ValidUpstreamEvent{State: &state}
 				validUpstream = true
 			case *protocol.BanMethodUpstreamStateEvent:
 				if bannedMethods.ContainsOne(stateEvent.Method) || slices.Contains(u.upConfig.Methods.EnableMethods, stateEvent.Method) {


### PR DESCRIPTION
## Problem

When a settings validator stops an upstream (`FatalSettingError`) and the upstream later recovers, consumers of the `SubscribeChainStatus` gRPC stream can keep seeing the chain as **Unavailable indefinitely**. In production we observed a consumer staying stale for 75 minutes after the upstream had recovered (nodecore itself logged `statuses=[AVAILABLE/1]` the whole time), and per-connection divergence across identical subscribers — some healthy, some stale — proving per-connection delta loss. Only rebuilding the connection repaired the view.

Two defects compound here:

1. **The chain-status protocol is delta-based over lossy hops.** Buffered-channel fan-outs (`pkg/utils/subscriptions.go`) drop events under pressure by design — a busy instance logs hundreds of such drops per day — and `SubscribeChainStatus` sent its `FullResponse` exactly once per connection. One lost `Status: Available` delta = a permanently stale subscriber. Nothing in the protocol ever reconciles the two sides.

2. **The chain supervisor ignores `ValidUpstreamEvent`.** It handles `RemoveUpstreamEvent` (deletes the upstream from the chain map), but recovery re-adds the upstream only when a *later* `StateUpstreamEvent` happens to fire — which requires some sub-state to actually change. An upstream that comes back identical to how it left would never be re-added.

## Fix

**Periodic state resync** (`sub_chain_status.go`): every chain on the stream re-sends its full current state once a minute as a regular delta-style response — deliberately **without the head**. Head freshness is already guaranteed by per-block head events; more importantly, consumers reduce a response that carries a head to a head-only update for existing upstreams, so a snapshot with a head would lose exactly the state it is meant to repair. Worst-case staleness after any lost delta, on either side of the stream, is now one interval instead of infinity. Cost: one small message per chain per connection per minute.

**Deterministic re-add** (`chain_supervisor.go`, `upstream_events.go`, `protocol/data.go`): `ValidUpstreamEvent` now carries the upstream-state snapshot (the publisher already had it in hand) and the chain supervisor applies it symmetrically to the removal: immediate re-register + `updateState()` + head recomputation.

## Tests

- `TestChainSupervisorValidUpstreamEventRestoresRemovedUpstream` — remove → valid restores the upstream, chain status, head, and emits a `StatusWrapper(Available)` delta to subscribers; plus a defensive nil-state case
- `TestSubscribeChainStatus_PeriodicResyncResendsStateWithoutHead` — simulates the lost delta (state changes with no event reaching the stream) and verifies the resync repairs it: regular non-full response, carries status/methods, **no head**
- `TestSubscribeChainStatus_NoResyncBeforeFirstFullResponse` — no snapshots before the initial full response

## Live verification

Reproduced end-to-end against a mock EVM upstream with a toggleable logIndex corruption (`first log index is 200 instead of 0`, the signature of erigontech/erigon#22504) and a gRPC client subscribed to `SubscribeChainStatus`:

```
09:37:13  STATUS=AVAIL_UNAVAILABLE   <- validator stops the upstream
09:37:33  STATUS=AVAIL_OK            <- recovery propagates
09:37:59  STATUS=AVAIL_OK methods=61 bounds=0 finalization subs=0 nodes=1   <- resync snapshot
09:38:59  STATUS=AVAIL_OK methods=61 bounds=0 finalization subs=0 nodes=1   <- resync snapshot, 60s later
```

Resync responses carry no head (heads keep flowing as separate per-block events).