### PR TITLE
fix: accept numeric JSON-RPC ids in ws messages (ethermint newHeads subscriptions)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-ws-flexible-id-design.md
+++ b/docs/superpowers/specs/2026-07-16-ws-flexible-id-design.md
@@ -107,5 +107,7 @@ call sites — the type is private to the parser.
   or verify-then-trust) is a separate, coordinated change: a single provider
   switching alone becomes the minority voice and gets flagged as forked —
   exactly the incident that surfaced this bug.
-- Consider reporting the notification-vs-canonical hash mismatch upstream to
-  the ethermint/evmos maintainers.
+- Consider reporting the notification-vs-canonical hash mismatch upstream.
+  The original evmos/ethermint repo is archived (April 2024); the living
+  successor is **cosmos/evm**, and affected chains vendor their own forks —
+  those are the actionable places for a report.

--- a/docs/superpowers/specs/2026-07-16-ws-flexible-id-design.md
+++ b/docs/superpowers/specs/2026-07-16-ws-flexible-id-design.md
@@ -1,0 +1,111 @@
+# Tolerant JSON-RPC id in the ws message parser — design
+
+- **Date:** 2026-07-16
+- **Status:** Implemented — branch `fix/ethermint-ws-heads`
+- **Area:** `internal/protocol` (`parse_response.go`)
+
+## 1. Problem
+
+nodecore sends ws JSON-RPC requests with a **string** id (`{"id":"1"}`) and
+parsed responses with a strict `Id string` field. Per JSON-RPC 2.0 the id is
+a string, a number or null — and some upstream nodes reply with a **numeric**
+id even when the request carried a string one. Ethermint/evmos-lineage nodes
+(cosmos-EVM chains such as zeta-chain and mezo) do exactly that, but only on
+the `eth_subscribe` path:
+
+```
+>> {"id":"1","jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"]}
+<< {"jsonrpc":"2.0","result":"0xad3ddeb5ed159eb69129a94e1b5b8a1c","id":1}
+```
+
+(captured with a logging ws proxy between nodecore and a live node; the same
+node echoes string ids verbatim on regular calls like `eth_blockNumber`).
+
+`sonic.Unmarshal` fails on `"id":1` vs `Id string`, the whole frame is
+classified `Unknown`, `ParseWsMessage` returns an error — and the ws
+processor **tears down the entire connection** and reconnects. The result on
+every ethermint upstream:
+
+- a permanent connect → subscribe → parse-fail → disconnect loop
+  (visible as constant TIME_WAIT churn towards the node's ws port);
+- `newHeads` notifications are never consumed; heads come only from the
+  `getLatestBlock` fallback at each (re)subscribe, so the reported head is
+  **~60s / 10-20 blocks stale**;
+- the head hash source silently diverges from sibling provider instances
+  subscribed to the same node (they use the notification hashes), so the
+  consumers' fork detection flags the nodecore-fed connections as forked and
+  pulls them from rotation. Two production chains sat in that state for days.
+
+## 2. Goal
+
+Accept every id shape JSON-RPC 2.0 allows, so a spec-legal response can never
+kill the connection; ethermint upstreams get working `newHeads` subscriptions
+with per-block head freshness and the same head-hash source as other
+subscribers of the same node.
+
+### Non-goals
+
+- **Choosing the head-hash source** (notification hash vs re-fetched
+  canonical hash) — see §8; deliberate follow-up, not this change.
+- Changing the outgoing request id format (string ids stay).
+- HTTP response parsing (ids there are echoed by the same code path that
+  produced them; no observed issue).
+
+## 3. Key decisions (settled → implemented)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Where to fix | The ws frame parser only (`jsonRpcWsMessage`), the single place that misclassified frames |
+| 2 | Id representation | `flexibleId` string type with custom `UnmarshalJSON`: strings decode normally, numbers keep their raw decimal text, `null`/absent → empty |
+| 3 | Number normalization | Raw text form (`1` → `"1"`) — exactly what the request registry keys on, since outgoing ids are `fmt.Sprintf("%d", n)` |
+| 4 | Non-integer ids | Kept as raw text (`1.5` → `"1.5"`); they can never match a registry key and are ignored like any unknown id — no special casing |
+| 5 | Failure mode | Unparseable id still fails the frame (unchanged); only the legal-but-numeric case is new |
+
+## 4. Architecture
+
+```
+ node ws ──► ws_session ──► ParseWsMessage ──► requestRegistry (match by id / subId)
+                              │
+                              ├─ before: "id":1 → unmarshal error → Unknown → DISCONNECT ⚠
+                              └─ after:  "id":1 → flexibleId "1" → JsonRpc → matched, sub registered
+```
+
+## 5. Implementation
+
+`internal/protocol/parse_response.go`: `jsonRpcWsMessage.Id` becomes
+`flexibleId`; `ParseJsonRpcWsMessage` reads `string(wsMessage.Id)`. No other
+call sites — the type is private to the parser.
+
+## 6. Edge cases
+
+- `"id":null` → empty id; for a frame with neither id, subId nor error the
+  existing "wrong json-rpc ws response" classification still applies.
+- Huge numeric ids: kept as raw text, no integer overflow possible.
+- Frames with both `params` (subscription) and an id are classified as
+  subscription events, as before — id handling only affects the RPC branch.
+
+## 7. Testing
+
+- Unit: numeric-id result frame, numeric-id error frame, null id
+  (`parse_response_flexid_test.go`) — the first two fail on the old parser.
+- Live, against two production ethermint nodes (zeta-chain, mezo):
+  - before: 1-2 heads/min, `couldn't parse ws message: invalid response
+    type - unknown` on every subscribe, constant reconnects;
+  - after: **18 heads/min (zeta, ~3.5s block time) and 14 heads/45s (mezo)**,
+    zero parse errors, zero resubscribes over the observation window;
+  - head hashes match the raw `newHeads` notification stream **21/21** —
+    i.e. parity with every other ws subscriber of the same node.
+
+## 8. Open questions / future
+
+- **Ethermint notification hashes are not the canonical block hashes** (the
+  node's own `eth_getBlockByNumber` disagrees with its `newHeads` `hash`
+  field, while `parentHash` in notifications is canonical). With this fix
+  nodecore reports the notification hashes — consistent with other
+  subscribers of the same node, which is what consumers' quorum-based fork
+  detection needs. Moving the fleet to canonical hashes (fetch-after-notify
+  or verify-then-trust) is a separate, coordinated change: a single provider
+  switching alone becomes the minority voice and gets flagged as forked —
+  exactly the incident that surfaced this bug.
+- Consider reporting the notification-vs-canonical hash mismatch upstream to
+  the ethermint/evmos maintainers.

--- a/internal/protocol/parse_response.go
+++ b/internal/protocol/parse_response.go
@@ -176,8 +176,33 @@ type jsonRpcWsParams struct {
 	Subscription json.RawMessage `json:"subscription"`
 }
 
+// flexibleId decodes a JSON-RPC id that may arrive as a string or a number.
+// Some upstreams (ethermint/evmos-lineage nodes: zeta-chain, mezo, ...) reply
+// to eth_subscribe with a numeric id even when the request id was a string; a
+// strict string field failed the whole message unmarshal, the frame was
+// classified Unknown and the ws connection was torn down on every subscribe.
+// Numbers normalize to their decimal string form, which is exactly what the
+// request registry keys on ("1" -> 1 -> "1").
+type flexibleId string
+
+func (f *flexibleId) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := sonic.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*f = flexibleId(s)
+		return nil
+	}
+	*f = flexibleId(data)
+	return nil
+}
+
 type jsonRpcWsMessage struct {
-	Id     string           `json:"id"`
+	Id     flexibleId       `json:"id"`
 	Result json.RawMessage  `json:"result"`
 	Params *jsonRpcWsParams `json:"params"`
 	Error  json.RawMessage  `json:"error"`
@@ -193,7 +218,7 @@ func ParseJsonRpcWsMessage(body []byte) *WsResponse {
 	wsMessage := jsonRpcWsMessage{}
 	err := sonic.Unmarshal(body, &wsMessage)
 	if err == nil {
-		id = wsMessage.Id
+		id = string(wsMessage.Id)
 
 		if wsMessage.Params != nil {
 			responseType = Ws

--- a/internal/protocol/parse_response_flexid_test.go
+++ b/internal/protocol/parse_response_flexid_test.go
@@ -1,0 +1,40 @@
+package protocol_test
+
+import (
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+// Ethermint/evmos-lineage nodes reply to eth_subscribe with a NUMERIC id even
+// when the request carried a string id ({"id":"1"} -> {"id":1}). A strict
+// string id used to fail the whole unmarshal, the frame was classified
+// Unknown and the ws connection was torn down - leaving such upstreams in a
+// permanent reconnect loop with heads only from the resubscribe fallback.
+func TestParseJsonRpcWsMessage_NumericIdResultResponse(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","result":"0xad3ddeb5ed159eb69129a94e1b5b8a1c","id":1}`)
+	ws := protocol.ParseJsonRpcWsMessage(body)
+
+	assert.Nil(t, ws.Error)
+	assert.Equal(t, "1", ws.Id, "numeric id must normalize to its decimal string form")
+	assert.Equal(t, protocol.JsonRpc, ws.Type)
+	assert.Equal(t, `"0xad3ddeb5ed159eb69129a94e1b5b8a1c"`, string(ws.Message))
+}
+
+func TestParseJsonRpcWsMessage_NumericIdErrorResponse(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","error":{"code":-32601,"message":"method not found"},"id":7}`)
+	ws := protocol.ParseJsonRpcWsMessage(body)
+
+	assert.NotNil(t, ws.Error)
+	assert.Equal(t, "7", ws.Id)
+	assert.Equal(t, protocol.JsonRpc, ws.Type)
+}
+
+func TestParseJsonRpcWsMessage_NullIdIsIgnored(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","result":"0x1","id":null}`)
+	ws := protocol.ParseJsonRpcWsMessage(body)
+
+	assert.Equal(t, "", ws.Id)
+	assert.Equal(t, protocol.JsonRpc, ws.Type)
+}


### PR DESCRIPTION
## Problem

Per JSON-RPC 2.0 the `id` is a string, a number or null. nodecore sends ws requests with string ids and parsed responses with a strict `Id string` field — so an upstream replying with a **numeric id** failed the whole frame unmarshal, the message was classified `Unknown`, and the ws processor **tore down the connection**.

Ethermint/evmos-lineage nodes (cosmos-EVM chains: zeta-chain, mezo, …) do exactly that on the `eth_subscribe` path (while echoing string ids verbatim on regular calls):

```
>> {"id":"1","jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"]}
<< {"jsonrpc":"2.0","result":"0xad3ddeb5ed159eb69129a94e1b5b8a1c","id":1}
```

Consequences on every ethermint upstream: a permanent connect → subscribe → parse-fail → disconnect loop; `newHeads` never consumed; heads only from the resubscribe fallback (**~60s / 10-20 blocks stale**); and a head-hash source diverging from sibling subscribers of the same node, which quorum-based fork detection downstream flags as a fork — two production chains sat out of rotation for days over this.

## Fix

`jsonRpcWsMessage.Id` decodes through a `flexibleId` type: strings as-is, numbers as their raw decimal text (exactly what the request registry keys on, since outgoing ids are `fmt.Sprintf("%d", n)`), null/absent as empty. Scope is the ws frame parser only.

## Tests

- `parse_response_flexid_test.go`: numeric-id result frame, numeric-id error frame, null id — the first two fail on the old parser.

## Live verification (real ethermint nodes)

| | before | after |
|---|---|---|
| heads | 1-2/min (resubscribe fallback only) | **18/min** (zeta, ~3.5s blocks), **14/45s** (mezo) |
| `couldn't parse ws message` | every subscribe | 0 |
| reconnect loop | constant | 0 resubscribes |
| head hash vs raw newHeads stream | diverged | **21/21 match** |

Design spec: `docs/superpowers/specs/2026-07-16-ws-flexible-id-design.md` (includes the notification-hash-vs-canonical follow-up question).