### PR TITLE
chore: bump go.mongodb.org/mongo-driver to v1.17.7 (CVE-2026-2303)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-bump-mongo-driver-design.md
+++ b/docs/superpowers/specs/2026-07-16-bump-mongo-driver-design.md
@@ -1,0 +1,29 @@
+# Bump go.mongodb.org/mongo-driver to 1.17.7 — design
+
+- **Date:** 2026-07-16
+- **Status:** Implemented — branch `chore/bump-mongo-driver`
+- **Area:** `go.mod` / `go.sum` only
+
+## 1. Problem
+
+Dependabot alert #19: CVE-2026-2303 (GHSA-cp6g-7hqx-qxhp, medium) — heap
+out-of-bounds read in GSSAPI error handling of `go.mongodb.org/mongo-driver`
+< 1.17.7. nodecore pins v1.17.4 as an **indirect** dependency pulled in by
+`github.com/deckarep/golang-set/v2`.
+
+## 2. Impact assessment
+
+`go mod why go.mongodb.org/mongo-driver` → *main module does not need this
+package*: it is never imported by any package in nodecore's build graph, so
+the vulnerable code does not ship in the binary. The bump exists to clear the
+alert and to be safe against future transitive imports.
+
+## 3. Change
+
+`go get go.mongodb.org/mongo-driver@v1.17.7 && go mod tidy` — go.sum delta
+only, no code changes, `go build ./...` clean.
+
+## 4. Testing
+
+Regular CI (build/test/lint/e2e); no targeted tests possible or needed for an
+unused transitive dependency.

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.mongodb.org/mongo-driver v1.17.4 // indirect
+	go.mongodb.org/mongo-driver v1.17.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
-go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
-go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=


### PR DESCRIPTION
Clears Dependabot alert #19 — CVE-2026-2303 / GHSA-cp6g-7hqx-qxhp (medium): heap out-of-bounds read in GSSAPI error handling of `mongo-go-driver` < 1.17.7.

Impact assessment: the driver is an **unused indirect dependency** (pulled in by `github.com/deckarep/golang-set/v2`); `go mod why` confirms no package in the build graph imports it, so the vulnerable code never ships in the binary. go.mod/go.sum-only change.

Spec: `docs/superpowers/specs/2026-07-16-bump-mongo-driver-design.md`