### PR TITLE
feat: Bitcoin family support (bitcoin, dogecoin)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
+++ b/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
@@ -1,0 +1,186 @@
+# Bitcoin family support — design
+
+Date: 2026-07-17
+Status: approved (pre-implementation)
+
+## Goal
+
+Add first-class support for the **Bitcoin** blockchain family to nodecore
+(`BlockchainType = "bitcoin"`), covering **bitcoin** and **dogecoin** (mainnet
+and testnet networks as present in `chains.yaml`), with full gRPC (emerald)
+API support, so these chains can be removed from dshackle.
+
+## Scope
+
+- **In scope:** bitcoind-style JSON-RPC upstreams (Bitcoin Core, Dogecoin
+  Core) with HTTP basic auth; the 19-method surface currently served by
+  dshackle (see method table); optional **esplora** (electrs) secondary
+  endpoint backing `listunspent`; head tracking, chain/health validation,
+  client labels, prune-aware lower bounds; gRPC ChainRef support (already in
+  the emerald proto for BITCOIN/DOGECOIN).
+- **Out of scope (YAGNI):** wallet methods beyond the dshackle surface; ZMQ
+  or WebSocket-style head subscriptions (bitcoind has none we consume);
+  Litecoin/other UTXO chains (nothing registered in Consul today); deployment automation
+  ansible filter changes (deferred until the family passes live validation
+  from a laptop-run nodecore instance — see Testing).
+
+## Approach
+
+Bitcoin is modelled as a **JSON-RPC blockchain family** following the
+Algorand/Aptos template: a `bitcoin_specific` chain-specific package plus a
+data-driven method spec. A runtime-only extension is not viable for a new
+family (compile-time factory switch), consistent with prior family additions.
+
+One family covers both bitcoin and dogecoin: Dogecoin Core is a Bitcoin Core
+fork with an API-compatible RPC surface for every method in scope.
+
+### Verified live API shapes (from our production nodes)
+
+`getblockchaininfo` (Bitcoin Core 26.1, mainnet; JSON-RPC 1.0 envelope,
+`error: null` on success):
+
+```json
+{"result":{"chain":"main","blocks":958407,"headers":958407,
+ "bestblockhash":"00000000000000000000d7c68a3b5e0794da056f7996c668620eb2b53591a8cf",
+ "difficulty":127170500429035.2,"time":1784290128,"mediantime":1784286851,
+ "verificationprogress":1,"initialblockdownload":false,
+ "size_on_disk":860307387461,"pruned":false,"warnings":""},"error":null,"id":1}
+```
+
+Dogecoin Core (mainnet) returns the same shape with `"chain":"main"` as well —
+**the `chain` field cannot distinguish bitcoin from dogecoin**; only the
+genesis hash can (see Chain validation). Dogecoin's payload has no `time`
+top-level field on older cores; head tracking must not depend on it.
+
+`getnetworkinfo`: `{"version":260100,"subversion":"/Satoshi:26.1.0/",
+"connections":10,...}` — source for the client version label and peer count.
+
+`getblockhash 0`: bitcoin mainnet `000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`,
+dogecoin mainnet `1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691`.
+
+Esplora (electrs) `GET /address/{addr}/utxo`:
+
+```json
+[{"txid":"548030c7...","vout":0,
+  "status":{"confirmed":true,"block_height":903979,"block_hash":"000...f2f",
+            "block_time":1751639616},"value":927}]
+```
+
+`GET /blocks/tip/height` → plain-text height (used only by the live-test
+harness, not by nodecore).
+
+## Architecture
+
+### Factory and type plumbing
+
+- `upstream_factory.go`: new `case chains.Bitcoin` returning
+  `bitcoin_specific.NewBitcoinChainSpecificObject(...)`.
+- `chains.Bitcoin` already exists in `chains.go`; `IsValidBlockchainType`
+  already accepts it. `chains.yaml` already registers bitcoin/dogecoin with
+  `type: bitcoin` — no registry work.
+
+### Head tracking (`bitcoin_specific`)
+
+RPC polling head (no subscriptions), same lifecycle as Algorand's:
+
+1. Poll `getbestblockhash` at the configured poll interval.
+2. On hash change, fetch `getblockheader <hash>` (verbose) for
+   `height`/`time` and publish the new head.
+
+`getblockheader` verbose is available on both Bitcoin Core and Dogecoin Core
+and is far cheaper than a verbose `getblock`.
+
+### Chain validation
+
+`BitcoinChainValidator` fetches `getblockhash 0` once and compares against
+the expected genesis hash for the configured chain. Expected hashes live in
+the validator keyed by `chains.Chain` (BITCOIN, BITCOIN_TESTNET, DOGECOIN,
+DOGECOIN_TESTNET); mainnet values verified above, testnet values verified
+against our nodes during implementation. `getblockchaininfo.chain`
+(`main`/`test`) is checked as a secondary signal. This mirrors what the
+`chain-id` check does for EVM — genesis hash is the only reliable
+discriminator between bitcoin and dogecoin.
+
+### Health validation
+
+`BitcoinHealthValidator` uses `getblockchaininfo`:
+- syncing: `initialblockdownload == true` or `headers - blocks` above the
+  chain's lag threshold;
+- peers (when `validate-peers`): `getconnectioncount > 0`.
+
+### Labels and lower bounds
+
+- `client_version` label from `getnetworkinfo.subversion`
+  (e.g. `/Satoshi:26.1.0/` → `26.1.0`).
+- Lower bounds: if `getblockchaininfo.pruned == true`, `pruneheight` becomes
+  the BLOCK/TX bound; otherwise bound 1 (archive). Our nodes are unpruned;
+  the pruned path still gets unit coverage.
+
+### Method spec (`pkg/methods/specs/bitcoin.json`)
+
+The 19 methods dshackle serves, with equivalent semantics:
+
+| group | methods | routing/quorum |
+|---|---|---|
+| fresh | getblock, gettransaction, gettxout, getmemorypool, getrawmempool, getmempoolinfo, getblockheader | default |
+| not-null retry | getblockhash, getrawtransaction, estimatesmartfee | retry on null result |
+| head-verified | getbestblockhash, getblocknumber, getblockcount, getreceivedbyaddress, getblockchaininfo | route to best-head upstream |
+
+`getblocknumber` is not a real bitcoind method — it is a dshackle-era alias
+kept for client compatibility; nodecore translates it to `getblockcount`.
+`getmemorypool` is likewise ancient (dropped by modern Bitcoin Core) and is
+kept passthrough-only for surface parity — the node's own error is returned.
+| passthrough | getconnectioncount, getnetworkinfo | default (no dshackle-style hardcoding — these are our own nodes) |
+| broadcast | sendrawtransaction | broadcast to all upstreams |
+| esplora-backed | listunspent | translated, see below |
+
+### Esplora translation (`listunspent`)
+
+Esplora is an optional `rest-additional` connector on the upstream (the same
+mechanism tron uses for its solidity endpoint). `listunspent` is intercepted
+in `bitcoin_specific`: the address argument maps to
+`GET /address/{addr}/utxo`, and the esplora response is converted to the
+bitcoind `listunspent` result shape (txid, vout, address, amount in BTC from
+sats, confirmations computed from current head vs `status.block_height`).
+Upstreams without an esplora connector get `listunspent` banned via the
+existing method-ban mechanism, so routing skips them (dogecoin has no
+esplora today).
+
+### Authentication
+
+bitcoind requires HTTP basic auth. Connector URLs support userinfo
+(`http://user:pass@host:port`) or an explicit `Authorization` header via the
+connector `headers` field — whichever the existing connector plumbing already
+handles; verified during implementation with a live node.
+
+## Testing
+
+1. **Unit tests** (template parity with aptos/algorand): head parsing,
+   genesis validation incl. bitcoin-vs-dogecoin cross-check, health/syncing
+   states, subversion label parsing, prune bounds, esplora→listunspent
+   mapping on captured fixtures, method-spec loading.
+2. **Live comparison harness (laptop, before any infra change).** nodecore
+   runs locally on the laptop with a hand-written config; upstreams are our
+   production nodes reached through ssh port-forwards (node RPC/esplora ports
+   are firewalled to internal hosts). A corpus runner exercises **every**
+   method in the spec against (a) the node directly and (b) nodecore
+   (`/queries/bitcoin`), asserting identical results modulo volatile fields
+   (connection counts, mempool contents, relative confirmations). Corpus
+   includes: fresh blocks by height and hash, deep historical blocks, raw
+   transactions, txout lookups, an address with known UTXOs (esplora path),
+   estimatesmartfee, invalid-parameter negative cases, and unknown-method
+   handling. `sendrawtransaction` is exercised for real only on
+   **dogecoin-testnet**; on mainnets only with a deterministically invalid
+   transaction (expected error passthrough), nothing is broadcast.
+3. **Staged rollout (after laptop validation, separate step).** Wire the
+   deployment automation (basic auth + esplora meta), enable bitcoin on
+   one production nodecore instance while dshackle still serves the chain,
+   compare error rates and responses, then drop `bitcoin`/`dogecoin` from
+   `INCLUDE_TO_DSHACKLE`.
+
+## Out of scope / follow-ups
+
+- Deployment automation changes ship only after step 2 passes.
+- near, ripple, starknet, ton follow as separate family designs reusing this
+  template; celestia/stellar additionally need `chains.yaml` registry entries
+  (they are absent there today).

--- a/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
+++ b/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
@@ -20,9 +20,9 @@ API support, so these chains can be removed from dshackle.
   the emerald proto for BITCOIN/DOGECOIN).
 - **Out of scope (YAGNI):** wallet methods beyond the dshackle surface; ZMQ
   or WebSocket-style head subscriptions (bitcoind has none we consume);
-  Litecoin/other UTXO chains (nothing registered in Consul today); deployment automation
-  ansible filter changes (deferred until the family passes live validation
-  from a laptop-run nodecore instance — see Testing).
+  Litecoin/other UTXO chains (no nodes deployed today); deployment automation
+  changes (deferred until the family passes live validation from a laptop-run
+  nodecore instance — see Testing).
 
 ## Approach
 
@@ -178,15 +178,24 @@ handles; verified during implementation with a live node.
    handling. `sendrawtransaction` is exercised for real only on
    **dogecoin-testnet**; on mainnets only with a deterministically invalid
    transaction (expected error passthrough), nothing is broadcast.
-3. **Staged rollout (after laptop validation, separate step).** Wire the
-   deployment automation (basic auth + esplora meta), enable bitcoin on
-   one production nodecore instance while dshackle still serves the chain,
-   compare error rates and responses, then drop `bitcoin`/`dogecoin` from
-   `INCLUDE_TO_DSHACKLE`.
+   **Executed 2026-07-17 — passed.** nodecore ran locally against
+   a production bitcoin node (mainnet + esplora) and a production dogecoin
+   node (mainnet/testnet):
+   65 PASS / 3 FAIL / 0 SKIP. The only failures are the unknown-method error
+   *text* (`foobarmethod`): nodecore rejects unknown methods locally from the
+   method spec and synthesizes its own -32601 message instead of forwarding —
+   standard nodecore behavior for every family, code preserved, accepted.
+   Findings: dogecoin testnet genesis `bb0a78…59e` verified live; wallet-built
+   bitcoind returns `-18 No wallet is loaded` (not -32601) for
+   `getreceivedbyaddress` and nodecore passes it through verbatim;
+   `listunspent` UTXO sets match esplora exactly (7 UTXOs on the probe
+   address); lower-bounds detection is off by default outside strict mode
+   (`option_defaults.go`), enabled explicitly it published BLOCK=1/TX=1 for
+   the unpruned node; dogecoin 1.14 accepts int verbosity for
+   getblock/getrawtransaction, so no bool-form divergence exists in practice.
 
 ## Out of scope / follow-ups
 
-- Deployment automation changes ship only after step 2 passes.
 - near, ripple, starknet, ton follow as separate family designs reusing this
   template; celestia/stellar additionally need `chains.yaml` registry entries
   (they are absent there today).

--- a/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
+++ b/docs/superpowers/specs/2026-07-17-bitcoin-support-design.md
@@ -136,15 +136,21 @@ kept passthrough-only for surface parity — the node's own error is returned.
 
 ### Esplora translation (`listunspent`)
 
-Esplora is an optional `rest-additional` connector on the upstream (the same
-mechanism tron uses for its solidity endpoint). `listunspent` is intercepted
-in `bitcoin_specific`: the address argument maps to
+Esplora is an optional `rest-additional` connector on the upstream. Design
+note (discovered during implementation): nodecore has no per-chain
+request-rewrite hook — tron's solidity endpoint is a set of first-class REST
+methods, not a translation — so the interception lives in a small generic
+`(spec, method) → {buildRequest, reshapeResponse}` transformer registry in
+the flow layer (consulted in `sendUnaryRequest` before the connector call),
+not in `bitcoin_specific`. For `listunspent` the address argument maps to
 `GET /address/{addr}/utxo`, and the esplora response is converted to the
 bitcoind `listunspent` result shape (txid, vout, address, amount in BTC from
 sats, confirmations computed from current head vs `status.block_height`).
-Upstreams without an esplora connector get `listunspent` banned via the
-existing method-ban mechanism, so routing skips them (dogecoin has no
-esplora today).
+`listunspent` is declared only in the esplora spec (`rest-additional`), so
+upstreams without an esplora connector never advertise it and routing skips
+them statically — no runtime ban needed (dogecoin has no esplora today).
+`getblocknumber` → `getblockcount` uses the same registry as a pure
+request-rewrite.
 
 ### Authentication
 

--- a/internal/protocol/errors.go
+++ b/internal/protocol/errors.go
@@ -227,6 +227,13 @@ func QuorumNotSupportedError(reason string) *ResponseError {
 
 const InvalidParams = -32602
 
+func InvalidParamsError(message string) *ResponseError {
+	return &ResponseError{
+		Code:    InvalidParams,
+		Message: message,
+	}
+}
+
 func UnsupportedBlockTagError(chain, tag string) *ResponseError {
 	return &ResponseError{
 		Code:    InvalidParams,

--- a/internal/protocol/parse_response.go
+++ b/internal/protocol/parse_response.go
@@ -29,7 +29,12 @@ func parseJsonRpcBody(id string, body []byte, responseCode int) *BaseUpstreamRes
 			result = []byte(rawResult)
 		}
 	}
-	if errorNode, err := searcher.GetByPath("error"); err == nil {
+	// A JSON `null` error is how bitcoind (and other JSON-RPC 1.0-style
+	// servers) spell "no error" - it always sends the "error" key, even on
+	// success. Treat it the same as an absent key rather than as an error,
+	// otherwise every successful bitcoind response would be misparsed as a
+	// failure.
+	if errorNode, err := searcher.GetByPath("error"); err == nil && errorNode.TypeSafe() != ast.V_NULL {
 		if errorRaw, err := errorNode.Raw(); err == nil {
 			bodyBytes := []byte(errorRaw)
 			if errorNode.TypeSafe() == ast.V_STRING {

--- a/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
+++ b/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
@@ -1,0 +1,184 @@
+package bitcoin_specific
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+// errUnsupportedHeadSubscriptions is returned by SubscribeHeadRequest and
+// ParseSubscriptionBlock: bitcoind has no push-style head notification we can
+// consume (no ZMQ/WS in scope), so head tracking is poll-only.
+var errUnsupportedHeadSubscriptions = fmt.Errorf("bitcoin: head subscriptions are not supported")
+
+type BitcoinChainSpecificObject struct {
+	ctx             context.Context
+	upstreamId      string
+	connector       connectors.ApiConnector
+	options         *chains.Options
+	internalTimeout time.Duration
+	labelsDelay     time.Duration
+	configuredChain *chains.ConfiguredChain
+}
+
+func NewBitcoinChainSpecificObject(
+	ctx context.Context,
+	configuredChain *chains.ConfiguredChain,
+	upstreamId string,
+	connector connectors.ApiConnector,
+	options *chains.Options,
+) *BitcoinChainSpecificObject {
+	return &BitcoinChainSpecificObject{
+		ctx:             ctx,
+		upstreamId:      upstreamId,
+		connector:       connector,
+		options:         options,
+		internalTimeout: options.InternalTimeout,
+		labelsDelay:     options.ValidationInterval * 5,
+		configuredChain: configuredChain,
+	}
+}
+
+func (b *BitcoinChainSpecificObject) BlockProcessor() blocks.BlockProcessor {
+	return nil
+}
+
+// LabelsProcessor has no detectors yet - client-version labelling lands in a
+// later task. NewBaseLabelsProcessor returns nil for an empty detector list,
+// which satisfies the labels.LabelsProcessor interface as a no-op.
+func (b *BitcoinChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
+	return labels.NewBaseLabelsProcessor(b.ctx, b.upstreamId, []labels.LabelsDetector{}, b.labelsDelay)
+}
+
+func (b *BitcoinChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
+	return caps.DefaultCapDetectors(b.upstreamId, input.WsConnector)
+}
+
+// LowerBoundProcessor has no detectors yet - prune-aware bounds land in a
+// later task. NewBaseLowerBoundProcessor returns nil for an empty detector
+// list, which satisfies the lower_bounds.LowerBoundProcessor interface as a
+// no-op.
+func (b *BitcoinChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
+	return lower_bounds.NewBaseLowerBoundProcessor(
+		b.ctx,
+		b.upstreamId,
+		b.configuredChain.AverageRemoveSpeed(),
+		[]lower_bounds.LowerBoundDetector{},
+	)
+}
+
+// HealthValidators has no validators yet - health/syncing checks land in a
+// later task; the disable-option short-circuit is kept so the shape matches
+// what every other family already does.
+func (b *BitcoinChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	if b.options != nil && *b.options.DisableHealthValidation {
+		return []validations.Validator[protocol.AvailabilityStatus]{}
+	}
+	return []validations.Validator[protocol.AvailabilityStatus]{}
+}
+
+// SettingsValidators has no validators yet - genesis-hash chain validation
+// lands in a later task; the disable-option short-circuit is kept so the
+// shape matches what every other family already does.
+func (b *BitcoinChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
+	if b.configuredChain == nil || b.configuredChain.ChainId == "" {
+		return nil
+	}
+	if b.options != nil && *b.options.DisableChainValidation {
+		return []validations.Validator[validations.ValidationSettingResult]{}
+	}
+	return []validations.Validator[validations.ValidationSettingResult]{}
+}
+
+// GetLatestBlock polls getbestblockhash, then getblockheader on that hash to
+// pick up height/hash/parent-hash. bitcoind has no head subscription, so this
+// poll is the only way head tracking learns about a new block.
+func (b *BitcoinChainSpecificObject) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
+	hashRequest, err := protocol.NewInternalUpstreamJsonRpcRequest("getbestblockhash", []any{}, b.configuredChain.Chain)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+	hashResponse := b.connector.SendRequest(ctx, hashRequest)
+	if hashResponse.HasError() {
+		return protocol.ZeroBlock{}, hashResponse.GetError()
+	}
+	hash := protocol.ResultAsString(hashResponse.ResponseResult())
+	if hash == "" {
+		return protocol.ZeroBlock{}, fmt.Errorf("bitcoin upstream '%s' has no best block hash", b.upstreamId)
+	}
+
+	headerRequest, err := protocol.NewInternalUpstreamJsonRpcRequest("getblockheader", []any{hash}, b.configuredChain.Chain)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+	headerResponse := b.connector.SendRequest(ctx, headerRequest)
+	if headerResponse.HasError() {
+		return protocol.ZeroBlock{}, headerResponse.GetError()
+	}
+
+	block, err := b.ParseBlock(headerResponse.ResponseResult())
+	if err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse bitcoin block header for hash '%s': %w", hash, err)
+	}
+	return block, nil
+}
+
+// GetFinalizedBlock delegates to GetLatestBlock: bitcoind has no separate
+// finalized-head notion in scope here (confirmations-based finality is a
+// follow-up), same contract as algorand's pure-poll head tracking.
+func (b *BitcoinChainSpecificObject) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
+	return b.GetLatestBlock(ctx)
+}
+
+// ParseBlock expects the payload shape of getblockheader (verbose, the
+// default): {"hash", "height", "previousblockhash", ...}. Both Bitcoin Core
+// and Dogecoin Core share this shape.
+func (b *BitcoinChainSpecificObject) ParseBlock(blockBytes []byte) (protocol.Block, error) {
+	header := bitcoinBlockHeader{}
+	if err := sonic.Unmarshal(blockBytes, &header); err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the bitcoin block header, reason - %s", err.Error())
+	}
+	if header.Hash == "" {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the bitcoin block header, got '%s'", string(blockBytes))
+	}
+
+	parentHash := blockchain.EmptyHash
+	if header.PreviousBlockHash != "" {
+		parentHash = blockchain.NewHashIdFromString(header.PreviousBlockHash)
+	}
+
+	return protocol.NewBlock(
+		header.Height,
+		0,
+		blockchain.NewHashIdFromString(header.Hash),
+		parentHash,
+	), nil
+}
+
+func (b *BitcoinChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
+	return protocol.ZeroBlock{}, errUnsupportedHeadSubscriptions
+}
+
+func (b *BitcoinChainSpecificObject) SubscribeHeadRequest() (protocol.RequestHolder, error) {
+	return nil, errUnsupportedHeadSubscriptions
+}
+
+type bitcoinBlockHeader struct {
+	Hash              string `json:"hash"`
+	Height            uint64 `json:"height"`
+	PreviousBlockHash string `json:"previousblockhash"`
+}
+
+var _ chains_specific.ChainSpecific = (*BitcoinChainSpecificObject)(nil)

--- a/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
+++ b/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
@@ -12,8 +12,11 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
 	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/bitcoin_labels"
 	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/bitcoin_bounds"
 	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/bitcoin_validations"
 	"github.com/drpcorg/nodecore/pkg/blockchain"
 	"github.com/drpcorg/nodecore/pkg/chains"
 )
@@ -55,43 +58,51 @@ func (b *BitcoinChainSpecificObject) BlockProcessor() blocks.BlockProcessor {
 	return nil
 }
 
-// LabelsProcessor has no detectors yet - client-version labelling lands in a
-// later task. NewBaseLabelsProcessor returns nil for an empty detector list,
-// which satisfies the labels.LabelsProcessor interface as a no-op.
 func (b *BitcoinChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
-	return labels.NewBaseLabelsProcessor(b.ctx, b.upstreamId, []labels.LabelsDetector{}, b.labelsDelay)
+	labelsDetectors := []labels.LabelsDetector{
+		labels.NewClientLabelDetectorHandler(
+			b.upstreamId,
+			b.connector,
+			bitcoin_labels.NewBitcoinClientLabelsDetector(b.configuredChain.Chain),
+			b.internalTimeout,
+		),
+	}
+	return labels.NewBaseLabelsProcessor(b.ctx, b.upstreamId, labelsDetectors, b.labelsDelay)
 }
 
 func (b *BitcoinChainSpecificObject) CapDetectors(input caps.DetectorInput) []caps.CapDetector {
 	return caps.DefaultCapDetectors(b.upstreamId, input.WsConnector)
 }
 
-// LowerBoundProcessor has no detectors yet - prune-aware bounds land in a
-// later task. NewBaseLowerBoundProcessor returns nil for an empty detector
-// list, which satisfies the lower_bounds.LowerBoundProcessor interface as a
-// no-op.
 func (b *BitcoinChainSpecificObject) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
+	detectors := []lower_bounds.LowerBoundDetector{
+		bitcoin_bounds.NewBitcoinLowerBoundDetector(
+			b.upstreamId,
+			b.configuredChain.Chain,
+			b.internalTimeout,
+			b.connector,
+		),
+	}
 	return lower_bounds.NewBaseLowerBoundProcessor(
 		b.ctx,
 		b.upstreamId,
 		b.configuredChain.AverageRemoveSpeed(),
-		[]lower_bounds.LowerBoundDetector{},
+		detectors,
 	)
 }
 
-// HealthValidators has no validators yet - health/syncing checks land in a
-// later task; the disable-option short-circuit is kept so the shape matches
-// what every other family already does.
 func (b *BitcoinChainSpecificObject) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
 	if b.options != nil && *b.options.DisableHealthValidation {
 		return []validations.Validator[protocol.AvailabilityStatus]{}
 	}
-	return []validations.Validator[protocol.AvailabilityStatus]{}
+	validatePeers := b.options != nil && b.options.ValidatePeers != nil && *b.options.ValidatePeers
+	return []validations.Validator[protocol.AvailabilityStatus]{
+		bitcoin_validations.NewBitcoinHealthValidator(
+			b.upstreamId, b.connector, b.configuredChain, b.internalTimeout, validatePeers,
+		),
+	}
 }
 
-// SettingsValidators has no validators yet - genesis-hash chain validation
-// lands in a later task; the disable-option short-circuit is kept so the
-// shape matches what every other family already does.
 func (b *BitcoinChainSpecificObject) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
 	if b.configuredChain == nil || b.configuredChain.ChainId == "" {
 		return nil
@@ -99,7 +110,9 @@ func (b *BitcoinChainSpecificObject) SettingsValidators() []validations.Validato
 	if b.options != nil && *b.options.DisableChainValidation {
 		return []validations.Validator[validations.ValidationSettingResult]{}
 	}
-	return []validations.Validator[validations.ValidationSettingResult]{}
+	return []validations.Validator[validations.ValidationSettingResult]{
+		bitcoin_validations.NewBitcoinChainValidator(b.upstreamId, b.connector, b.configuredChain, b.internalTimeout),
+	}
 }
 
 // GetLatestBlock polls getbestblockhash, then getblockheader on that hash to

--- a/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific_test.go
@@ -1,0 +1,167 @@
+package bitcoin_specific_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	bestBlockHash = "00000000000000000000d7c68a3b5e0794da056f7996c668620eb2b53591a8cf"
+	prevBlockHash = "0000000000000000000000000000000000000000000000000000000000003f2f"
+)
+
+func methodIs(method string) any {
+	return mock.MatchedBy(func(r protocol.RequestHolder) bool { return r.Method() == method })
+}
+
+func headerFixture(hash, prev string) []byte {
+	return []byte(`{
+		"hash": "` + hash + `",
+		"confirmations": 1,
+		"height": 958407,
+		"version": 537427968,
+		"time": 1784290128,
+		"mediantime": 1784286851,
+		"nTx": 3011,
+		"previousblockhash": "` + prev + `"
+	}`)
+}
+
+// jsonRpcEnvelope wraps a raw JSON-RPC "result" payload the way a real
+// bitcoind response is shaped: {"result":<payload>,"error":null,"id":1}.
+// bitcoind always sends an explicit "error":null on success (unlike the
+// other JSON-RPC 2.0 upstreams in this codebase, which omit "error"
+// entirely) - see the parse_response.go fix that makes a null error parse
+// as "no error" instead of a failure.
+func jsonRpcEnvelope(result string) []byte {
+	return []byte(`{"result":` + result + `,"error":null,"id":1}`)
+}
+
+func TestBitcoinSubscribeHeadRequestUnsupported(t *testing.T) {
+	req, err := test_utils.NewBitcoinChainSpecific(context.Background(), nil).SubscribeHeadRequest()
+	assert.Nil(t, req)
+	assert.EqualError(t, err, "bitcoin: head subscriptions are not supported")
+}
+
+func TestBitcoinParseSubscriptionBlock(t *testing.T) {
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), nil).ParseSubscriptionBlock([]byte(`{}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.EqualError(t, err, "bitcoin: head subscriptions are not supported")
+}
+
+func TestBitcoinParseBlockHeader(t *testing.T) {
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), nil).ParseBlock(headerFixture(bestBlockHash, prevBlockHash))
+	assert.Nil(t, err)
+
+	expected := protocol.NewBlock(
+		958407, 0,
+		blockchain.NewHashIdFromString(bestBlockHash),
+		blockchain.NewHashIdFromString(prevBlockHash),
+	)
+	assert.Equal(t, expected, block)
+}
+
+func TestBitcoinParseBlockInvalidJSON(t *testing.T) {
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), nil).ParseBlock([]byte(`not json`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the bitcoin block header")
+}
+
+func TestBitcoinParseBlockEmptyHash(t *testing.T) {
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), nil).ParseBlock([]byte(`{"height": 100}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "couldn't parse the bitcoin block header")
+}
+
+func TestBitcoinGetLatestBlock(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+
+	hashResp := protocol.NewHttpUpstreamResponse("1", jsonRpcEnvelope(`"`+bestBlockHash+`"`), 200, protocol.JsonRpc)
+
+	headerResp := protocol.NewHttpUpstreamResponse("1", jsonRpcEnvelope(string(headerFixture(bestBlockHash, prevBlockHash))), 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, methodIs("getbestblockhash")).Return(hashResp).Once()
+	connector.On("SendRequest", ctx, methodIs("getblockheader")).Return(headerResp).Once()
+
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	assert.Nil(t, err)
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(
+		958407, 0,
+		blockchain.NewHashIdFromString(bestBlockHash),
+		blockchain.NewHashIdFromString(prevBlockHash),
+	)
+	assert.Equal(t, expected, block)
+}
+
+func TestBitcoinGetLatestBlockBestHashError(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "best hash error", nil))
+
+	connector.On("SendRequest", ctx, methodIs("getbestblockhash")).Return(response).Once()
+
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+
+	var upErr *protocol.ResponseError
+	assert.True(t, errors.As(err, &upErr))
+	assert.Equal(t, 1, upErr.Code)
+	assert.Equal(t, "best hash error", upErr.Message)
+}
+
+func TestBitcoinGetLatestBlockHeaderError(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+
+	hashResp := protocol.NewHttpUpstreamResponse("1", jsonRpcEnvelope(`"`+bestBlockHash+`"`), 200, protocol.JsonRpc)
+	headerErr := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(2, "header error", nil))
+
+	connector.On("SendRequest", ctx, methodIs("getbestblockhash")).Return(hashResp).Once()
+	connector.On("SendRequest", ctx, methodIs("getblockheader")).Return(headerErr).Once()
+
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), connector).GetLatestBlock(ctx)
+	connector.AssertExpectations(t)
+	assert.True(t, block.IsFullEmpty())
+
+	var upErr *protocol.ResponseError
+	assert.True(t, errors.As(err, &upErr))
+	assert.Equal(t, 2, upErr.Code)
+	assert.Equal(t, "header error", upErr.Message)
+}
+
+// TestBitcoinGetFinalizedBlockDelegatesToLatest mirrors algorand: bitcoind has
+// no separate finalized-head concept in scope here, so GetFinalizedBlock just
+// forwards to GetLatestBlock.
+func TestBitcoinGetFinalizedBlockDelegatesToLatest(t *testing.T) {
+	ctx := context.Background()
+	connector := mocks.NewConnectorMock()
+
+	hashResp := protocol.NewHttpUpstreamResponse("1", jsonRpcEnvelope(`"`+bestBlockHash+`"`), 200, protocol.JsonRpc)
+	headerResp := protocol.NewHttpUpstreamResponse("1", jsonRpcEnvelope(string(headerFixture(bestBlockHash, prevBlockHash))), 200, protocol.JsonRpc)
+
+	connector.On("SendRequest", ctx, methodIs("getbestblockhash")).Return(hashResp).Once()
+	connector.On("SendRequest", ctx, methodIs("getblockheader")).Return(headerResp).Once()
+
+	block, err := test_utils.NewBitcoinChainSpecific(context.Background(), connector).GetFinalizedBlock(ctx)
+	assert.Nil(t, err)
+	connector.AssertExpectations(t)
+
+	expected := protocol.NewBlock(
+		958407, 0,
+		blockchain.NewHashIdFromString(bestBlockHash),
+		blockchain.NewHashIdFromString(prevBlockHash),
+	)
+	assert.Equal(t, expected, block)
+}

--- a/internal/upstreams/flow/method_translation.go
+++ b/internal/upstreams/flow/method_translation.go
@@ -1,0 +1,177 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+)
+
+// methodTranslator rewrites a client method into the request an upstream
+// actually understands and reshapes the upstream response back into the shape
+// the client expects. Translators are looked up by (spec name, client method)
+// in sendUnaryRequest right before the request hits an api connector, so the
+// translated request's spec method drives the connector choice.
+type methodTranslator interface {
+	TranslateRequest(ctx context.Context, request protocol.RequestHolder) (protocol.RequestHolder, error)
+	TranslateResponse(request, upstreamRequest protocol.RequestHolder, upstreamHeadHeight uint64, response protocol.ResponseHolder) protocol.ResponseHolder
+}
+
+var methodTranslators = map[string]map[string]methodTranslator{
+	"bitcoin": {
+		"getblocknumber": &jsonRpcMethodAlias{specName: "bitcoin", target: "getblockcount"},
+		"listunspent":    &bitcoinListUnspentTranslator{specName: "bitcoin"},
+	},
+}
+
+func getMethodTranslator(specName, method string) methodTranslator {
+	return methodTranslators[specName][method]
+}
+
+// jsonRpcMethodAlias resends the request under another JSON-RPC method name,
+// keeping the id and params intact. The response passes through untouched.
+type jsonRpcMethodAlias struct {
+	specName string
+	target   string
+}
+
+func (a *jsonRpcMethodAlias) TranslateRequest(_ context.Context, request protocol.RequestHolder) (protocol.RequestHolder, error) {
+	body, err := jsonRpcBodyOf(request)
+	if err != nil {
+		return nil, err
+	}
+	body.Method = a.target
+	return protocol.NewUpstreamJsonRpcRequest(request.Id(), *body, false, a.specName, request.Selectors()...), nil
+}
+
+func (a *jsonRpcMethodAlias) TranslateResponse(_, _ protocol.RequestHolder, _ uint64, response protocol.ResponseHolder) protocol.ResponseHolder {
+	return response
+}
+
+const esploraAddressUtxoMethod = "GET#/address/*/utxo"
+
+// bitcoinListUnspentTranslator serves bitcoind's listunspent from an esplora
+// upstream: GET /address/{addr}/utxo, then reshapes the utxo list into the
+// bitcoind response shape.
+type bitcoinListUnspentTranslator struct {
+	specName string
+}
+
+func (t *bitcoinListUnspentTranslator) TranslateRequest(_ context.Context, request protocol.RequestHolder) (protocol.RequestHolder, error) {
+	body, err := jsonRpcBodyOf(request)
+	if err != nil {
+		return nil, err
+	}
+	address, err := listUnspentAddress(body.Params)
+	if err != nil {
+		return nil, err
+	}
+	params := &protocol.RequestParams{PathParams: []string{address}}
+	return protocol.NewUpstreamRestRequest(request.Id(), esploraAddressUtxoMethod, params, nil, t.specName, request.Selectors()...), nil
+}
+
+func (t *bitcoinListUnspentTranslator) TranslateResponse(request, upstreamRequest protocol.RequestHolder, upstreamHeadHeight uint64, response protocol.ResponseHolder) protocol.ResponseHolder {
+	if response.HasError() {
+		return response
+	}
+	var utxos []esploraUtxo
+	if err := sonic.Unmarshal(response.ResponseResult(), &utxos); err != nil {
+		return protocol.NewTotalFailureFromErr(request.Id(), protocol.IncorrectResponseBodyError(err), protocol.JsonRpc)
+	}
+	address := ""
+	if params := upstreamRequest.RequestParams(); params != nil && len(params.PathParams) > 0 {
+		address = params.PathParams[0]
+	}
+	unspent := make([]listUnspentUtxo, 0, len(utxos))
+	for _, utxo := range utxos {
+		unspent = append(unspent, listUnspentUtxo{
+			Txid:          utxo.Txid,
+			Vout:          utxo.Vout,
+			Address:       address,
+			Amount:        satsToBtc(utxo.Value),
+			Confirmations: utxoConfirmations(utxo.Status, upstreamHeadHeight),
+		})
+	}
+	result, err := sonic.Marshal(unspent)
+	if err != nil {
+		return protocol.NewTotalFailureFromErr(request.Id(), protocol.IncorrectResponseBodyError(err), protocol.JsonRpc)
+	}
+	return protocol.NewSimpleHttpUpstreamResponse(request.Id(), result, protocol.JsonRpc)
+}
+
+type esploraUtxo struct {
+	Txid   string            `json:"txid"`
+	Vout   uint32            `json:"vout"`
+	Status esploraUtxoStatus `json:"status"`
+	Value  uint64            `json:"value"`
+}
+
+type esploraUtxoStatus struct {
+	Confirmed   bool   `json:"confirmed"`
+	BlockHeight uint64 `json:"block_height"`
+}
+
+type listUnspentUtxo struct {
+	Txid          string          `json:"txid"`
+	Vout          uint32          `json:"vout"`
+	Address       string          `json:"address"`
+	Amount        json.RawMessage `json:"amount"`
+	Confirmations uint64          `json:"confirmations"`
+}
+
+func jsonRpcBodyOf(request protocol.RequestHolder) (*protocol.JsonRpcRequestBody, error) {
+	rawBody, err := request.Body()
+	if err != nil {
+		return nil, protocol.ClientError(err)
+	}
+	var body protocol.JsonRpcRequestBody
+	if err := sonic.Unmarshal(rawBody, &body); err != nil {
+		return nil, protocol.ClientError(err)
+	}
+	return &body, nil
+}
+
+// listUnspentAddress extracts the single queried address from bitcoind-style
+// listunspent params - [minconf, maxconf, [addresses]] - accepting a bare
+// address string in place of the array defensively.
+func listUnspentAddress(rawParams json.RawMessage) (string, error) {
+	var params []any
+	if len(rawParams) > 0 {
+		if err := sonic.Unmarshal(rawParams, &params); err != nil {
+			return "", protocol.InvalidParamsError("listunspent params must be an array")
+		}
+	}
+	for _, param := range params {
+		switch value := param.(type) {
+		case string:
+			return value, nil
+		case []any:
+			if len(value) != 1 {
+				return "", protocol.InvalidParamsError("listunspent supports exactly one address")
+			}
+			address, ok := value[0].(string)
+			if !ok {
+				return "", protocol.InvalidParamsError("listunspent address must be a string")
+			}
+			return address, nil
+		}
+	}
+	return "", protocol.InvalidParamsError("listunspent requires an address")
+}
+
+const satsPerBtc = 100_000_000
+
+// satsToBtc renders a satoshi amount as a fixed 8-decimal BTC JSON number,
+// avoiding float64 artifacts.
+func satsToBtc(sats uint64) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf("%d.%08d", sats/satsPerBtc, sats%satsPerBtc))
+}
+
+func utxoConfirmations(status esploraUtxoStatus, headHeight uint64) uint64 {
+	if !status.Confirmed || status.BlockHeight == 0 || headHeight < status.BlockHeight {
+		return 0
+	}
+	return headHeight - status.BlockHeight + 1
+}

--- a/internal/upstreams/flow/method_translation_test.go
+++ b/internal/upstreams/flow/method_translation_test.go
@@ -1,0 +1,237 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/drpcorg/nodecore/internal/config"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func bitcoinJsonRpcRequest(t *testing.T, method string, params string) protocol.RequestHolder {
+	t.Helper()
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	body := protocol.JsonRpcRequestBody{Id: []byte(`5`), Method: method, Params: json.RawMessage(params)}
+	return protocol.NewUpstreamJsonRpcRequest("223", body, false, "bitcoin")
+}
+
+func TestGetBlockNumberTranslatesToGetBlockCount(t *testing.T) {
+	request := bitcoinJsonRpcRequest(t, "getblocknumber", `[]`)
+	translator := getMethodTranslator("bitcoin", "getblocknumber")
+	require.NotNil(t, translator)
+
+	translated, err := translator.TranslateRequest(context.Background(), request)
+
+	require.NoError(t, err)
+	assert.Equal(t, "getblockcount", translated.Method())
+	assert.Equal(t, "223", translated.Id())
+	body, err := translated.Body()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":5,"jsonrpc":"2.0","method":"getblockcount","params":[]}`, string(body))
+
+	response := protocol.NewSimpleHttpUpstreamResponse("223", []byte(`850000`), protocol.JsonRpc)
+	assert.Same(t, response, translator.TranslateResponse(request, translated, 850_000, response))
+}
+
+func TestListUnspentTranslatesToEsploraUtxoRequest(t *testing.T) {
+	translator := getMethodTranslator("bitcoin", "listunspent")
+	require.NotNil(t, translator)
+
+	for name, params := range map[string]string{
+		"bitcoind style":  `[1, 9999999, ["bc1qaddress"]]`,
+		"address in args": `[1, 9999999, "bc1qaddress"]`,
+		"single address":  `["bc1qaddress"]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := bitcoinJsonRpcRequest(t, "listunspent", params)
+
+			translated, err := translator.TranslateRequest(context.Background(), request)
+
+			require.NoError(t, err)
+			assert.Equal(t, "GET#/address/*/utxo", translated.Method())
+			assert.Equal(t, protocol.Rest, translated.RequestType())
+			assert.Equal(t, "223", translated.Id())
+			require.NotNil(t, translated.RequestParams())
+			assert.Equal(t, []string{"bc1qaddress"}, translated.RequestParams().PathParams)
+		})
+	}
+}
+
+func TestListUnspentInvalidParams(t *testing.T) {
+	translator := getMethodTranslator("bitcoin", "listunspent")
+	require.NotNil(t, translator)
+
+	for name, params := range map[string]string{
+		"no params":          `[]`,
+		"no address":         `[1, 9999999]`,
+		"multiple addresses": `[1, 9999999, ["addr1", "addr2"]]`,
+		"non-string address": `[1, 9999999, [42]]`,
+		"not an array":       `{"minconf": 1}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := bitcoinJsonRpcRequest(t, "listunspent", params)
+
+			_, err := translator.TranslateRequest(context.Background(), request)
+
+			require.Error(t, err)
+			respErr, ok := err.(*protocol.ResponseError)
+			require.True(t, ok)
+			assert.Equal(t, protocol.InvalidParams, respErr.Code)
+		})
+	}
+}
+
+func TestListUnspentReshapesEsploraResponse(t *testing.T) {
+	translator := getMethodTranslator("bitcoin", "listunspent")
+	require.NotNil(t, translator)
+	request := bitcoinJsonRpcRequest(t, "listunspent", `[1, 9999999, ["bc1qaddress"]]`)
+	translated, err := translator.TranslateRequest(context.Background(), request)
+	require.NoError(t, err)
+
+	esploraBody := `[
+		{"txid":"aa11","vout":1,"status":{"confirmed":true,"block_height":849000,"block_hash":"00","block_time":1},"value":927},
+		{"txid":"bb22","vout":0,"status":{"confirmed":true,"block_height":850000},"value":150000000},
+		{"txid":"cc33","vout":2,"status":{"confirmed":false},"value":100000000}
+	]`
+	response := protocol.NewSimpleHttpUpstreamResponse("223", []byte(esploraBody), protocol.Rest)
+
+	reshaped := translator.TranslateResponse(request, translated, 850_000, response)
+
+	require.False(t, reshaped.HasError())
+	assert.Equal(t, "223", reshaped.Id())
+	assert.JSONEq(t, `[
+		{"txid":"aa11","vout":1,"address":"bc1qaddress","amount":0.00000927,"confirmations":1001},
+		{"txid":"bb22","vout":0,"address":"bc1qaddress","amount":1.50000000,"confirmations":1},
+		{"txid":"cc33","vout":2,"address":"bc1qaddress","amount":1.00000000,"confirmations":0}
+	]`, string(reshaped.ResponseResult()))
+	assert.Contains(t, string(reshaped.ResponseResult()), `"amount":0.00000927`)
+}
+
+func TestListUnspentPassesThroughUpstreamError(t *testing.T) {
+	translator := getMethodTranslator("bitcoin", "listunspent")
+	require.NotNil(t, translator)
+	request := bitcoinJsonRpcRequest(t, "listunspent", `[1, 9999999, ["bc1qaddress"]]`)
+	translated, err := translator.TranslateRequest(context.Background(), request)
+	require.NoError(t, err)
+
+	response := protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithMessage("esplora is down"))
+
+	assert.Same(t, response, translator.TranslateResponse(request, translated, 850_000, response))
+}
+
+func TestSatsToBtc(t *testing.T) {
+	assert.Equal(t, "0.00000927", string(satsToBtc(927)))
+	assert.Equal(t, "0.00000000", string(satsToBtc(0)))
+	assert.Equal(t, "1.00000000", string(satsToBtc(100_000_000)))
+	assert.Equal(t, "21.12345678", string(satsToBtc(2_112_345_678)))
+}
+
+func bitcoinTestUpstream(connector connectors.ApiConnector, headHeight uint64) *upstreams.BaseUpstream {
+	upState := utils.NewAtomic[protocol.UpstreamState]()
+	state := protocol.DefaultUpstreamState(mocks.NewMethodsMock(), mapset.NewThreadUnsafeSet[protocol.Cap](), "00012", nil, nil)
+	state.HeadData = protocol.NewBlockWithHeight(headHeight)
+	upState.Store(state)
+
+	return upstreams.NewBaseUpstreamWithParams(
+		"id",
+		chains.BITCOIN,
+		[]connectors.ApiConnector{connector},
+		&config.Upstream{Id: "id", PollInterval: 10 * time.Millisecond, Options: &chains.Options{InternalTimeout: 5 * time.Second}},
+		"00012",
+		upState,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func TestUnaryRequestProcessorTranslatesListUnspent(t *testing.T) {
+	request := bitcoinJsonRpcRequest(t, "listunspent", `[1, 9999999, ["bc1qaddress"]]`)
+
+	apiConnector := mocks.NewConnectorMockWithType(specs.RestAdditional)
+	upstream := bitcoinTestUpstream(apiConnector, 850_000)
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+
+	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+	apiConnector.On("SendRequest", mock.Anything, mock.MatchedBy(func(req protocol.RequestHolder) bool {
+		return req.Method() == "GET#/address/*/utxo" &&
+			req.RequestType() == protocol.Rest &&
+			req.RequestParams() != nil &&
+			len(req.RequestParams().PathParams) == 1 &&
+			req.RequestParams().PathParams[0] == "bc1qaddress"
+	})).Return(protocol.NewSimpleHttpUpstreamResponse("223", []byte(`[{"txid":"aa11","vout":1,"status":{"confirmed":true,"block_height":849000},"value":927}]`), protocol.Rest))
+
+	processor := NewUnaryRequestProcessor(chains.BITCOIN, upSupervisor)
+	response := processor.ProcessRequest(context.Background(), strategy, request)
+
+	unaryRespWrapper := response.(*UnaryResponse).ResponseWrapper
+	apiConnector.AssertExpectations(t)
+	assert.Equal(t, "223", unaryRespWrapper.RequestId)
+	assert.Equal(t, "id", unaryRespWrapper.UpstreamId)
+	require.False(t, unaryRespWrapper.Response.HasError())
+	assert.JSONEq(t, `[{"txid":"aa11","vout":1,"address":"bc1qaddress","amount":0.00000927,"confirmations":1001}]`, string(unaryRespWrapper.Response.ResponseResult()))
+}
+
+func TestUnaryRequestProcessorTranslatesGetBlockNumber(t *testing.T) {
+	request := bitcoinJsonRpcRequest(t, "getblocknumber", `[]`)
+
+	apiConnector := mocks.NewConnectorMockWithType(specs.JsonRpcConnector)
+	upstream := bitcoinTestUpstream(apiConnector, 850_000)
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+
+	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+	apiConnector.On("SendRequest", mock.Anything, mock.MatchedBy(func(req protocol.RequestHolder) bool {
+		body, err := req.Body()
+		return err == nil && req.Method() == "getblockcount" && string(body) == `{"id":5,"jsonrpc":"2.0","method":"getblockcount","params":[]}`
+	})).Return(protocol.NewSimpleHttpUpstreamResponse("223", []byte(`850000`), protocol.JsonRpc))
+
+	processor := NewUnaryRequestProcessor(chains.BITCOIN, upSupervisor)
+	response := processor.ProcessRequest(context.Background(), strategy, request)
+
+	unaryRespWrapper := response.(*UnaryResponse).ResponseWrapper
+	apiConnector.AssertExpectations(t)
+	assert.Equal(t, "223", unaryRespWrapper.RequestId)
+	require.False(t, unaryRespWrapper.Response.HasError())
+	assert.Equal(t, `850000`, string(unaryRespWrapper.Response.ResponseResult()))
+}
+
+func TestUnaryRequestProcessorListUnspentInvalidParamsNoUpstreamCall(t *testing.T) {
+	request := bitcoinJsonRpcRequest(t, "listunspent", `[1, 9999999]`)
+
+	apiConnector := mocks.NewConnectorMockWithType(specs.RestAdditional)
+	upstream := bitcoinTestUpstream(apiConnector, 850_000)
+	upSupervisor := mocks.NewUpstreamSupervisorMock()
+	strategy := mocks.NewMockStrategy()
+
+	upSupervisor.On("GetExecutor").Return(test_utils.CreateExecutor())
+	strategy.On("SelectUpstream", request).Return("id", nil)
+	upSupervisor.On("GetUpstream", "id").Return(upstream)
+
+	processor := NewUnaryRequestProcessor(chains.BITCOIN, upSupervisor)
+	response := processor.ProcessRequest(context.Background(), strategy, request)
+
+	unaryRespWrapper := response.(*UnaryResponse).ResponseWrapper
+	apiConnector.AssertNotCalled(t, "SendRequest")
+	assert.Equal(t, "223", unaryRespWrapper.RequestId)
+	require.True(t, unaryRespWrapper.Response.HasError())
+	assert.Equal(t, protocol.InvalidParams, unaryRespWrapper.Response.GetError().Code)
+}

--- a/internal/upstreams/flow/request_processor.go
+++ b/internal/upstreams/flow/request_processor.go
@@ -189,12 +189,29 @@ func sendUnaryRequest(
 ) (*protocol.ResponseHolderWrapper, error) {
 	zerolog.Ctx(ctx).Debug().Msgf("sending a request %s to upstream %s", request.Method(), upstream.GetId())
 
-	apiConnector := getMethodConnector(upstream, request.SpecMethod())
+	upstreamRequest := request
+	translator := getMethodTranslator(chains.GetMethodSpecNameByChain(upstream.GetChain()), request.Method())
+	if translator != nil {
+		translated, err := translator.TranslateRequest(ctx, request)
+		if err != nil {
+			return &protocol.ResponseHolderWrapper{
+				RequestId:  request.Id(),
+				UpstreamId: upstream.GetId(),
+				Response:   protocol.NewTotalFailureFromErr(request.Id(), err, request.RequestType()),
+			}, nil
+		}
+		upstreamRequest = translated
+	}
+
+	apiConnector := getMethodConnector(upstream, upstreamRequest.SpecMethod())
 	if apiConnector == nil {
 		return nil, protocol.NoApiConnectorsError(request.Method())
 	}
 
-	response := apiConnector.SendRequest(ctx, request)
+	response := apiConnector.SendRequest(ctx, upstreamRequest)
+	if translator != nil {
+		response = translator.TranslateResponse(request, upstreamRequest, upstream.GetCurrentHeadHeight(), response)
+	}
 
 	if response.ResponseCode() == http.StatusTooManyRequests && upstream.GetUpstreamState().AutoTuneRateLimiter != nil {
 		upstream.GetUpstreamState().AutoTuneRateLimiter.IncErrors()

--- a/internal/upstreams/labels/bitcoin_labels/bitcoin_detectors.go
+++ b/internal/upstreams/labels/bitcoin_labels/bitcoin_detectors.go
@@ -1,0 +1,42 @@
+package bitcoin_labels
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+type BitcoinClientLabelsDetector struct {
+	chain chains.Chain
+}
+
+func NewBitcoinClientLabelsDetector(chain chains.Chain) *BitcoinClientLabelsDetector {
+	return &BitcoinClientLabelsDetector{chain: chain}
+}
+
+func (b *BitcoinClientLabelsDetector) NodeTypeRequest() (protocol.RequestHolder, error) {
+	return protocol.NewInternalUpstreamJsonRpcRequest("getnetworkinfo", []any{}, b.chain)
+}
+
+type bitcoinNetworkInfoResponse struct {
+	Subversion string `json:"subversion"`
+}
+
+func (b *BitcoinClientLabelsDetector) ClientVersionAndType(data []byte) (string, string, error) {
+	var networkInfo bitcoinNetworkInfoResponse
+	if err := sonic.Unmarshal(data, &networkInfo); err != nil {
+		return "", "", fmt.Errorf("bitcoin getnetworkinfo payload unparseable: %w", err)
+	}
+	// subversion looks like "/Satoshi:26.1.0/" (Dogecoin Core reports "/Shibetoshi:1.14.9/")
+	clientType, version, found := strings.Cut(strings.Trim(networkInfo.Subversion, "/"), ":")
+	if !found || clientType == "" || version == "" {
+		return "", "bitcoind", nil
+	}
+	return version, strings.ToLower(clientType), nil
+}
+
+var _ labels.ClientLabelsDetector = (*BitcoinClientLabelsDetector)(nil)

--- a/internal/upstreams/labels/bitcoin_labels/bitcoin_detectors_test.go
+++ b/internal/upstreams/labels/bitcoin_labels/bitcoin_detectors_test.go
@@ -1,0 +1,86 @@
+package bitcoin_labels_test
+
+import (
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/bitcoin_labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitcoinClientLabelsDetectorNodeTypeRequest(t *testing.T) {
+	detector := bitcoin_labels.NewBitcoinClientLabelsDetector(chains.BITCOIN)
+
+	request, err := detector.NodeTypeRequest()
+	require.NoError(t, err)
+	require.NotNil(t, request)
+
+	assert.Equal(t, "getnetworkinfo", request.Method())
+	assert.Equal(t, protocol.JsonRpc, request.RequestType())
+
+	body, err := request.Body()
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"id":"1","jsonrpc":"2.0","method":"getnetworkinfo","params":[]}`, string(body))
+}
+
+func TestBitcoinClientLabelsDetectorClientVersionAndType(t *testing.T) {
+	tests := []struct {
+		name               string
+		data               []byte
+		expectedVersion    string
+		expectedClientType string
+		expectErr          bool
+	}{
+		{
+			name:               "parses bitcoin core subversion",
+			data:               []byte(`{"version":260100,"subversion":"/Satoshi:26.1.0/","connections":10}`),
+			expectedVersion:    "26.1.0",
+			expectedClientType: "satoshi",
+		},
+		{
+			name:               "parses dogecoin core subversion",
+			data:               []byte(`{"version":1140900,"subversion":"/Shibetoshi:1.14.9/","connections":8}`),
+			expectedVersion:    "1.14.9",
+			expectedClientType: "shibetoshi",
+		},
+		{
+			name:               "falls back on missing subversion",
+			data:               []byte(`{"version":260100,"connections":10}`),
+			expectedVersion:    "",
+			expectedClientType: "bitcoind",
+		},
+		{
+			name:               "falls back on subversion without version",
+			data:               []byte(`{"subversion":"/Satoshi/"}`),
+			expectedVersion:    "",
+			expectedClientType: "bitcoind",
+		},
+		{
+			name:      "fails on invalid json",
+			data:      []byte(`{"subversion":`),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := bitcoin_labels.NewBitcoinClientLabelsDetector(chains.BITCOIN)
+
+			version, clientType, err := detector.ClientVersionAndType(tt.data)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Empty(t, version)
+				assert.Empty(t, clientType)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedVersion, version)
+			assert.Equal(t, tt.expectedClientType, clientType)
+		})
+	}
+}

--- a/internal/upstreams/lower_bounds/bitcoin_bounds/bitcoin_lower_bound.go
+++ b/internal/upstreams/lower_bounds/bitcoin_bounds/bitcoin_lower_bound.go
@@ -1,0 +1,136 @@
+package bitcoin_bounds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+// The prune point moves slowly (bitcoind trims in large chunks), so a long
+// period is enough.
+const bitcoinPeriod = 15 * time.Minute
+
+var errBitcoinNoPruneHeight = errors.New("bitcoin node is pruned but reported no pruneheight")
+
+var bitcoinEmittedBoundTypes = []protocol.LowerBoundType{
+	protocol.BlockBound,
+	protocol.TxBound,
+}
+
+type BitcoinLowerBoundDetector struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           chains.Chain
+	internalTimeout time.Duration
+
+	lastBound atomic.Int64
+}
+
+func NewBitcoinLowerBoundDetector(
+	upstreamId string,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *BitcoinLowerBoundDetector {
+	return &BitcoinLowerBoundDetector{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (b *BitcoinLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	info, err := b.fetchBlockchainInfo(ctx)
+	if err != nil {
+		return b.fallback(fmt.Errorf("cannot fetch blockchain info: %w", err)), nil
+	}
+
+	bound := int64(1)
+	if info.Pruned {
+		if info.PruneHeight <= 0 {
+			return b.fallback(errBitcoinNoPruneHeight), nil
+		}
+		bound = info.PruneHeight
+	}
+	b.lastBound.Store(bound)
+
+	return bitcoinBounds(bound), nil
+}
+
+func (b *BitcoinLowerBoundDetector) SupportedTypes() []protocol.LowerBoundType {
+	return append(append([]protocol.LowerBoundType{}, bitcoinEmittedBoundTypes...), protocol.UnknownBound)
+}
+
+func (b *BitcoinLowerBoundDetector) Period() time.Duration {
+	return bitcoinPeriod
+}
+
+// fallback decides what to publish when the calculation cannot complete.
+// If a previous tick produced a bound, re-emit it so the router keeps using
+// the last known good value. Otherwise emit UnknownBound=0 so consumers get
+// an explicit "we don't know" signal instead of silence.
+func (b *BitcoinLowerBoundDetector) fallback(reason error) []protocol.LowerBoundData {
+	if cached := b.lastBound.Load(); cached > 0 {
+		log.Warn().Err(reason).Msgf(
+			"bitcoin upstream '%s' lower-bound calculation failed; retaining cached bound=%d",
+			b.upstreamId, cached,
+		)
+		return bitcoinBounds(cached)
+	}
+	log.Warn().Err(reason).Msgf(
+		"bitcoin upstream '%s' lower-bound calculation failed and no cache available; emitting UnknownBound",
+		b.upstreamId,
+	)
+	return []protocol.LowerBoundData{
+		protocol.NewLowerBoundDataNow(0, protocol.UnknownBound),
+	}
+}
+
+func bitcoinBounds(bound int64) []protocol.LowerBoundData {
+	bounds := make([]protocol.LowerBoundData, 0, len(bitcoinEmittedBoundTypes))
+	for _, bt := range bitcoinEmittedBoundTypes {
+		bounds = append(bounds, protocol.NewLowerBoundDataNow(bound, bt))
+	}
+	return bounds
+}
+
+func (b *BitcoinLowerBoundDetector) fetchBlockchainInfo(ctx context.Context) (*bitcoinBlockchainInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("getblockchaininfo", []any{}, b.chain)
+	if err != nil {
+		return nil, err
+	}
+
+	response := b.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	raw := response.ResponseResult()
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("bitcoin upstream '%s' getblockchaininfo returned an empty body", b.upstreamId)
+	}
+	var info bitcoinBlockchainInfo
+	if err := sonic.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("bitcoin upstream '%s' getblockchaininfo unparseable: %w", b.upstreamId, err)
+	}
+	return &info, nil
+}
+
+type bitcoinBlockchainInfo struct {
+	Pruned      bool  `json:"pruned"`
+	PruneHeight int64 `json:"pruneheight"`
+}
+
+var _ lower_bounds.LowerBoundDetector = (*BitcoinLowerBoundDetector)(nil)

--- a/internal/upstreams/lower_bounds/bitcoin_bounds/bitcoin_lower_bound_test.go
+++ b/internal/upstreams/lower_bounds/bitcoin_bounds/bitcoin_lower_bound_test.go
@@ -1,0 +1,145 @@
+package bitcoin_bounds_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/bitcoin_bounds"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func bitcoinInfoResponse(pruned bool, pruneHeight int64) protocol.ResponseHolder {
+	body := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":"1","result":{"chain":"main","blocks":850000,"pruned":%t,"pruneheight":%d}}`,
+		pruned, pruneHeight,
+	)
+	return protocol.NewHttpUpstreamResponse("1", []byte(body), 200, protocol.JsonRpc)
+}
+
+func bitcoinUnprunedResponse() protocol.ResponseHolder {
+	body := `{"jsonrpc":"2.0","id":"1","result":{"chain":"main","blocks":850000,"pruned":false}}`
+	return protocol.NewHttpUpstreamResponse("1", []byte(body), 200, protocol.JsonRpc)
+}
+
+func matchBitcoinInfoRequest() func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		return req.Method() == "getblockchaininfo" && req.RequestType() == protocol.JsonRpc
+	}
+}
+
+func boundsByType(t *testing.T, result []protocol.LowerBoundData) map[protocol.LowerBoundType]int64 {
+	t.Helper()
+	got := make(map[protocol.LowerBoundType]int64, len(result))
+	for _, b := range result {
+		got[b.Type] = b.Bound
+	}
+	return got
+}
+
+func TestBitcoinLowerBoundDetector_SupportedTypesAndPeriod(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	assert.ElementsMatch(t,
+		[]protocol.LowerBoundType{
+			protocol.BlockBound,
+			protocol.TxBound,
+			protocol.UnknownBound,
+		},
+		detector.SupportedTypes(),
+	)
+	assert.Equal(t, 15*time.Minute, detector.Period())
+}
+
+func TestBitcoinLowerBoundDetector_UnprunedReturnsOne(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(bitcoinUnprunedResponse())
+
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	result, err := detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	got := boundsByType(t, result)
+	assert.Equal(t, int64(1), got[protocol.BlockBound])
+	assert.Equal(t, int64(1), got[protocol.TxBound])
+}
+
+func TestBitcoinLowerBoundDetector_PrunedReturnsPruneHeight(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(bitcoinInfoResponse(true, 812345))
+
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	result, err := detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	got := boundsByType(t, result)
+	assert.Equal(t, int64(812345), got[protocol.BlockBound])
+	assert.Equal(t, int64(812345), got[protocol.TxBound])
+}
+
+func TestBitcoinLowerBoundDetector_ErrorWithCacheRetainsCachedBound(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(bitcoinInfoResponse(true, 812345)).
+		Once()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ServerError()))
+
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	result, err := detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	result, err = detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	got := boundsByType(t, result)
+	assert.Equal(t, int64(812345), got[protocol.BlockBound])
+	assert.Equal(t, int64(812345), got[protocol.TxBound])
+}
+
+func TestBitcoinLowerBoundDetector_ErrorWithoutCacheEmitsUnknownBound(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ServerError()))
+
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	result, err := detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, protocol.UnknownBound, result[0].Type)
+	assert.Equal(t, int64(0), result[0].Bound)
+}
+
+func TestBitcoinLowerBoundDetector_PrunedWithoutPruneHeightFallsBack(t *testing.T) {
+	connector := mocks.NewConnectorMock()
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchBitcoinInfoRequest())).
+		Return(bitcoinInfoResponse(true, 0))
+
+	detector := bitcoin_bounds.NewBitcoinLowerBoundDetector("id", chains.BITCOIN, time.Second, connector)
+
+	result, err := detector.DetectLowerBound(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, protocol.UnknownBound, result[0].Type)
+	assert.Equal(t, int64(0), result[0].Bound)
+}

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/aptos_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/aztec_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/beacon_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/bitcoin_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/evm_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/solana_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/tron_specific"
@@ -220,6 +221,14 @@ func getChainSpecific(
 		), nil
 	case chains.Algorand:
 		return algorand_specific.NewAlgorandChainSpecificObject(
+			ctx,
+			configuredChain,
+			conf.Id,
+			upstreamConnectorsInfo.internalRequestConnector,
+			conf.Options,
+		), nil
+	case chains.Bitcoin:
+		return bitcoin_specific.NewBitcoinChainSpecificObject(
 			ctx,
 			configuredChain,
 			conf.Id,

--- a/internal/upstreams/validations/bitcoin_validations/bitcoin_chain_validator.go
+++ b/internal/upstreams/validations/bitcoin_validations/bitcoin_chain_validator.go
@@ -1,0 +1,93 @@
+package bitcoin_validations
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+var errBitcoinEmptyGenesis = errors.New("bitcoin node returned empty genesis hash")
+
+var expectedGenesisHashes = map[chains.Chain]string{
+	chains.BITCOIN:          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+	chains.BITCOIN_TESTNET:  "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+	chains.DOGECOIN:         "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691",
+	chains.DOGECOIN_TESTNET: "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e",
+}
+
+type BitcoinChainValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           *chains.ConfiguredChain
+	internalTimeout time.Duration
+}
+
+func NewBitcoinChainValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+) *BitcoinChainValidator {
+	return &BitcoinChainValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (b *BitcoinChainValidator) Validate() validations.ValidationSettingResult {
+	expected, hasMapping := expectedGenesisHashes[b.chain.Chain]
+	if !hasMapping {
+		log.Warn().Msgf(
+			"no expected genesis hash for chain '%s', skipping chain validation of bitcoin upstream '%s'",
+			b.chain.Chain.String(),
+			b.upstreamId,
+		)
+		return validations.Valid
+	}
+	genesis, err := b.fetchGenesisHash()
+	if err != nil {
+		log.Error().Err(err).Msgf("failed to fetch bitcoin genesis hash for upstream '%s'", b.upstreamId)
+		return validations.SettingsError
+	}
+	if strings.EqualFold(genesis, expected) {
+		return validations.Valid
+	}
+	log.Error().Msgf(
+		"'%s' expects genesis hash '%s' but bitcoin upstream '%s' reports '%s'",
+		b.chain.Chain.String(),
+		expected,
+		b.upstreamId,
+		genesis,
+	)
+	return validations.FatalSettingError
+}
+
+func (b *BitcoinChainValidator) fetchGenesisHash() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("getblockhash", []any{0}, b.chain.Chain)
+	if err != nil {
+		return "", err
+	}
+	response := b.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return "", response.GetError()
+	}
+	genesis := protocol.ResultAsString(response.ResponseResult())
+	if genesis == "" {
+		return "", errBitcoinEmptyGenesis
+	}
+	return genesis, nil
+}
+
+var _ validations.SettingsValidator = (*BitcoinChainValidator)(nil)

--- a/internal/upstreams/validations/bitcoin_validations/bitcoin_health_validator.go
+++ b/internal/upstreams/validations/bitcoin_validations/bitcoin_health_validator.go
@@ -1,0 +1,122 @@
+package bitcoin_validations
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	errBitcoinInitialBlockDownload = errors.New("bitcoin node is in initial block download")
+	errBitcoinNoPeers              = errors.New("bitcoin node has no peers")
+)
+
+type BitcoinHealthValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           *chains.ConfiguredChain
+	internalTimeout time.Duration
+	validatePeers   bool
+}
+
+func NewBitcoinHealthValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+	validatePeers bool,
+) *BitcoinHealthValidator {
+	return &BitcoinHealthValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+		validatePeers:   validatePeers,
+	}
+}
+
+func (b *BitcoinHealthValidator) Validate() protocol.AvailabilityStatus {
+	info, err := b.fetchBlockchainInfo()
+	if err != nil {
+		log.Error().Err(err).Msgf("bitcoin upstream '%s' health validation failed", b.upstreamId)
+		return protocol.Unavailable
+	}
+	if info.InitialBlockDownload {
+		log.Warn().Err(errBitcoinInitialBlockDownload).Msgf("bitcoin upstream '%s' is in initial block download", b.upstreamId)
+		return protocol.Syncing
+	}
+	syncingLag := b.chain.Settings.Lags.Syncing
+	if syncingLag > 0 && info.Headers >= info.Blocks && int64(info.Headers-info.Blocks) > syncingLag {
+		log.Warn().Msgf(
+			"bitcoin upstream '%s' is syncing, headers=%d blocks=%d",
+			b.upstreamId,
+			info.Headers,
+			info.Blocks,
+		)
+		return protocol.Syncing
+	}
+	if b.validatePeers {
+		peers, err := b.fetchConnectionCount()
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to fetch bitcoin connection count for upstream '%s'", b.upstreamId)
+			return protocol.Unavailable
+		}
+		if peers == 0 {
+			log.Error().Err(errBitcoinNoPeers).Msgf("bitcoin upstream '%s' has no peers", b.upstreamId)
+			return protocol.Unavailable
+		}
+	}
+	return protocol.Available
+}
+
+func (b *BitcoinHealthValidator) fetchBlockchainInfo() (*BitcoinBlockchainInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("getblockchaininfo", []any{}, b.chain.Chain)
+	if err != nil {
+		return nil, err
+	}
+	response := b.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	var info BitcoinBlockchainInfo
+	if err := sonic.Unmarshal(response.ResponseResult(), &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func (b *BitcoinHealthValidator) fetchConnectionCount() (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), b.internalTimeout)
+	defer cancel()
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("getconnectioncount", []any{}, b.chain.Chain)
+	if err != nil {
+		return 0, err
+	}
+	response := b.connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return 0, response.GetError()
+	}
+	return strconv.ParseUint(protocol.ResultAsString(response.ResponseResult()), 10, 64)
+}
+
+type BitcoinBlockchainInfo struct {
+	Blocks               uint64 `json:"blocks"`
+	Headers              uint64 `json:"headers"`
+	InitialBlockDownload bool   `json:"initialblockdownload"`
+	Pruned               bool   `json:"pruned"`
+	PruneHeight          uint64 `json:"pruneheight"`
+}
+
+var _ validations.HealthValidator = (*BitcoinHealthValidator)(nil)

--- a/internal/upstreams/validations/bitcoin_validations/bitcoin_validators_test.go
+++ b/internal/upstreams/validations/bitcoin_validations/bitcoin_validators_test.go
@@ -1,0 +1,125 @@
+package bitcoin_validations_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/bitcoin_validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	bitcoinGenesis  = `"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"`
+	dogecoinGenesis = `"1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"`
+)
+
+func isGetBlockHash(r protocol.RequestHolder) bool       { return r.Method() == "getblockhash" }
+func isGetBlockchainInfo(r protocol.RequestHolder) bool  { return r.Method() == "getblockchaininfo" }
+func isGetConnectionCount(r protocol.RequestHolder) bool { return r.Method() == "getconnectioncount" }
+
+func blockchainInfoBody(blocks, headers uint64, ibd bool) []byte {
+	return []byte(fmt.Sprintf(
+		`{"blocks":%d,"headers":%d,"initialblockdownload":%t,"pruned":false}`,
+		blocks, headers, ibd,
+	))
+}
+
+func TestBitcoinChainValidatorValidOnMatch(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockHash)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(bitcoinGenesis), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinChainValidator("id", conn, chains.GetChain("bitcoin"), time.Second)
+	assert.Equal(t, validations.Valid, v.Validate())
+}
+
+func TestBitcoinChainValidatorFatalOnMismatch(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	// a dogecoin node behind a config that says bitcoin
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockHash)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(dogecoinGenesis), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinChainValidator("id", conn, chains.GetChain("bitcoin"), time.Second)
+	assert.Equal(t, validations.FatalSettingError, v.Validate())
+}
+
+func TestBitcoinChainValidatorSkipsUnmappedChain(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	v := bitcoin_validations.NewBitcoinChainValidator("id", conn, chains.GetChain("litecoin"), time.Second)
+	assert.Equal(t, validations.Valid, v.Validate())
+	conn.AssertNotCalled(t, "SendRequest", mock.Anything, mock.Anything)
+}
+
+func TestBitcoinChainValidatorRetriesOnFetchError(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockHash)).
+		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "boom", nil)))
+	v := bitcoin_validations.NewBitcoinChainValidator("id", conn, chains.GetChain("bitcoin"), time.Second)
+	assert.Equal(t, validations.SettingsError, v.Validate())
+}
+
+func TestBitcoinHealthAvailable(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 100, false), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, false)
+	assert.Equal(t, protocol.Available, v.Validate())
+}
+
+func TestBitcoinHealthSyncingOnInitialBlockDownload(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 100, true), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, false)
+	assert.Equal(t, protocol.Syncing, v.Validate())
+}
+
+func TestBitcoinHealthSyncingOnHeadersLag(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	// bitcoin's syncing lag is 3; headers are 10 blocks ahead
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 110, false), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, false)
+	assert.Equal(t, protocol.Syncing, v.Validate())
+}
+
+func TestBitcoinHealthUnavailableOnZeroPeers(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 100, false), protocol.JsonRpc))
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetConnectionCount)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(`0`), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, true)
+	assert.Equal(t, protocol.Unavailable, v.Validate())
+}
+
+func TestBitcoinHealthAvailableWithPeers(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 100, false), protocol.JsonRpc))
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetConnectionCount)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", []byte(`8`), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, true)
+	assert.Equal(t, protocol.Available, v.Validate())
+}
+
+func TestBitcoinHealthIgnoresPeersWhenDisabled(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewSimpleHttpUpstreamResponse("1", blockchainInfoBody(100, 100, false), protocol.JsonRpc))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, false)
+	assert.Equal(t, protocol.Available, v.Validate())
+	conn.AssertNotCalled(t, "SendRequest", mock.Anything, mock.MatchedBy(isGetConnectionCount))
+}
+
+func TestBitcoinHealthUnavailableOnError(t *testing.T) {
+	conn := mocks.NewConnectorMock()
+	conn.On("SendRequest", mock.Anything, mock.MatchedBy(isGetBlockchainInfo)).
+		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(1, "boom", nil)))
+	v := bitcoin_validations.NewBitcoinHealthValidator("id", conn, chains.GetChain("bitcoin"), time.Second, false)
+	assert.Equal(t, protocol.Unavailable, v.Validate())
+}

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -355,6 +355,8 @@ func getMethodSpecName(blockchainType BlockchainType, methodSpecName string) str
 		return "eth-beacon-chain"
 	case Aptos:
 		return "aptos"
+	case Bitcoin:
+		return "bitcoin"
 	}
 
 	return ""

--- a/pkg/chains/chains_test.go
+++ b/pkg/chains/chains_test.go
@@ -44,6 +44,11 @@ func TestAptosBlockchainTypeIsValid(t *testing.T) {
 	assert.True(t, IsValidBlockchainType("aptos"))
 }
 
+func TestBitcoinAndDogecoinMethodSpecNameIsBitcoin(t *testing.T) {
+	assert.Equal(t, "bitcoin", GetMethodSpecNameByChain(BITCOIN))
+	assert.Equal(t, "bitcoin", GetMethodSpecNameByChain(DOGECOIN))
+}
+
 func TestGetChainByChainIdAndVersionScopesByType(t *testing.T) {
 	// Ethereum mainnet is registered with chain-id 0x1 / net-version 1.
 	eth := GetChainByChainIdAndVersion(Ethereum, "0x1", "1")

--- a/pkg/methods/methods_spec_test.go
+++ b/pkg/methods/methods_spec_test.go
@@ -245,6 +245,15 @@ func TestBitcoinSpecLoads(t *testing.T) {
 	spec = specs.GetSpecMethod("bitcoin", "eth_call")
 	assert.Nil(t, spec)
 
+	// listunspent is served via esplora, so it resolves only for upstreams with
+	// the rest-additional connector
+	jsonRpcMethods := specs.GetSpecMethodsByConnectors("bitcoin", []specs.ApiConnectorType{specs.JsonRpcConnector})
+	assert.NotContains(t, jsonRpcMethods[specs.DefaultMethodGroup], "listunspent")
+	assert.Contains(t, jsonRpcMethods[specs.DefaultMethodGroup], "getblocknumber")
+
+	restAdditionalMethods := specs.GetSpecMethodsByConnectors("bitcoin", []specs.ApiConnectorType{specs.RestAdditional})
+	assert.Contains(t, restAdditionalMethods[specs.DefaultMethodGroup], "listunspent")
+
 	template, params, ok := specs.MatchRestMethod("bitcoin", "GET#/address/bc1qxyz/utxo")
 	assert.True(t, ok)
 	assert.Equal(t, "GET#/address/*/utxo", template)

--- a/pkg/methods/methods_spec_test.go
+++ b/pkg/methods/methods_spec_test.go
@@ -229,6 +229,28 @@ func TestAptosSpecLoadsAndMatchesRestRoutes(t *testing.T) {
 	assert.Equal(t, []string{"12345"}, params)
 }
 
+func TestBitcoinSpecLoads(t *testing.T) {
+	err := specs.NewMethodSpecLoader().Load()
+	assert.NoError(t, err)
+
+	spec := specs.GetSpecMethod("bitcoin", "getblock")
+	assert.NotNil(t, spec)
+
+	spec = specs.GetSpecMethod("bitcoin", "sendrawtransaction")
+	assert.NotNil(t, spec)
+
+	spec = specs.GetSpecMethod("bitcoin", "listunspent")
+	assert.NotNil(t, spec)
+
+	spec = specs.GetSpecMethod("bitcoin", "eth_call")
+	assert.Nil(t, spec)
+
+	template, params, ok := specs.MatchRestMethod("bitcoin", "GET#/address/bc1qxyz/utxo")
+	assert.True(t, ok)
+	assert.Equal(t, "GET#/address/*/utxo", template)
+	assert.Equal(t, []string{"bc1qxyz"}, params)
+}
+
 func TestAptosSpecMatchesNestedAccountAndTableRoutes(t *testing.T) {
 	loader := specs.NewMethodSpecLoader()
 	err := loader.Load()

--- a/pkg/methods/specs/bitcoin-esplora.json
+++ b/pkg/methods/specs/bitcoin-esplora.json
@@ -1,0 +1,22 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Bitcoin esplora methods",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "bitcoin-esplora",
+    "api-connectors": ["rest-additional"],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "GET#/address/*/utxo",
+      "group": "additional",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
+  ]
+}

--- a/pkg/methods/specs/bitcoin-esplora.json
+++ b/pkg/methods/specs/bitcoin-esplora.json
@@ -17,6 +17,14 @@
       "settings": {
         "cacheable": false
       }
+    },
+    {
+      "name": "listunspent",
+      "group": "additional",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
     }
   ]
 }

--- a/pkg/methods/specs/bitcoin-json-rpc.json
+++ b/pkg/methods/specs/bitcoin-json-rpc.json
@@ -1,0 +1,139 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Bitcoin JSON-RPC methods",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "bitcoin-json-rpc",
+    "api-connectors": ["json-rpc"],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "getblock",
+      "params": []
+    },
+    {
+      "name": "gettransaction",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "gettxout",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getmemorypool",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getrawmempool",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getmempoolinfo",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getblockheader",
+      "params": []
+    },
+    {
+      "name": "getblockhash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getrawtransaction",
+      "params": []
+    },
+    {
+      "name": "estimatesmartfee",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getbestblockhash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getblocknumber",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getblockcount",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getreceivedbyaddress",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getblockchaininfo",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getconnectioncount",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "getnetworkinfo",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "sendrawtransaction",
+      "params": [],
+      "settings": {
+        "cacheable": false,
+        "dispatch": "broadcast"
+      }
+    },
+    {
+      "name": "listunspent",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
+  ]
+}

--- a/pkg/methods/specs/bitcoin-json-rpc.json
+++ b/pkg/methods/specs/bitcoin-json-rpc.json
@@ -127,13 +127,6 @@
         "cacheable": false,
         "dispatch": "broadcast"
       }
-    },
-    {
-      "name": "listunspent",
-      "params": [],
-      "settings": {
-        "cacheable": false
-      }
     }
   ]
 }

--- a/pkg/methods/specs/bitcoin.json
+++ b/pkg/methods/specs/bitcoin.json
@@ -1,0 +1,12 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Bitcoin methods",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "bitcoin",
+    "type": "bundle"
+  },
+  "spec-imports": ["bitcoin-json-rpc", "bitcoin-esplora"]
+}

--- a/pkg/test_utils/test_helpers.go
+++ b/pkg/test_utils/test_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/aptos_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/aztec_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/beacon_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/bitcoin_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/evm_specific"
 	specific "github.com/drpcorg/nodecore/internal/upstreams/chains_specific/solana_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
@@ -262,6 +263,16 @@ func NewBeaconChainSpecific(ctx context.Context, connector connectors.ApiConnect
 
 func NewAptosChainSpecific(ctx context.Context, connector connectors.ApiConnector) *aptos_specific.AptosChainSpecificObject {
 	return aptos_specific.NewAptosChainSpecificObject(ctx, chains.GetChain("aptos-mainnet"), "id", connector, newTestChainOptions())
+}
+
+func NewBitcoinChainSpecific(ctx context.Context, connector connectors.ApiConnector) *bitcoin_specific.BitcoinChainSpecificObject {
+	options := &chains.Options{
+		InternalTimeout:         5 * time.Second,
+		ValidationInterval:      10 * time.Second,
+		DisableChainValidation:  new(false),
+		DisableHealthValidation: new(false),
+	}
+	return bitcoin_specific.NewBitcoinChainSpecificObject(ctx, chains.GetChain("bitcoin-mainnet"), "id", connector, options)
 }
 
 func newTestChainOptions() *chains.Options {


### PR DESCRIPTION
## What

Adds first-class support for the Bitcoin blockchain family (`BlockchainType = "bitcoin"`), covering bitcoin and dogecoin (mainnet/testnet), so these chains can be served by nodecore instead of dshackle.

Design doc: `docs/superpowers/specs/2026-07-17-bitcoin-support-design.md`.

## How

- `bitcoin_specific` chain package: poll-based head tracking (`getbestblockhash` + `getblockheader`; bitcoind has no push head notifications), JSON-RPC 1.0 `error: null` envelope handling in `parseJsonRpcBody`.
- Genesis-hash chain validation (`getblockhash 0` keyed by chain — the only reliable bitcoin-vs-dogecoin discriminator), health validation (IBD / headers-blocks lag / optional peer count), client labels from `getnetworkinfo.subversion`, prune-aware lower bounds (`pruneheight` when pruned, else archive).
- Method spec bundle `bitcoin` (json-rpc + esplora specs) with the 19-method dshackle-parity surface.
- New generic `(spec, method)` translator registry in the flow layer: `getblocknumber` → `getblockcount` alias; `listunspent` → esplora `GET /address/{addr}/utxo` on a `rest-additional` connector with response reshaped to the bitcoind format (exact 8-decimal sats→BTC, confirmations from tracked head). Upstreams without esplora never advertise `listunspent`.

## Testing

- Unit tests across all new packages (validators incl. bitcoin/dogecoin genesis cross-check, labels, bounds, translator, spec loading).
- Live corpus against production bitcoin (mainnet + esplora) and dogecoin (mainnet/testnet) nodes: every spec method compared node-direct vs nodecore — 65/68 identical; the 3 diffs are nodecore's synthesized unknown-method -32601 text (standard for all families). Details in the design doc.