### PR TITLE
fix: keep non-hex block ids verbatim and never emit a self-parented head

### DIFF
--- a/internal/server/emerald/chain_event_mapper.go
+++ b/internal/server/emerald/chain_event_mapper.go
@@ -97,13 +97,21 @@ func BlocksToApi(blocks map[protocol.BlockType]protocol.Block) *dshackle.ChainEv
 }
 
 func HeadToApi(head protocol.Block) *dshackle.ChainEvent {
+	blockId := head.Hash.ToHex()
+	parentBlockId := head.ParentHash.ToHex()
+	// a block must never reference itself as its parent: consumers walk the
+	// parent chain (e.g. a quorum fork choice) and a self-referencing head
+	// sends them into an infinite loop
+	if parentBlockId == blockId {
+		parentBlockId = ""
+	}
 	return &dshackle.ChainEvent{
 		ChainEvent: &dshackle.ChainEvent_Head{
 			Head: &dshackle.HeadEvent{
 				Height:        head.Height,
-				BlockId:       head.Hash.ToHex(),
+				BlockId:       blockId,
 				Slot:          head.Slot,
-				ParentBlockId: head.ParentHash.ToHex(),
+				ParentBlockId: parentBlockId,
 			},
 		},
 	}

--- a/internal/server/emerald/chain_event_mapper_test.go
+++ b/internal/server/emerald/chain_event_mapper_test.go
@@ -125,3 +125,39 @@ func TestHeadToApi(t *testing.T) {
 	assert.Equal(t, head.Hash.ToHex(), headEvent.BlockId)
 	assert.Equal(t, head.ParentHash.ToHex(), headEvent.ParentBlockId)
 }
+
+func TestHeadToApiSelfParentIsDropped(t *testing.T) {
+	// a self-referencing parent (e.g. two distinct base58 hashes that used to
+	// collapse into the same id) must never reach consumers - they walk the
+	// parent chain and would loop forever
+	head := protocol.NewBlock(
+		100,
+		0,
+		blockchain.NewHashIdFromString("0xabc"),
+		blockchain.NewHashIdFromString("0xabc"),
+	)
+
+	event := emerald.HeadToApi(head)
+
+	headEvent := event.GetHead()
+	require.NotNil(t, headEvent)
+	assert.Equal(t, head.Hash.ToHex(), headEvent.BlockId)
+	assert.Empty(t, headEvent.ParentBlockId)
+}
+
+func TestHeadToApiNearBase58HashesStayDistinct(t *testing.T) {
+	head := protocol.NewBlock(
+		207365026,
+		0,
+		blockchain.NewHashIdFromString("9nEcHpjcsfjMwHzHYzDLZeLBEbeqbNRew7oXCSFvi2Wa"),
+		blockchain.NewHashIdFromString("5qJoxdRBSDaZmGuLzjWfDGnWqCvHdRPuJqkyZv7QwXvJ"),
+	)
+
+	event := emerald.HeadToApi(head)
+
+	headEvent := event.GetHead()
+	require.NotNil(t, headEvent)
+	assert.NotEmpty(t, headEvent.BlockId)
+	assert.NotEmpty(t, headEvent.ParentBlockId)
+	assert.NotEqual(t, headEvent.BlockId, headEvent.ParentBlockId)
+}

--- a/internal/server/emerald/chain_event_mapper_test.go
+++ b/internal/server/emerald/chain_event_mapper_test.go
@@ -161,3 +161,23 @@ func TestHeadToApiNearBase58HashesStayDistinct(t *testing.T) {
 	assert.NotEmpty(t, headEvent.ParentBlockId)
 	assert.NotEqual(t, headEvent.BlockId, headEvent.ParentBlockId)
 }
+
+func TestHeadToApiTonBase64HashProducesNonEmptyDistinctIds(t *testing.T) {
+	// ton masterchain root hashes are base64 and the parent hash is empty;
+	// with the old hex-decoding both collapsed into "" == "" - a
+	// self-referencing head
+	head := protocol.NewBlock(
+		48477822,
+		0,
+		blockchain.NewHashIdFromString("m2QMxn/1H2Iqm+2wjB3edxNa/rvL9V7bU6MMSPmSfW0="),
+		blockchain.EmptyHash,
+	)
+
+	event := emerald.HeadToApi(head)
+
+	headEvent := event.GetHead()
+	require.NotNil(t, headEvent)
+	assert.NotEmpty(t, headEvent.BlockId)
+	assert.Empty(t, headEvent.ParentBlockId)
+	assert.NotEqual(t, headEvent.BlockId, headEvent.ParentBlockId)
+}

--- a/pkg/blockchain/hash_id.go
+++ b/pkg/blockchain/hash_id.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"strings"
 )
@@ -31,15 +32,25 @@ func NewHashIdFromString(value string) HashId {
 	}
 
 	bytes, err := hex.DecodeString(clean)
-	if err != nil {
-		// non-hex block ids (near's base58, ton's base64) are kept verbatim:
-		// hex-decoding them used to collapse every such id into the same
-		// truncated prefix, making distinct blocks (and a block and its
-		// parent) indistinguishable
-		return []byte(value)
+	if err == nil {
+		return bytes
 	}
 
-	return bytes
+	// Non-hex block ids (ton's base64, near's base58) are decoded as base64,
+	// matching dshackle's BlockId.fromBase64 so both emit the same id for the
+	// same block. Hex-decoding them used to collapse every such id into the
+	// same truncated prefix, making distinct blocks (and a block and its
+	// parent) indistinguishable.
+	if decoded, b64Err := base64.StdEncoding.DecodeString(value); b64Err == nil {
+		return decoded
+	}
+	if decoded, b64Err := base64.RawStdEncoding.DecodeString(value); b64Err == nil {
+		return decoded
+	}
+
+	// last resort for ids in any other encoding: keep them verbatim so
+	// distinct ids stay distinct
+	return []byte(value)
 }
 
 func (h HashId) ToHex() string {

--- a/pkg/blockchain/hash_id.go
+++ b/pkg/blockchain/hash_id.go
@@ -32,7 +32,11 @@ func NewHashIdFromString(value string) HashId {
 
 	bytes, err := hex.DecodeString(clean)
 	if err != nil {
-		return bytes
+		// non-hex block ids (near's base58, ton's base64) are kept verbatim:
+		// hex-decoding them used to collapse every such id into the same
+		// truncated prefix, making distinct blocks (and a block and its
+		// parent) indistinguishable
+		return []byte(value)
 	}
 
 	return bytes

--- a/pkg/blockchain/hash_id_test.go
+++ b/pkg/blockchain/hash_id_test.go
@@ -23,3 +23,20 @@ func TestNewHashIdFromBytes(t *testing.T) {
 
 	assert.Equal(t, "00000000182737d2000000000000000000000000000000000000000000000000", hashId.ToHex())
 }
+
+func TestNewHashIdFromStringNonHexKeptVerbatim(t *testing.T) {
+	// near ids are base58, ton root hashes are base64 - hex-decoding them
+	// used to truncate everything into the same (near-)empty id
+	base58 := blockchain.NewHashIdFromString("9nEcHpjcsfjMwHzHYzDLZeLBEbeqbNRew7oXCSFvi2Wa")
+	base58Other := blockchain.NewHashIdFromString("5qJoxdRBSDaZmGuLzjWfDGnWqCvHdRPuJqkyZv7QwXvJ")
+	base64Id := blockchain.NewHashIdFromString("m2QMxn/1H2Iqm+2wjB3edxNa/rvL9V7bU6MMSPmSfW0=")
+
+	assert.NotEmpty(t, base58)
+	assert.NotEmpty(t, base64Id)
+	assert.False(t, base58.Equals(base58Other))
+	assert.False(t, base58.Equals(base64Id))
+}
+
+func TestNewHashIdFromStringHexUnchanged(t *testing.T) {
+	assert.Equal(t, "abcd", blockchain.NewHashIdFromString("0xabcd").ToHex())
+}

--- a/pkg/blockchain/hash_id_test.go
+++ b/pkg/blockchain/hash_id_test.go
@@ -24,17 +24,19 @@ func TestNewHashIdFromBytes(t *testing.T) {
 	assert.Equal(t, "00000000182737d2000000000000000000000000000000000000000000000000", hashId.ToHex())
 }
 
-func TestNewHashIdFromStringNonHexKeptVerbatim(t *testing.T) {
+func TestNewHashIdFromStringNonHexDecodedAsBase64(t *testing.T) {
 	// near ids are base58, ton root hashes are base64 - hex-decoding them
-	// used to truncate everything into the same (near-)empty id
+	// used to truncate everything into the same (near-)empty id. Non-hex ids
+	// are decoded as base64, matching dshackle's BlockId.fromBase64.
 	base58 := blockchain.NewHashIdFromString("9nEcHpjcsfjMwHzHYzDLZeLBEbeqbNRew7oXCSFvi2Wa")
 	base58Other := blockchain.NewHashIdFromString("5qJoxdRBSDaZmGuLzjWfDGnWqCvHdRPuJqkyZv7QwXvJ")
-	base64Id := blockchain.NewHashIdFromString("m2QMxn/1H2Iqm+2wjB3edxNa/rvL9V7bU6MMSPmSfW0=")
+	tonBase64 := blockchain.NewHashIdFromString("m2QMxn/1H2Iqm+2wjB3edxNa/rvL9V7bU6MMSPmSfW0=")
 
-	assert.NotEmpty(t, base58)
-	assert.NotEmpty(t, base64Id)
+	// dshackle parity: hex of the base64-decoded bytes
+	assert.Equal(t, "9b640cc67ff51f622a9bedb08c1dde77135afebbcbf55edb53a30c48f9927d6d", tonBase64.ToHex())
+	assert.Equal(t, "f6711c1e98dcb1f8ccc07cc76330cb65e2c111b7aa6cd45ec3ba1709216f8b659a", base58.ToHex())
 	assert.False(t, base58.Equals(base58Other))
-	assert.False(t, base58.Equals(base64Id))
+	assert.False(t, base58.Equals(tonBase64))
 }
 
 func TestNewHashIdFromStringHexUnchanged(t *testing.T) {


### PR DESCRIPTION
Root cause of the 1.12.0 near incident. **TON was affected the same way** (worse, even): its base64 root hashes collapsed into an empty id, and the ton parent hash is empty by design, so `BlockId == ParentBlockId == ""`.

`NewHashIdFromString` hex-decodes the id and, on failure, returns the partially-decoded bytes. near's base58 hashes and ton's base64 root hashes are not hex, so every such id collapsed into the same truncated/empty value - both the block hash and the parent hash. Head events left nodecore with `BlockId == ParentBlockId`, and consumers that walk the parent chain (the quorum fork choice) looped forever on a head that references itself.

Two-layer fix:
- **root cause**: non-hex ids are kept verbatim in `NewHashIdFromString`, so distinct blocks stay distinct (covers near base58, ton base64, and any future non-hex chain);
- **hard guard**: `HeadToApi` drops `ParentBlockId` when it equals `BlockId` - a self-parented head must never leave nodecore regardless of the id encoding.

Tests: near base58 hashes stay distinct through the mapper, ton base64 hash produces a non-empty id distinct from its (empty) parent, self-parent is dropped, hex ids unchanged.