### PR TITLE
chore: switch runtime image to distroless, pin base digests and strip binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /app
 
 # Install build dependencies
@@ -23,23 +23,17 @@ ARG GIT_SHA=
 # platform. This avoids slow QEMU-emulated Go builds for multi-arch images.
 RUN go run cmd/chains/init_chains.go && \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} \
-    go build -ldflags "-X github.com/drpcorg/nodecore/internal/buildinfo.Version=${VERSION} -X github.com/drpcorg/nodecore/internal/buildinfo.GitSHA=${GIT_SHA}" \
+    go build -trimpath -ldflags "-s -w -X github.com/drpcorg/nodecore/internal/buildinfo.Version=${VERSION} -X github.com/drpcorg/nodecore/internal/buildinfo.GitSHA=${GIT_SHA}" \
     -o /app/nodecore cmd/nodecore/main.go
 
 # Final stage
-FROM alpine:3.24
-RUN apk --no-cache add ca-certificates tzdata
+# distroless/static ships CA certificates, tzdata and a built-in nonroot user (uid 65532)
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:f5b485ea962d9bd1186b2f6b3a061191539b905b82ec395de78cbfae51f20e35
 WORKDIR /app
 
 # Copy binary from builder stage
 COPY --from=builder /app/nodecore .
 COPY nodecore-default.yml nodecore.yml
 
-# Create non-root user
-RUN addgroup -g 1001 -S nodecore && \
-    adduser -S nodecore -u 1001 -G nodecore
-
-USER nodecore
-
 EXPOSE 8080
-CMD ["./nodecore"]
+CMD ["/app/nodecore"]


### PR DESCRIPTION
## What

- Switch the final stage from `alpine:3.24` to `gcr.io/distroless/static-debian12:nonroot`, following the pattern used by other popular golang projects
- Pin both base images (builder and runtime) to their multi-arch index digests for reproducible, tamper-evident builds
- Add `-trimpath` and `-ldflags "-s -w"` to the release build to strip debug info and build-machine paths

## Why

The binary is built with `CGO_ENABLED=0`, so it is fully static and never uses the base image's libc — benchmarks of the hot JSON-RPC parsing/streaming paths (`internal/protocol`, `internal/server/emerald`) across alpine, distroless, debian-slim and ubuntu bases showed no statistically significant runtime difference (benchstat, 9 samples per base). The base image choice is therefore about size and attack surface, not performance:

- **Smaller attack surface**: distroless has no shell, no package manager and no busybox, which eliminates most CVE-scanner findings on the runtime image — relevant for infrastructure that users self-host
- **Smaller image**: 71.6 MB → 45.5 MB (−36%), with the stripped binary going from 59 MB to 41 MB
- **Simpler final stage**: distroless/static already ships CA certificates, tzdata and a built-in `nonroot` user (uid 65532), so the `apk add` and `addgroup`/`adduser` steps are removed entirely
- **No path leakage**: without `-trimpath`, log caller fields exposed the build machine's filesystem paths (e.g. `../Users/<user>/Documents/projects/...`); they now show module paths (`github.com/drpcorg/nodecore/internal/...`)

Stripping has no runtime cost: Go always keeps its internal function/line table, so panic stack traces, `runtime.Caller` (zerolog caller field) and pprof/Pyroscope profiling all keep working. The only loss is attaching Delve/GDB to the shipped binary, which distroless precludes anyway; local `make build` stays unstripped for debugging.

## Verification

- Full `docker build` succeeds; container starts as uid 65532, all three HTTP servers come up and the metrics port responds
- Outbound HTTPS to upstreams verified: `drpc-eth` head poller runs with zero x509/certificate errors (confirms the distroless CA bundle works)
- Log caller paths confirmed to show module paths instead of local build paths

## Notes

- With digest pinning, CA bundle and base image updates only arrive via digest bumps (handled by the repo's existing Dependabot config)
- `docker exec <container> sh` no longer works by design; use `kubectl debug` ephemeral containers when a shell next to the process is needed