### PR TITLE
Cosmos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ nodecore is **API/protocol-agnostic**: it is not tied to a single RPC shape. It 
 
 ### Supported chains, methods & interfaces
 
-- **Interfaces** — `json-rpc` (over HTTP), `websocket`, and `rest` upstream connectors. The set available for a given chain is declared by that chain's [method spec](docs/nodecore/11-method-specs.md).
-- **Chains** — every chain defined in [`chains.yaml`](https://github.com/drpcorg/public/blob/main/chains.yaml). Current chain families are EVM (Ethereum, Polygon, Optimism, Arbitrum, Base, BSC, and many others), Solana, Algorand, Aztec, Aptos, Bitcoin (bitcoin, dogecoin), NEAR, Starknet, TON (v2 HTTP API + v3 indexer), and the Ethereum/Gnosis Beacon Chain (consensus layer, REST-only).
+- **Interfaces** — `json-rpc` (over HTTP), `websocket`, `rest`, and `tendermint` upstream connectors. The set available for a given chain is declared by that chain's [method spec](docs/nodecore/11-method-specs.md).
+- **Chains** — every chain defined in [`chains.yaml`](https://github.com/drpcorg/public/blob/main/chains.yaml). Current chain families are EVM (Ethereum, Polygon, Optimism, Arbitrum, Base, BSC, and many others), Solana, Algorand, Aztec, Aptos, Bitcoin (bitcoin, dogecoin), NEAR, Starknet, TON (v2 HTTP API + v3 indexer), Cosmos SDK (CometBFT RPC + LCD REST), and the Ethereum/Gnosis Beacon Chain (consensus layer, REST-only).
 - **Methods** — per-chain RPC behavior is data-driven via [method specs](docs/nodecore/11-method-specs.md), covering standard EVM/Solana methods, subscriptions, and EVM filter methods. Methods unsupported by an upstream are automatically banned for it to avoid wasted requests.
 
 ## Key features
 
 - **Intelligent routing** — dynamically selects the most suitable upstream based on real-time performance metrics (latency, error rate, availability) for optimal speed, reliability, and fault-tolerance. See [Upstream config](docs/nodecore/05-upstream-config.md).
-- **API/protocol-agnostic** — JSON-RPC, WebSocket, and REST interfaces across EVM, Solana, Algorand, Aztec, Aptos, Bitcoin, NEAR, Starknet, TON, and the Ethereum/Gnosis Beacon Chain, all driven by data-defined [method specs](docs/nodecore/11-method-specs.md). EVM filter methods (`eth_newFilter`, `eth_getFilterLogs`, etc.) are routed only to the upstream where the filter was created.
+- **API/protocol-agnostic** — JSON-RPC, WebSocket, and REST interfaces across EVM, Solana, Algorand, Aztec, Aptos, Bitcoin, NEAR, Starknet, TON, Cosmos SDK, and the Ethereum/Gnosis Beacon Chain, all driven by data-defined [method specs](docs/nodecore/11-method-specs.md). Cosmos chains are reachable over both shapes of the CometBFT RPC (JSON-RPC and URI calls) plus the LCD REST API. EVM filter methods (`eth_newFilter`, `eth_getFilterLogs`, etc.) are routed only to the upstream where the filter was created.
 - **Subscriptions** — WebSocket subscriptions are aggregated so many identical client subscriptions share one upstream stream, with optional local synthesis of EVM topics (`newHeads`, `logs`, pending transactions). See [Subscriptions](docs/nodecore/13-subscriptions.md).
 - **Caching** — minimizes redundant traffic by caching frequent requests across in-memory/Redis/Postgres backends with configurable policies. See [Cache](docs/nodecore/04-cache.md).
 - **Failsafe mechanisms** — request hedging (duplicate slow requests to multiple upstreams) and configurable automatic retries. See [Upstream config](docs/nodecore/05-upstream-config.md).

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -592,7 +592,7 @@ Each upstream can expose multiple interfaces for communication. A blockchain net
 Supported connector types:
 
 - `json-rpc` - HTTP-based JSON-RPC. Available on every chain family
-- `tendermint` - the Tendermint/CometBFT consensus RPC (port `26657` by convention) used by every Cosmos SDK chain. This is the one connector that speaks **two wire shapes at once**: CometBFT serves the same method set as JSON-RPC on `POST /` and as URI calls on `GET /<method>?<args>`, so a client may reach `status` either as `{"method":"status"}` or as `GET /status` and nodecore forwards the request in whichever shape it arrived. See [Cosmos deployment](#cosmos-deployment)
+- `tendermint` - the Tendermint/CometBFT consensus RPC (port `26657` by convention) used by every Cosmos SDK chain. This is the one connector that speaks **two wire shapes at once**: CometBFT serves the same method set as JSON-RPC on `POST /` and as URI calls on `GET /<method>?<args>`, so a client may reach `status` either as `{"method":"status"}` or as `GET /status` and nodecore forwards the request in whichever shape it arrived.
 - `websocket` - WebSocket-based JSON-RPC. Required for subscriptions and certain streaming requests (e.g. `eth_subscribe`)
 - `rest` - REST endpoints. Used by chains whose canonical API is REST-shaped (e.g. Algorand, TRON, Aptos, Cosmos SDK chains, and the Ethereum/Gnosis Beacon Chain). TRON additionally exposes an Ethereum-compatible `json-rpc` surface; you can configure either or both connectors on a TRON upstream — `rest` reaches `/wallet/*` (full node) and `/walletsolidity/*` (confirmed mirror), `json-rpc` reaches `/jsonrpc`. Aptos upstreams use `rest` exclusively, serving the fullnode `/v1/*` API. On Cosmos SDK chains `rest` is the LCD / gRPC-gateway API (port `1317` by convention, `/cosmos/*`, `/cosmwasm/*`, `/ibc/*`)
 - `grpc` - gRPC endpoints (declared by spec on a per-chain basis)
@@ -643,46 +643,6 @@ upstreams:
       - type: rest-indexer
         url: http://ton-index:8082
 ```
-
-### Cosmos deployment
-
-A Cosmos SDK node serves two APIs out of one process: the **Tendermint/CometBFT consensus RPC** (`26657`, connector type `tendermint`) and the **LCD** (`1317`, connector type `rest`). Unlike TON's two APIs, these are not independent systems — they read the same store, so they share a head and a retention window. Configuring both connectors on one upstream is therefore the normal deployment, not a degraded one, and nodecore emits no warning for it.
-
-When both are present, the `tendermint` connector drives head tracking, health, chain validation, labels and lower bounds, because a single `status` call answers all of them:
-
-| Signal | `tendermint` | `rest` (LCD) |
-| --- | --- | --- |
-| Head / finalized block | `block` | `GET /cosmos/base/tendermint/v1beta1/blocks/latest` |
-| Sync state | `status` → `sync_info.catching_up` | `GET /cosmos/base/tendermint/v1beta1/syncing` |
-| Peers | `net_info` → `n_peers` (only when `validate-peers` is on; often firewalled off on hosted endpoints) | not exposed |
-| Chain validation | `status` → `node_info.network` | `node_info` → `default_node_info.network` |
-| `client_version` label | CometBFT version | SDK app version (e.g. gaia's) |
-| Lower bound | `status` → `sync_info.earliest_block_height`, one call | binary search over `blocks/{height}` |
-
-A committed CometBFT block is final, so the finalized block always equals the head, and there is no "safe" block concept — safe-block detection is disabled for cosmos upstreams. Head tracking is poll-only: CometBFT's `/websocket` subscriptions are not used.
-
-Block ids agree across the two connectors even though the encodings differ (CometBFT renders hashes as uppercase hex, the LCD as base64) — nodecore decodes both to the same bytes, so a `tendermint`-driven and a `rest`-driven upstream of the same chain report the same head hash.
-
-```yaml
-# Normal deployment: both APIs of one node on one upstream
-upstreams:
-  - id: cosmos-hub-node
-    chain: cosmos-hub
-    connectors:
-      - type: tendermint
-        url: http://cosmos-node:26657
-      - type: rest
-        url: http://cosmos-node:1317
-
-# LCD-only upstream (e.g. a provider that exposes 1317 but not 26657)
-  - id: cosmos-hub-lcd
-    chain: cosmos-hub
-    connectors:
-      - type: rest
-        url: https://cosmos-rest.example.com
-```
-
-Each upstream only advertises the methods its connector types carry, so a `tendermint` method sent to an LCD-only upstream (or vice versa) is rejected with `-32601` rather than being misrouted.
 
 ### Tor .onion upstreams
 
@@ -799,4 +759,3 @@ Cosmos upstreams have no standalone liveness probe: the syncing and peers
 validators *are* the health validators, so `disable-health-validation` turns
 both off regardless of `validate-syncing` / `validate-peers`. Which pair runs
 depends on the connector driving the upstream — see
-[Cosmos deployment](#cosmos-deployment) for how that connector is chosen.

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -338,8 +338,8 @@ The `chain-defaults` section defines per-chain baseline settings. `<chain>.optio
   * `disable-health-validation` - Disables only the health validators (per chain family). **_Default_**: `false`
   * `disable-lower-bounds-detection` - Disables the earliest-available-block detector. Mode-dependent default: `true` in `default` mode, `false` in `strict` mode
   * `disable-labels-detection` - Disables the EVM label detectors (client/version, archive, gas, flashblock, etc.). Mode-dependent default: `true` in `default` mode, `false` in `strict` mode
-  * `validate-syncing` - For EVM chains, calls `eth_syncing` periodically and marks the upstream unavailable when it is syncing. For beacon-chain upstreams it probes `GET /eth/v1/node/syncing` instead (marking the upstream `Syncing`, or `Unavailable` when its execution layer is offline). Bitcoin-family upstreams probe `getblockchaininfo` (`initialblockdownload`, plus a headers-vs-blocks lag threshold). For NEAR upstreams the `status` probe's `sync_info.syncing` and a stale-head guard on `latest_block_time` drive the same signal (always on as part of health validation). Starknet upstreams probe `starknet_syncing` (a plain `false` or a sync object, judged with a lag threshold). TON upstream health uses `getMasterchainInfo` liveness (v2) and `masterchainInfo` `gen_utime` freshness (v3). Mode-dependent default: `false` in `default` mode, `true` in `strict` mode
-  * `validate-peers` - For EVM chains, calls `net_peerCount` periodically and pairs with `min-peers`. For beacon-chain upstreams it probes `GET /eth/v1/node/peer_count`. Bitcoin-family upstreams call `getconnectioncount`. NEAR upstreams probe `network_info` `num_active_peers`. Starknet has no peer probe (nodes sync from the feeder gateway, not p2p), so `validate-peers` has no effect there; likewise for TON upstreams. Mode-dependent default: `false` in `default` mode, `true` in `strict` mode
+  * `validate-syncing` - For EVM chains, calls `eth_syncing` periodically and marks the upstream unavailable when it is syncing. For beacon-chain upstreams it probes `GET /eth/v1/node/syncing` instead (marking the upstream `Syncing`, or `Unavailable` when its execution layer is offline). Bitcoin-family upstreams probe `getblockchaininfo` (`initialblockdownload`, plus a headers-vs-blocks lag threshold). For NEAR upstreams the `status` probe's `sync_info.syncing` and a stale-head guard on `latest_block_time` drive the same signal (always on as part of health validation). Starknet upstreams probe `starknet_syncing` (a plain `false` or a sync object, judged with a lag threshold). TON upstream health uses `getMasterchainInfo` liveness (v2) and `masterchainInfo` `gen_utime` freshness (v3). Cosmos upstreams read the node's own flag — `status` → `sync_info.catching_up` over the `tendermint` connector, `GET /cosmos/base/tendermint/v1beta1/syncing` over the LCD. Mode-dependent default: `false` in `default` mode, `true` in `strict` mode
+  * `validate-peers` - For EVM chains, calls `net_peerCount` periodically and pairs with `min-peers`. For beacon-chain upstreams it probes `GET /eth/v1/node/peer_count`. Bitcoin-family upstreams call `getconnectioncount`. NEAR upstreams probe `network_info` `num_active_peers`. Starknet has no peer probe (nodes sync from the feeder gateway, not p2p), so `validate-peers` has no effect there; likewise for TON upstreams. Cosmos upstreams probe `net_info` → `n_peers` over the `tendermint` connector only — the LCD exposes no peer count, so a `rest`-driven cosmos upstream ignores this flag too. Mode-dependent default: `false` in `default` mode, `true` in `strict` mode
   * `min-peers` - Minimum acceptable peer count when `validate-peers` is on. **_Default_**: `1`
   * `validate-call-limit` - For EVM chains, periodically probes the upstream's `eth_call` return-data limit and marks the upstream unhealthy when its observed limit is below `call-limit-size`. Mode-dependent default: `false` in `default` mode, `true` in `strict` mode
   * `call-limit-size` - Threshold (in bytes) of the smallest acceptable `eth_call` return-data limit. **_Default_**: `1000000` (1 MB)
@@ -592,11 +592,12 @@ Each upstream can expose multiple interfaces for communication. A blockchain net
 Supported connector types:
 
 - `json-rpc` - HTTP-based JSON-RPC. Available on every chain family
+- `tendermint` - the Tendermint/CometBFT consensus RPC (port `26657` by convention) used by every Cosmos SDK chain. This is the one connector that speaks **two wire shapes at once**: CometBFT serves the same method set as JSON-RPC on `POST /` and as URI calls on `GET /<method>?<args>`, so a client may reach `status` either as `{"method":"status"}` or as `GET /status` and nodecore forwards the request in whichever shape it arrived. See [Cosmos deployment](#cosmos-deployment)
 - `websocket` - WebSocket-based JSON-RPC. Required for subscriptions and certain streaming requests (e.g. `eth_subscribe`)
-- `rest` - REST endpoints. Used by chains whose canonical API is REST-shaped (e.g. Algorand, TRON, Aptos, and the Ethereum/Gnosis Beacon Chain). TRON additionally exposes an Ethereum-compatible `json-rpc` surface; you can configure either or both connectors on a TRON upstream — `rest` reaches `/wallet/*` (full node) and `/walletsolidity/*` (confirmed mirror), `json-rpc` reaches `/jsonrpc`. Aptos upstreams use `rest` exclusively, serving the fullnode `/v1/*` API
+- `rest` - REST endpoints. Used by chains whose canonical API is REST-shaped (e.g. Algorand, TRON, Aptos, Cosmos SDK chains, and the Ethereum/Gnosis Beacon Chain). TRON additionally exposes an Ethereum-compatible `json-rpc` surface; you can configure either or both connectors on a TRON upstream — `rest` reaches `/wallet/*` (full node) and `/walletsolidity/*` (confirmed mirror), `json-rpc` reaches `/jsonrpc`. Aptos upstreams use `rest` exclusively, serving the fullnode `/v1/*` API. On Cosmos SDK chains `rest` is the LCD / gRPC-gateway API (port `1317` by convention, `/cosmos/*`, `/cosmwasm/*`, `/ibc/*`)
 - `grpc` - gRPC endpoints (declared by spec on a per-chain basis)
 - `rest-indexer` - a **self-contained indexer REST API** running next to the node API (e.g. the TON v3 indexer). This is a plain type: it may be an upstream's only connector (a standalone indexer upstream with its own head/health/bounds) or sit alongside the node-API connector on one upstream; see [TON deployment modes](#ton-deployment-modes)
-- `rest-additional` - REST endpoints that augment a chain whose primary transport is something else (e.g. Hyperliquid). This is an *additional* connector: it cannot work standalone at all - an upstream cannot consist of only `rest-additional` connectors, at least one plain connector (`json-rpc` / `rest` / `grpc` / `websocket` / `rest-indexer`) must also be configured
+- `rest-additional` - REST endpoints that augment a chain whose primary transport is something else (e.g. Hyperliquid). This is an *additional* connector: it cannot work standalone at all - an upstream cannot consist of only `rest-additional` connectors, at least one plain connector (`json-rpc` / `tendermint` / `rest` / `grpc` / `websocket` / `rest-indexer`) must also be configured
 
 By defining multiple connectors under one upstream, you give nodecore the flexibility to select the right transport for each incoming request.
 
@@ -604,8 +605,8 @@ Every upstream must also track its head (latest block / finalization state). The
 
 - If `head-connector` is set explicitly, that type is used
 - Otherwise nodecore picks the best connector available on the upstream, where "best" depends on [`mode`](#mode):
-  - `mode: default` - prefers the simplest type, in order `json-rpc` → `rest` → `grpc` → `websocket`
-  - `mode: strict` - prefers the most capable type, in reverse order `websocket` → `grpc` → `rest` → `json-rpc`
+  - `mode: default` - prefers the simplest type, in order `json-rpc` → `tendermint` → `rest` → `grpc` → `websocket`
+  - `mode: strict` - prefers the most capable type, in reverse order `websocket` → `grpc` → `rest` → `tendermint` → `json-rpc`
 
 `rest-additional` connectors are never chosen as the head connector.
 
@@ -643,6 +644,46 @@ upstreams:
         url: http://ton-index:8082
 ```
 
+### Cosmos deployment
+
+A Cosmos SDK node serves two APIs out of one process: the **Tendermint/CometBFT consensus RPC** (`26657`, connector type `tendermint`) and the **LCD** (`1317`, connector type `rest`). Unlike TON's two APIs, these are not independent systems — they read the same store, so they share a head and a retention window. Configuring both connectors on one upstream is therefore the normal deployment, not a degraded one, and nodecore emits no warning for it.
+
+When both are present, the `tendermint` connector drives head tracking, health, chain validation, labels and lower bounds, because a single `status` call answers all of them:
+
+| Signal | `tendermint` | `rest` (LCD) |
+| --- | --- | --- |
+| Head / finalized block | `block` | `GET /cosmos/base/tendermint/v1beta1/blocks/latest` |
+| Sync state | `status` → `sync_info.catching_up` | `GET /cosmos/base/tendermint/v1beta1/syncing` |
+| Peers | `net_info` → `n_peers` (only when `validate-peers` is on; often firewalled off on hosted endpoints) | not exposed |
+| Chain validation | `status` → `node_info.network` | `node_info` → `default_node_info.network` |
+| `client_version` label | CometBFT version | SDK app version (e.g. gaia's) |
+| Lower bound | `status` → `sync_info.earliest_block_height`, one call | binary search over `blocks/{height}` |
+
+A committed CometBFT block is final, so the finalized block always equals the head, and there is no "safe" block concept — safe-block detection is disabled for cosmos upstreams. Head tracking is poll-only: CometBFT's `/websocket` subscriptions are not used.
+
+Block ids agree across the two connectors even though the encodings differ (CometBFT renders hashes as uppercase hex, the LCD as base64) — nodecore decodes both to the same bytes, so a `tendermint`-driven and a `rest`-driven upstream of the same chain report the same head hash.
+
+```yaml
+# Normal deployment: both APIs of one node on one upstream
+upstreams:
+  - id: cosmos-hub-node
+    chain: cosmos-hub
+    connectors:
+      - type: tendermint
+        url: http://cosmos-node:26657
+      - type: rest
+        url: http://cosmos-node:1317
+
+# LCD-only upstream (e.g. a provider that exposes 1317 but not 26657)
+  - id: cosmos-hub-lcd
+    chain: cosmos-hub
+    connectors:
+      - type: rest
+        url: https://cosmos-rest.example.com
+```
+
+Each upstream only advertises the methods its connector types carry, so a `tendermint` method sent to an LCD-only upstream (or vice versa) is rejected with `-32601` rather than being misrouted.
+
 ### Tor .onion upstreams
 
 NodeCore supports connecting to upstreams hosted as Tor hidden services (`.onion` addresses) for both `json-rpc` and `websocket` connectors. This provides enhanced privacy and censorship resistance.
@@ -678,7 +719,7 @@ When NodeCore detects a `.onion` hostname, it automatically routes the connectio
 - `id` - Unique identifier of the upstream. **_Required_**, **_Unique_**
 - `chain` - The chain this upstream serves (e.g. `ethereum`, `polygon`, `solana`, `algorand`, `aztec-mainnet`, `aptos-mainnet`). Must match values from [chains.yaml](https://github.com/drpcorg/public/blob/main/chains.yaml). **_Required_**
 - `connectors` - The access endpoints for this upstream. **_Required_**, **_at least one_**. There can be only one connector of each type per upstream, and at least one connector must be a plain type (not `rest-additional`). Each connector has:
-  - `type` - one of `json-rpc`, `websocket`, `rest`, `grpc`, `rest-additional`. **_Required_**
+  - `type` - one of `json-rpc`, `tendermint`, `websocket`, `rest`, `grpc`, `rest-indexer`, `rest-additional`. **_Required_**
   - `url` - full endpoint URL. **_Required_**
   - `headers` - optional key/value map of extra headers to send with requests
   - `ca` - Path to a Certificate Authority (CA) certificate file to validate client certificates (for example, if you use self-signed certificates)
@@ -715,6 +756,8 @@ Validators and label detectors run periodically (every `validation-interval`) ag
 | NEAR chain validator | NEAR | `disable-chain-validation`, `disable-settings-validation`, `disable-validation` | Equivalent of chain-id check, comparing the `status` probe's `chain_id` against the configured chain |
 | Starknet chain validator | Starknet | `disable-chain-validation`, `disable-settings-validation`, `disable-validation` | Equivalent of chain-id check, comparing the `starknet_chainId` hex-felt against the configured chain |
 | TON chain validator | TON | `disable-chain-validation`, `disable-settings-validation`, `disable-validation` | v2: checks the network zerostate hashes from `getMasterchainInfo` `result.init`; v3: checks `masterchainInfo` `last.global_id`. In combined mode the primary connector's validator runs |
+| Tendermint chain validator | Cosmos (`tendermint`) | `disable-chain-validation`, `disable-settings-validation`, `disable-validation` | Equivalent of chain-id check, comparing `status` → `node_info.network` against the configured chain-id (`cosmoshub-4`, `osmosis-1`, …) case-insensitively. Cosmos chain-ids are opaque strings, not numbers. Strict: **any** non-match is fatal, including an empty `network` — an upstream that answers but cannot say which chain it serves is refused at startup |
+| Cosmos chain validator | Cosmos (`rest`) | `disable-chain-validation`, `disable-settings-validation`, `disable-validation` | The same check over the LCD: `GET /cosmos/base/tendermint/v1beta1/node_info` → `default_node_info.network` |
 | `eth_syncing` validator | EVM | `validate-syncing` (set to `false`) or `disable-settings-validation` | Marks the upstream as syncing/unavailable when the node reports it is not fully synced |
 | `net_peerCount` validator | EVM | `validate-peers` / `min-peers` or `disable-settings-validation` | Marks the upstream as unhealthy when peer count drops below `min-peers` |
 | `eth_call` return-data limit | EVM | `validate-call-limit` or `disable-settings-validation` | Probes the upstream's maximum `eth_call` return-data size and marks it unhealthy if it is below `call-limit-size` |
@@ -730,11 +773,16 @@ Validators and label detectors run periodically (every `validation-interval`) ag
 | Health validator (NEAR) | NEAR | `disable-health-validation` | Calls the NEAR `status` RPC; marks the upstream `Syncing` when `sync_info.syncing` is true or `latest_block_time` is stale (stale-head guard). With `validate-peers` on, also probes `network_info` and marks the upstream `Unavailable` at zero `num_active_peers` |
 | Health validator (Starknet) | Starknet | `disable-health-validation` | Calls `starknet_syncing`: a plain `false` is healthy, a sync object marks the upstream `Syncing` when the current-to-highest block lag exceeds the threshold. `validate-peers` has no effect (no p2p peer count — nodes sync from the feeder gateway) |
 | Health validator (TON) | TON | `disable-health-validation` | v2: `getMasterchainInfo` liveness; v3: `masterchainInfo` `gen_utime` freshness (a stale masterchain head marks the upstream `Syncing`). In combined mode the primary connector's validator runs; `validate-peers` has no effect |
+| Syncing validator (Tendermint) | Cosmos (`tendermint`) | `validate-syncing` (set to `false`) or `disable-health-validation` | Reads the node's own opinion — `status` → `sync_info.catching_up` — and marks the upstream `Syncing` while it is fast-syncing or state-syncing. No block-time arithmetic involved |
+| Peers validator (Tendermint) | Cosmos (`tendermint`) | `validate-peers` / `min-peers` or `disable-health-validation` | Reads `net_info` → `n_peers` (rendered as a decimal *string* by CometBFT) and marks the upstream immature below `min-peers`. `net_info` is frequently firewalled off on hosted endpoints, which is why this stays off unless you enable it |
+| Syncing validator (Cosmos LCD) | Cosmos (`rest`) | `validate-syncing` (set to `false`) or `disable-health-validation` | Probes `GET /cosmos/base/tendermint/v1beta1/syncing` — the same signal as `catching_up`, exposed by the LCD as its own endpoint. The LCD publishes no peer count, so `validate-peers` has no effect on a `rest`-driven cosmos upstream |
 | Lower-bound detector | Solana, Algorand, Aztec, Aptos | `disable-lower-bounds-detection` | Determines the earliest available block / slot on the upstream so that queries against pruned ranges can be routed away |
 | Lower-bound detector (Beacon) | Beacon Chain | `disable-lower-bounds-detection` | Binary-searches the earliest retained block, state, epoch (attestation rewards), and blob-sidecar slots so requests against pruned ranges are routed away |
 | Lower-bound detector (Bitcoin) | Bitcoin | `disable-lower-bounds-detection` | Publishes `pruneheight` as the block/transaction lower bound when `getblockchaininfo.pruned` is true, and `1` (archive) otherwise |
 | Lower-bound detector (NEAR) | NEAR | `disable-lower-bounds-detection` | Reads `sync_info.earliest_block_height` from `status` and publishes it as the state and block lower bounds (a sliding GC window on non-archival nodes) |
 | Lower-bound detector (Starknet) | Starknet | `disable-lower-bounds-detection` | Verified probe of block 1: success publishes `1` as the lower bound, failure emits an explicit `UnknownBound` |
+| Lower-bound detector (Tendermint) | Cosmos (`tendermint`) | `disable-lower-bounds-detection` | Reads `status` → `sync_info.earliest_block_height` and publishes it as the state lower bound. One call, no search — CometBFT tells you the oldest height it still holds. Reported verbatim, `0` included |
+| Lower-bound detector (Cosmos LCD) | Cosmos (`rest`) | `disable-lower-bounds-detection` | The LCD has no `earliest_block_height` equivalent, so the bound is binary-searched over `GET /cosmos/base/tendermint/v1beta1/blocks/{height}` (a pruned height answers 4xx). Steady state costs a single probe per cycle, because the previously found bound is re-confirmed before any search |
 | Label detectors (EVM) | EVM | `disable-labels-detection` | Populates upstream labels - client name & version, archive vs. full, gas limit, flashblock support, high-latency-tx capability. Labels are exposed via the [gRPC API](12-grpc-server.md) so external consumers can target upstreams with specific capabilities |
 | Label detectors (Aptos) | Aptos | `disable-labels-detection` | Populates client name & version labels from the ledger-info endpoint (`GET /v1`) |
 | Client label detector (Beacon) | Beacon Chain | `disable-labels-detection` | Reads `GET /eth/v1/node/version` and publishes the consensus-client type and version labels (Lighthouse, Prysm, Teku, Nimbus, etc.) |
@@ -742,5 +790,13 @@ Validators and label detectors run periodically (every `validation-interval`) ag
 | Client label detector (NEAR) | NEAR | `disable-labels-detection` | Reads `version.version` from `status` and publishes the client (`neard`) and version labels |
 | Client label detector (Starknet) | Starknet | `disable-labels-detection` | Two-step probe: `pathfinder_version` first, then `juno_version`; the one that answers sets the client and version labels |
 | Client label detector (TON) | TON | `disable-labels-detection` | v2: reads title/version from `GET /openapi.json`; v3: reads `GET /doc.json` and publishes `ton-index-go` with its version |
+| Client label detector (Tendermint) | Cosmos (`tendermint`) | `disable-labels-detection` | Publishes `client_type=cosmos` and the **CometBFT** version from `status` → `node_info.version` |
+| Client label detector (Cosmos LCD) | Cosmos (`rest`) | `disable-labels-detection` | Publishes `client_type=cosmos` and the **SDK application** version from `node_info` → `application_version.version` (e.g. gaia's `v21.0.0`), falling back to the CometBFT version when a trimmed LCD omits it. The two connectors therefore report different `client_version` values for the same node — app version vs. consensus-engine version |
 
 `disable-validation` is the master switch and overrides every per-validator flag.
+
+Cosmos upstreams have no standalone liveness probe: the syncing and peers
+validators *are* the health validators, so `disable-health-validation` turns
+both off regardless of `validate-syncing` / `validate-peers`. Which pair runs
+depends on the connector driving the upstream — see
+[Cosmos deployment](#cosmos-deployment) for how that connector is chosen.

--- a/docs/nodecore/05-upstream-config.md
+++ b/docs/nodecore/05-upstream-config.md
@@ -754,8 +754,3 @@ Validators and label detectors run periodically (every `validation-interval`) ag
 | Client label detector (Cosmos LCD) | Cosmos (`rest`) | `disable-labels-detection` | Publishes `client_type=cosmos` and the **SDK application** version from `node_info` → `application_version.version` (e.g. gaia's `v21.0.0`), falling back to the CometBFT version when a trimmed LCD omits it. The two connectors therefore report different `client_version` values for the same node — app version vs. consensus-engine version |
 
 `disable-validation` is the master switch and overrides every per-validator flag.
-
-Cosmos upstreams have no standalone liveness probe: the syncing and peers
-validators *are* the health validators, so `disable-health-validation` turns
-both off regardless of `validate-syncing` / `validate-peers`. Which pair runs
-depends on the connector driving the upstream — see

--- a/docs/nodecore/11-method-specs.md
+++ b/docs/nodecore/11-method-specs.md
@@ -44,7 +44,7 @@ Each file declares one *named spec*. The spec name (`spec.name`) is what `chains
 - `type` (string, required) — either `plain` or `bundle`:
   - `plain` — a spec that contributes its own `methods` and declares its own `api-connectors`.
   - `bundle` — a spec that imports one or more other specs via `spec-imports` and exposes the union. A bundle must not declare `api-connectors` or `methods` of its own.
-- `api-connectors` (array of strings) — which transports this spec applies to. Allowed values: `json-rpc`, `rest`, `grpc`, `websocket`, `rest-additional`. **Required on plain specs**, **forbidden on bundle specs**.
+- `api-connectors` (array of strings) — which transports this spec applies to. Allowed values: `json-rpc`, `tendermint`, `rest`, `grpc`, `websocket`, `rest-indexer`, `rest-additional`. **Required on plain specs**, **forbidden on bundle specs**.
 
   > **⚠️ Order is significant.** nodecore iterates `api-connectors` in the order written and selects the connector for each method in that order. List the transports from preferred to least preferred for the methods in this spec — the first entry is what nodecore will try first when more than one of these connectors is configured on an upstream.
 
@@ -127,13 +127,61 @@ Example (Hyperliquid):
     "type": "plain"
   },
   "methods": [
-    { "name": "POST#/info",     "settings": { "cacheable": false } },
-    { "name": "POST#/exchange", "settings": { "cacheable": false } }
+    {
+      "name": "POST#/info",
+      "group": "additional",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/exchange",
+      "group": "additional",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
   ]
 }
 ```
 
 `rest-additional` is reserved for specs that augment an upstream whose primary transport is something else. An upstream cannot consist of only `rest-additional` connectors (see [Upstream config](05-upstream-config.md#connectors)).
+
+## Dual-shape methods: the `tendermint` connector
+
+The Tendermint/CometBFT RPC serves one method set over two wire shapes on the same port: JSON-RPC on `POST /` and URI calls on `GET /<method>?<args>`. The connector picks its shape from the incoming request, so **each tendermint method is declared twice in the spec** — once under its JSON-RPC name and once as a `GET#/...` route:
+
+```json
+{
+  "spec": {
+    "name": "cosmos-tendermint",
+    "api-connectors": ["tendermint"],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "status",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/status",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
+  ]
+}
+```
+
+Both entries resolve to the same `tendermint` connector: the plain name via exact JSON-RPC method lookup, the `GET#/...` name via the REST path matcher. Adding a tendermint method means adding both entries — otherwise it is reachable over only one of the two shapes.
+
+Every cosmos method is declared `cacheable: false`, for two independent reasons: the LCD selects historical state with the `x-cosmos-block-height` **header**, which is deliberately excluded from the REST cache key, and CometBFT's `height` argument is optional (an omitted height means *latest*), which no tag parser currently detects.
 
 ## Bundle example
 
@@ -175,6 +223,7 @@ nodecore embeds the specs below (see [`pkg/methods/specs/`](../../pkg/methods/sp
 | `near` | `near-json-rpc` |
 | `starknet` | `starknet-json-rpc` |
 | `ton` | `ton-http-v2`, `ton-index-v3` |
+| `cosmos` | `cosmos-tendermint`, `cosmos-rest` |
 
 ### Plain specs
 
@@ -185,7 +234,8 @@ Grouped by the transports they declare:
 | `json-rpc`, `websocket` | `arbitrum`, `cronos_zkevm`, `eth-json-rpc`, `fantom`, `filecoin`, `harmony_0`, `harmony_1`, `hyperliquid-eth`, `klaytn-json-rpc`, `linea`, `mantle`, `optimism`, `polygon`, `polygon_zkevm`, `rootstock`, `scroll`, `sei`, `solana-json-rpc`, `viction`, `zk` |
 | `json-rpc` | `algorand`, `aztec`, `bitcoin-json-rpc`, `near-json-rpc`, `starknet-json-rpc`, `tron-json-rpc` |
 | `websocket` | `eth-websocket`, `klaytn-websocket`, `solana-websocket` |
-| `rest` | `aptos`, `eth-beacon-chain`, `ton-http-v2`, `tron-rest` |
+| `tendermint` | `cosmos-tendermint` |
+| `rest` | `aptos`, `cosmos-rest`, `eth-beacon-chain`, `ton-http-v2`, `tron-rest` |
 | `rest-indexer` | `ton-index-v3` |
 | `rest-additional` | `bitcoin-esplora`, `hyperliquid-rest-additional`, `tron-rest-solidity` |
 

--- a/docs/superpowers/specs/2026-07-27-cosmos-support-design.md
+++ b/docs/superpowers/specs/2026-07-27-cosmos-support-design.md
@@ -1,0 +1,246 @@
+# Cosmos family support — design
+
+Date: 2026-07-27
+Status: implemented — see [Deltas from the original design](#deltas-from-the-original-design)
+for the points where the shipped code differs from the plan below.
+
+## Goal
+
+Add first-class support for the **Cosmos SDK** blockchain family to nodecore
+(`BlockchainType = "cosmos"`), covering all 12 `type: cosmos` protocols already
+registered in `chains.yaml` (cosmos-hub, axelar, osmosis, neutron, babylon,
+agoric, coreum, fetchai, provenance, initia, injective, mantra — 19 networks
+including testnets).
+
+Before this change, a `type: cosmos` upstream **panicked at startup**:
+`getChainSpecific` had no `chains.Cosmos` case, and `getMethodSpecName` had no
+`Cosmos` case, so those chains resolved to the empty method spec.
+
+dshackle supports cosmos over the Tendermint JSON-RPC only
+(`BlockchainType.COSMOS → ApiType.JSON_RPC`, 24 methods in
+`DefaultCosmosMethods`). nodecore covers all three surfaces a Cosmos node
+actually exposes.
+
+## Scope
+
+- **In scope:** three client-facing surfaces —
+  1. Tendermint/CometBFT RPC as **JSON-RPC** (`POST /`, port 26657),
+  2. the same Tendermint methods as **URI calls** (`GET /<method>?<args>`),
+  3. the Cosmos SDK **LCD** REST API (port 1317).
+
+  A new `tendermint` connector type serving (1) and (2) from one connector; a
+  `cosmos-tendermint` + `cosmos-rest` + `cosmos` bundle spec set; a
+  `tendermint_specific` package (reusable by any CometBFT chain) and a
+  `cosmos_specific` complex specific that dispatches on the primary connector.
+
+- **Out of scope (YAGNI):**
+  - **Caching** — everything ships `cacheable: false`; see Cacheability.
+  - **CometBFT `/websocket` subscriptions** — head tracking is poll-only, as
+    in dshackle (which leaves its `tm.event='NewBlockHeader'` subscription
+    commented out).
+  - **Chain-specific LCD modules** — `osmosis/*`, `injective/*`,
+    interchain-security are not declared.
+  - **`type: eth` cosmos-EVM chains** (cronos, evmos, haqq, kava, zeta-chain,
+    dymension, sei, okt, xrpl, tac, mezo — see `cosmos-nodes.md`). Attaching
+    `tendermint` / `rest` connectors to those is a separate change with a much
+    larger blast radius (it touches the EVM specific and the `eth` spec's
+    connector set).
+
+## Approach
+
+### The `tendermint` connector: one connector, two wire shapes
+
+CometBFT serves an identical method set as JSON-RPC on `POST /` and as URI
+calls on `GET /<method>?<args>`, both answering with the same
+`{"jsonrpc":..,"result":..}` envelope. So the wire shape is a property of the
+*request*, not of the connector — `HttpConnector.SendRequest` forwards a
+tendermint request in whichever shape it arrived:
+
+```go
+case specs.TendermintConnector:
+    if request.RequestType() == protocol.JsonRpc {
+        return h.sendJsonRpc(ctx, request)
+    }
+    return h.sendRest(ctx, request)
+```
+
+Nothing else in the connector changes: `sendRest` already builds
+`GET /status` out of the `GET#/status` template, and `sendJsonRpc` already
+POSTs the body verbatim to the endpoint root.
+
+`TendermintConnector` is inserted between `JsonRpcConnector` and
+`RestConnector` in the `ApiConnectorType` iota. The order is load-bearing:
+`GetBestConnector(DefaultMode)` takes the minimum, and on an upstream carrying
+both cosmos APIs the tendermint one must win the head/internal-request role.
+The enum values are never serialized, so inserting mid-enum is safe.
+
+### Specs: two entries per tendermint method
+
+Rather than teaching the framework to alias one method entry to two
+transports, each tendermint method is declared twice — `status` and
+`GET#/status`. This needs **zero framework change**: `buildRestMatcher`
+already keys REST routing off the `#` in a method name, and JSON-RPC
+resolution is exact-name. Each form then carries its own name into the
+connector, so no cross-mapping is needed anywhere.
+
+Specs:
+- `cosmos-tendermint` (plain, `api-connectors: ["tendermint"]`) — 28 methods ×
+  2 shapes = 56 entries. That is dshackle's 24 (`DefaultCosmosMethods`), plus
+  `header` / `header_by_hash` (CometBFT ≥ 0.35, which dshackle's list predates),
+  plus `dump_consensus_state` / `consensus_state` declared with
+  `"enabled": false` — dshackle marks the latter two "not safe", and declaring
+  them disabled documents the decision while still letting an operator opt in
+  via `methods.enable`. The four `broadcast_*` methods sit in a `broadcast`
+  group so transaction submission can be toggled as a set.
+- `cosmos-rest` (plain, `api-connectors: ["rest"]`) — 175 routes: every
+  standard SDK module plus CosmWasm and IBC.
+
+No method in either spec declares a `dispatch` policy. dshackle gives the
+broadcast methods `BroadcastQuorum`, but fan-out for cosmos is deferred, so
+`broadcast_*` and `POST /cosmos/tx/v1beta1/txs` route like any other method for
+now.
+- `cosmos` (bundle) — imports both. The two specs share no method names, and
+  tendermint URI paths live at the root (`/status`, `/block`) while LCD routes
+  are namespaced (`/cosmos/*`, `/cosmwasm/*`, `/ibc/*`), so there is no
+  collision in the shared path matcher.
+
+### Cacheability: nothing, deliberately
+
+Every cosmos method is `cacheable: false`, for two independent reasons:
+
+1. The LCD selects historical state with the **`x-cosmos-block-height`
+   header**, and `calculateRestHash` deliberately excludes headers from the
+   cache key — a cached balance would be served to a request asking for a
+   different height.
+2. CometBFT's `height` argument is **optional** (omitted means *latest*), and
+   there is no tag parser to detect that, so caching `block` would pin a stale
+   head. Note that `isHexNumberOrTag` accepts only `0x…` or an EVM block tag,
+   so it rejects the decimal heights CometBFT and the LCD use. Only six specs
+   ship a tag parser at all — `eth-json-rpc`, `arbitrum`, `fantom`, `harmony1`,
+   `klaytn-json-rpc`, `tron-json-rpc` — and every one belongs to a `type: eth`
+   chain. No non-EVM chain family declares one, and cosmos follows that
+   precedent.
+
+Unlocking caching later needs a decimal-height `ParserReturnType` (with a
+`.height // "latest"` jq path so an omitted height reads as a block tag) and
+`x-cosmos-block-height` folded into the REST cache key. Both touch shared
+`pkg/methods` / `protocol` code used by every chain, so they are out of this
+diff.
+
+### Specifics
+
+`tendermint_specific.TendermintChainSpecific` lives in its own package because
+the CometBFT consensus API is shared by every Cosmos SDK chain *and* by non-SDK
+CometBFT chains (BeaconKit, Heimdall), independently of whether an LCD sits
+next to it. All its internal probes go out as **JSON-RPC** so the shared
+`parseJsonRpcBody` path unwraps CometBFT's `result` envelope and surfaces its
+errors.
+
+`cosmos_specific.NewCosmosSpecific` is the complex specific, dispatching on the
+primary connector exactly like `NewTronSpecific`: `tendermint` →
+`TendermintChainSpecific`, `rest` → `CosmosRestSpecific`, anything else →
+error.
+
+Per-signal sources:
+
+| Signal | tendermint | rest (LCD) |
+| --- | --- | --- |
+| Head | `block` (no height ⇒ latest) | `blocks/latest` |
+| Finalized | = head (CometBFT commits are final) | = head |
+| Safe | n/a — safe detection disabled | n/a |
+| Syncing | `status` → `sync_info.catching_up` | `GET /…/syncing` |
+| Peers | `net_info` → `n_peers` (string!) | not exposed |
+| Chain validation | `status` → `node_info.network` | `default_node_info.network` |
+| Lower bound | `status` → `earliest_block_height`, one call | binary search over `blocks/{height}` via the shared `LowerBoundSearchCalculator` |
+| Labels | `client_type=cosmos`, CometBFT version | `client_type=cosmos`, SDK app version |
+
+Health validators improve on dshackle, which only calls `health` and ignores
+the payload: the syncing validator reads the node's own `catching_up` flag.
+Both health validators are gated on `ValidateSyncing` / `ValidatePeers`, which
+default to false in `default` mode and true in `strict` — relevant because
+`net_info` is frequently firewalled off on hosted endpoints.
+
+Chain validation is strict: anything other than a case-insensitive match
+against the configured chain-id is a `FatalSettingError`, including an empty
+`network`. An upstream that answers the probe but cannot say which chain it
+serves is refused at startup rather than retried — settings validation runs
+synchronously before an upstream is allowed to start.
+
+The tendermint lower bound is reported verbatim, `0` included; only a height
+that isn't a decimal number is an error. Both detectors claim `StateBound`
+only — the earliest retained height says nothing about which of tx / receipts /
+logs an upstream can serve.
+
+### Hash encodings agree across connectors
+
+CometBFT renders block hashes as uppercase hex, the LCD as base64.
+`blockchain.NewHashIdFromString` tries hex first, then base64 — and a 32-byte
+base64 hash is 44 chars ending in `=`, which cannot hex-decode — so both
+encodings reduce to the same bytes. A tendermint-driven and an LCD-driven
+upstream of the same chain therefore report identical head hashes. This is
+covered by an explicit test.
+
+### No combined-connector warning
+
+TON logs a warning when both its connectors are on one upstream, because its
+two APIs have independent data windows and failure modes. Cosmos is the
+opposite: 26657 and 1317 are served by the same process over the same store, so
+they share a head and a retention window. Both connectors on one upstream is
+the *normal* deployment and gets no warning.
+
+## Deltas from the original design
+
+Decided during implementation, after the plan above was approved:
+
+- **No `dispatch: "broadcast"` anywhere.** The plan gave the four tendermint
+  `broadcast_*` methods and the LCD `POST /cosmos/tx/v1beta1/txs` a broadcast
+  fan-out policy, matching dshackle. Dropped for now; the `broadcast` group
+  remains so the methods can still be toggled as a set.
+- **Unknown network is fatal, not retryable.** The plan had an empty
+  `network` / `default_node_info.network` return `SettingsError` on the theory
+  that a blank field means a failed read (a gateway's 200 error envelope)
+  rather than a wrong chain. The shipped validators treat any non-match as
+  `FatalSettingError`. Consequence: such an upstream is refused at startup
+  instead of recovering on the next validation tick.
+- **A zero lower bound is published, not rejected.** The plan errored on
+  `earliest_block_height: "0"`. The shipped detector reports whatever the node
+  says. Consequence: a node that reports 0 is advertised as serving from
+  genesis; the codebase's usual "we don't know" signal is `UnknownBound`, which
+  this path no longer emits.
+- **Both bound detectors claim `StateBound` only.** The plan had them also
+  claim `UnknownBound`.
+- **Spec JSON is expanded, one field per line**, matching `eth-json-rpc.json`
+  and `ton-http-v2.json` rather than the compact `aptos.json` style.
+- **`specific_helpers` was extracted after the fact.** The plan parked the
+  shared DTOs and fetch helpers in the `*_validations` packages (the aptos
+  precedent); they were moved out once it was clear four different subtrees
+  call them.
+
+## Files
+
+- `pkg/methods/specs/{cosmos-tendermint,cosmos-rest,cosmos}.json`
+- `pkg/methods/data.go` — `TendermintConnector`
+- `pkg/chains/chains.go` — `case Cosmos: return "cosmos"`
+- `internal/upstreams/connectors/http_connector.go` — request-shape dispatch
+- `internal/upstreams/upstream_factory.go` — connector + specific wiring
+- `internal/upstreams/blocks/head_processor.go` — tendermint polls its head
+- `internal/upstreams/chains_specific/tendermint_specific/`
+- `internal/upstreams/chains_specific/cosmos_specific/`
+- `internal/upstreams/chains_specific/specific_helpers/` — the shared request /
+  response plumbing: LCD route templates, the wire DTOs both families
+  unmarshal into, and the fetch/parse helpers around them. It has its own
+  package because the specifics, validators, label detectors and lower-bound
+  detectors all call it; a `validations` package should hold validators, not
+  transport helpers for three other packages. RPC method names are *not* kept
+  here as constants — they are passed as literals at the call site.
+- `internal/upstreams/validations/{tendermint,cosmos}_validations/`
+- `internal/upstreams/labels/{tendermint,cosmos}_labels/`
+- `internal/upstreams/lower_bounds/{tendermint,cosmos}_bounds/`
+- `internal/config/configs/upstreams/cosmos-{tendermint-and-rest,tendermint-only}.yaml`
+  — fixtures for the connector-preference and head-connector tests
+- tests: `pkg/methods/cosmos_spec_test.go`, `pkg/chains/cosmos_chains_test.go`,
+  `internal/config/cosmos_upstream_config_test.go`,
+  `internal/upstreams/connectors/tendermint_connector_test.go`, plus one test
+  file per specific
+- docs: `05-upstream-config.md` (connector type + Cosmos deployment),
+  `11-method-specs.md` (dual-shape convention + spec tables), `README.md`

--- a/internal/config/configs/upstreams/cosmos-tendermint-and-rest.yaml
+++ b/internal/config/configs/upstreams/cosmos-tendermint-and-rest.yaml
@@ -1,0 +1,9 @@
+upstream-config:
+  upstreams:
+    - id: cosmos-upstream
+      chain: cosmos-hub
+      connectors:
+        - type: rest
+          url: https://cosmos-rest.publicnode.com
+        - type: tendermint
+          url: https://cosmos-rpc.publicnode.com

--- a/internal/config/configs/upstreams/cosmos-tendermint-only.yaml
+++ b/internal/config/configs/upstreams/cosmos-tendermint-only.yaml
@@ -1,0 +1,8 @@
+upstream-config:
+  upstreams:
+    - id: cosmos-upstream
+      chain: cosmos-hub
+      head-connector: tendermint
+      connectors:
+        - type: tendermint
+          url: https://cosmos-rpc.publicnode.com

--- a/internal/config/cosmos_upstream_config_test.go
+++ b/internal/config/cosmos_upstream_config_test.go
@@ -1,0 +1,56 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/config"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A cosmos node serves two APIs from one process - the CometBFT RPC on 26657
+// and the SDK LCD on 1317 - so both connectors on one upstream is the normal
+// deployment, and the tendermint one must win the head/internal-request role:
+// it answers head, sync state, network id, version and earliest retained
+// height from a single `status` call.
+func TestCosmosUpstreamPrefersTendermintForHead(t *testing.T) {
+	t.Setenv(config.ConfigPathVar, "configs/upstreams/cosmos-tendermint-and-rest.yaml")
+	appConfig, err := config.NewAppConfig()
+	require.NoError(t, err)
+
+	require.Len(t, appConfig.UpstreamConfig.Upstreams, 1)
+	upstream := appConfig.UpstreamConfig.Upstreams[0]
+
+	assert.Equal(t, specs.TendermintConnector.String(), upstream.HeadConnector)
+	assert.Equal(t, specs.TendermintConnector, upstream.GetBestConnector(config.DefaultMode))
+	assert.ElementsMatch(t,
+		[]specs.ApiConnectorType{specs.TendermintConnector, specs.RestConnector},
+		upstream.GetApiConnectorTypes(),
+	)
+}
+
+func TestGetBestConnectorWithTendermint(t *testing.T) {
+	upstream := &config.Upstream{
+		Connectors: []*config.ApiConnectorConfig{
+			{Type: specs.RestConnector.String()},
+			{Type: specs.TendermintConnector.String()},
+		},
+	}
+
+	assert.Equal(t, specs.TendermintConnector, upstream.GetBestConnector(config.DefaultMode))
+	assert.Equal(t, specs.RestConnector, upstream.GetBestConnector(config.StrictMode))
+}
+
+func TestTendermintIsValidHeadConnector(t *testing.T) {
+	t.Setenv(config.ConfigPathVar, "configs/upstreams/cosmos-tendermint-only.yaml")
+	appConfig, err := config.NewAppConfig()
+	require.NoError(t, err)
+
+	require.Len(t, appConfig.UpstreamConfig.Upstreams, 1)
+	upstream := appConfig.UpstreamConfig.Upstreams[0]
+
+	assert.Equal(t, specs.TendermintConnector.String(), upstream.HeadConnector)
+	require.Len(t, upstream.Connectors, 1)
+	assert.Equal(t, specs.TendermintConnector, upstream.Connectors[0].GetApiConnectorType())
+}

--- a/internal/upstreams/blocks/head_processor.go
+++ b/internal/upstreams/blocks/head_processor.go
@@ -135,7 +135,7 @@ func createHead(
 	options *chains.Options,
 ) Head {
 	switch headConnector.GetType() {
-	case specs.JsonRpcConnector, specs.RestConnector, specs.RestIndexer:
+	case specs.JsonRpcConnector, specs.TendermintConnector, specs.RestConnector, specs.RestIndexer:
 		return NewRpcHead(ctx, id, options.InternalTimeout, pollInterval, specific)
 	case specs.WebsocketConnector:
 		return NewSubHead(ctx, id, options.InternalTimeout, headConnector, specific)

--- a/internal/upstreams/chains_specific/cosmos_specific/cosmos_chain_specific.go
+++ b/internal/upstreams/chains_specific/cosmos_specific/cosmos_chain_specific.go
@@ -1,0 +1,42 @@
+package cosmos_specific
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/tendermint_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+)
+
+// NewCosmosSpecific picks the flavor from the primary (internal-request)
+// connector. A cosmos node exposes two independent APIs - the CometBFT RPC on
+// 26657 and the SDK LCD on 1317 - and either one can carry the full set of
+// probes nodecore needs, so an upstream may be configured with one or both.
+func NewCosmosSpecific(
+	ctx context.Context,
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	pollInterval time.Duration,
+	options *chains.Options,
+) (chains_specific.ChainSpecific, error) {
+	if connector == nil {
+		return nil, errors.New("no connector specified")
+	}
+	switch connector.GetType() {
+	case specs.TendermintConnector:
+		return tendermint_specific.NewTendermintSpecific(ctx, upstreamId, connector, chain, pollInterval, options)
+	case specs.RestConnector:
+		return newCosmosRestSpecific(ctx, upstreamId, connector, chain, pollInterval, options)
+	default:
+		return nil, fmt.Errorf(
+			"cosmos specific supports only tendermint or rest connector but not %s",
+			connector.GetType(),
+		)
+	}
+}

--- a/internal/upstreams/chains_specific/cosmos_specific/cosmos_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/cosmos_specific/cosmos_chain_specific_test.go
@@ -1,0 +1,378 @@
+package cosmos_specific_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/cosmos_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/tendermint_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/cosmos_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/cosmos_validations"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func matchCosmosRest(methodTemplate string, pathParams ...string) func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		if req.Method() != methodTemplate || req.RequestType() != protocol.Rest {
+			return false
+		}
+		restReq, ok := req.(*protocol.UpstreamRestRequest)
+		if !ok {
+			return false
+		}
+		var got []string
+		if params := restReq.RequestParams(); params != nil {
+			got = params.PathParams
+		}
+		if len(got) != len(pathParams) {
+			return false
+		}
+		for i := range got {
+			if got[i] != pathParams[i] {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func cosmosOK(body string) protocol.ResponseHolder {
+	return protocol.NewSimpleHttpUpstreamResponse("1", []byte(body), protocol.Rest)
+}
+
+func cosmosErr(code int, message string) protocol.ResponseHolder {
+	return protocol.NewHttpUpstreamResponse("1", []byte(fmt.Sprintf(`{"code":3,"message":%q}`, message)), code, protocol.Rest)
+}
+
+// cosmosBlockJSON renders the LCD block envelope: decimal string heights,
+// base64 hashes.
+func cosmosBlockJSON(height uint64, hash, parentHash string) string {
+	return fmt.Sprintf(
+		`{"block_id":{"hash":"%s"},"block":{"header":{"height":"%d","time":"2026-07-27T10:00:00Z","last_block_id":{"hash":"%s"}}}}`,
+		hash, height, parentHash,
+	)
+}
+
+func cosmosNodeInfoJSON(network, cometVersion, appVersion string) string {
+	return fmt.Sprintf(
+		`{"default_node_info":{"network":"%s","version":"%s"},"application_version":{"name":"gaia","version":"%s"}}`,
+		network, cometVersion, appVersion,
+	)
+}
+
+func cosmosOptions(validateSyncing bool) *chains.Options {
+	return &chains.Options{
+		InternalTimeout:        time.Second,
+		ValidationInterval:     time.Second,
+		MinPeers:               1,
+		ValidatePeers:          new(false),
+		ValidateSyncing:        new(validateSyncing),
+		DisableChainValidation: new(false),
+	}
+}
+
+func freshCosmosRest(t *testing.T, connector *mocks.ConnectorMock, opts *chains.Options) *cosmos_specific.CosmosRestSpecific {
+	t.Helper()
+	if opts == nil {
+		opts = cosmosOptions(false)
+	}
+	cs, err := cosmos_specific.NewCosmosSpecific(
+		context.Background(),
+		"upstream-id",
+		connector,
+		chains.GetChain("cosmos-hub"),
+		100*time.Millisecond,
+		opts,
+	)
+	require.NoError(t, err)
+	restSpecific, ok := cs.(*cosmos_specific.CosmosRestSpecific)
+	require.True(t, ok)
+	return restSpecific
+}
+
+// ---------- dispatch ----------
+
+func TestNewCosmosSpecificDispatchesOnConnectorType(t *testing.T) {
+	chain := chains.GetChain("cosmos-hub")
+
+	tendermintCs, err := cosmos_specific.NewCosmosSpecific(
+		context.Background(), "id",
+		mocks.NewConnectorMockWithType(specs.TendermintConnector),
+		chain, time.Second, cosmosOptions(false),
+	)
+	require.NoError(t, err)
+	assert.IsType(t, &tendermint_specific.TendermintChainSpecific{}, tendermintCs)
+
+	restCs, err := cosmos_specific.NewCosmosSpecific(
+		context.Background(), "id",
+		mocks.NewConnectorMockWithType(specs.RestConnector),
+		chain, time.Second, cosmosOptions(false),
+	)
+	require.NoError(t, err)
+	assert.IsType(t, &cosmos_specific.CosmosRestSpecific{}, restCs)
+}
+
+func TestNewCosmosSpecificUnsupportedConnector(t *testing.T) {
+	for _, connectorType := range []specs.ApiConnectorType{
+		specs.WebsocketConnector, specs.JsonRpcConnector, specs.RestIndexer,
+	} {
+		cs, err := cosmos_specific.NewCosmosSpecific(
+			context.Background(), "id",
+			mocks.NewConnectorMockWithType(connectorType),
+			chains.GetChain("cosmos-hub"), time.Second, cosmosOptions(false),
+		)
+		assert.Nil(t, cs)
+		assert.ErrorContains(t, err, "cosmos specific supports only tendermint or rest connector")
+	}
+}
+
+func TestNewCosmosSpecificNilConnector(t *testing.T) {
+	cs, err := cosmos_specific.NewCosmosSpecific(
+		context.Background(), "id", nil,
+		chains.GetChain("cosmos-hub"), time.Second, cosmosOptions(false),
+	)
+	assert.Nil(t, cs)
+	assert.ErrorContains(t, err, "no connector")
+}
+
+// ---------- head / blocks ----------
+
+func TestCosmosRestGetLatestBlock(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchCosmosRest(specific_helpers.CosmosLatestBlockRoute))).
+		Return(cosmosOK(cosmosBlockJSON(25000000, base64Hash("aa"), base64Hash("bb")))).
+		Once()
+
+	cs := freshCosmosRest(t, connector, nil)
+	block, err := cs.GetLatestBlock(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25000000), block.Height)
+	connector.AssertExpectations(t)
+}
+
+// The two connectors report the same block hash in different encodings -
+// uppercase hex over the CometBFT RPC, base64 over the LCD. Both must reduce
+// to the same HashId, otherwise two upstreams of one chain would appear to
+// disagree about the head.
+func TestCosmosHashEncodingsAgreeAcrossConnectors(t *testing.T) {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = byte(i * 7)
+	}
+	hexHash := strings.ToUpper(hex.EncodeToString(raw))
+	base64Hash := base64.StdEncoding.EncodeToString(raw)
+	require.NotEqual(t, hexHash, base64Hash)
+
+	tendermintConnector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	tendermintSpecific, err := tendermint_specific.NewTendermintSpecific(
+		context.Background(), "id", tendermintConnector,
+		chains.GetChain("cosmos-hub"), time.Second, cosmosOptions(false),
+	)
+	require.NoError(t, err)
+
+	fromRpc, err := tendermintSpecific.ParseBlock([]byte(cosmosBlockJSON(100, hexHash, hexHash)))
+	require.NoError(t, err)
+	fromLcd, err := freshCosmosRest(t, mocks.NewConnectorMockWithType(specs.RestConnector), nil).
+		ParseBlock([]byte(cosmosBlockJSON(100, base64Hash, base64Hash)))
+	require.NoError(t, err)
+
+	assert.Equal(t, fromRpc.Hash, fromLcd.Hash)
+	assert.Equal(t, blockchain.NewHashIdFromBytes(raw), fromLcd.Hash)
+	assert.Equal(t, fromRpc, fromLcd)
+}
+
+func TestCosmosRestGetFinalizedBlockIsTheHead(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchCosmosRest(specific_helpers.CosmosLatestBlockRoute))).
+		Return(cosmosOK(cosmosBlockJSON(7, base64Hash("cc"), base64Hash("dd")))).
+		Twice()
+
+	cs := freshCosmosRest(t, connector, nil)
+	latest, err := cs.GetLatestBlock(context.Background())
+	require.NoError(t, err)
+	finalized, err := cs.GetFinalizedBlock(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, latest, finalized)
+	connector.AssertExpectations(t)
+}
+
+func TestCosmosRestParseBlockRejectsGarbage(t *testing.T) {
+	cs := freshCosmosRest(t, mocks.NewConnectorMockWithType(specs.RestConnector), nil)
+
+	for _, payload := range []string{`nope`, `{}`, `{"block":{"header":{"height":"0"}}}`} {
+		block, err := cs.ParseBlock([]byte(payload))
+		assert.True(t, block.IsFullEmpty(), payload)
+		assert.Error(t, err, payload)
+	}
+}
+
+func TestCosmosRestHeadSubscriptionsUnsupported(t *testing.T) {
+	cs := freshCosmosRest(t, mocks.NewConnectorMockWithType(specs.RestConnector), nil)
+
+	req, err := cs.SubscribeHeadRequest()
+	assert.Nil(t, req)
+	assert.ErrorContains(t, err, "head subscriptions are not supported")
+
+	block, err := cs.ParseSubscriptionBlock([]byte(`{}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "head subscriptions are not supported")
+}
+
+// ---------- validators ----------
+
+// The LCD exposes no peer set, so there is only ever the syncing validator.
+func TestCosmosRestHealthValidators(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+
+	assert.Empty(t, freshCosmosRest(t, connector, cosmosOptions(false)).HealthValidators())
+
+	enabled := freshCosmosRest(t, connector, cosmosOptions(true)).HealthValidators()
+	require.Len(t, enabled, 1)
+	assert.IsType(t, &cosmos_validations.CosmosSyncingValidator{}, enabled[0])
+
+	withPeers := cosmosOptions(true)
+	withPeers.ValidatePeers = new(true)
+	assert.Len(t, freshCosmosRest(t, connector, withPeers).HealthValidators(), 1)
+}
+
+func TestCosmosSyncingValidator(t *testing.T) {
+	cases := []struct {
+		body string
+		want protocol.AvailabilityStatus
+	}{
+		{body: `{"syncing":false}`, want: protocol.Available},
+		{body: `{"syncing":true}`, want: protocol.Syncing},
+	}
+	for _, c := range cases {
+		connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+		connector.
+			On("SendRequest", mock.Anything, mock.MatchedBy(matchCosmosRest(specific_helpers.CosmosSyncingRoute))).
+			Return(cosmosOK(c.body)).
+			Once()
+
+		validator := cosmos_validations.NewCosmosSyncingValidator(
+			"id", chains.GetChain("cosmos-hub").Chain, connector, time.Second,
+		)
+		assert.Equal(t, c.want, validator.Validate())
+		connector.AssertExpectations(t)
+	}
+}
+
+func TestCosmosChainValidator(t *testing.T) {
+	chain := chains.GetChain("cosmos-hub")
+
+	cases := []struct {
+		name    string
+		network string
+		want    validations.ValidationSettingResult
+	}{
+		{name: "match", network: "cosmoshub-4", want: validations.Valid},
+		{name: "case insensitive", network: "COSMOSHUB-4", want: validations.Valid},
+		{name: "wrong network", network: "osmosis-1", want: validations.FatalSettingError},
+		// An upstream that answers node_info but reports no network cannot prove
+		// which chain it serves, so it is refused outright rather than retried.
+		{name: "empty network", network: "", want: validations.FatalSettingError},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+			connector.
+				On("SendRequest", mock.Anything, mock.MatchedBy(matchCosmosRest(specific_helpers.CosmosNodeInfoRoute))).
+				Return(cosmosOK(cosmosNodeInfoJSON(c.network, "0.38.17", "v21.0.0"))).
+				Once()
+
+			validator := cosmos_validations.NewCosmosChainValidator("id", connector, chain, time.Second)
+			assert.Equal(t, c.want, validator.Validate())
+			connector.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------- lower bounds ----------
+
+// The steady-state path: the previously found bound is re-confirmed with a
+// single probe.
+func TestCosmosLowerBoundSearchFindsFirstRetainedHeight(t *testing.T) {
+	const retainedFrom = 24000000
+	connector := mocks.NewConnectorMockWithType(specs.RestConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchCosmosRest(specific_helpers.CosmosLatestBlockRoute))).
+		Return(cosmosOK(cosmosBlockJSON(25000000, base64Hash("aa"), base64Hash("bb"))))
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(probedHeightMatches(func(h int64) bool { return h < retainedFrom }))).
+		Return(cosmosErr(400, "could not find results for height #1 (lowest height is 24000000)"))
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(probedHeightMatches(func(h int64) bool { return h >= retainedFrom }))).
+		Return(cosmosOK(cosmosBlockJSON(retainedFrom, base64Hash("aa"), base64Hash("bb"))))
+
+	detector := cosmos_bounds.NewCosmosLowerBoundDetector(
+		"id", chains.GetChain("cosmos-hub").Chain, time.Second, connector,
+	)
+	detector.SetSearchRetryPolicy(1, time.Millisecond, time.Millisecond)
+
+	bounds, err := detector.DetectLowerBound(context.Background())
+
+	require.NoError(t, err)
+	require.NotEmpty(t, bounds)
+	assert.Equal(t, int64(retainedFrom), bounds[0].Bound)
+	assert.Equal(t, protocol.StateBound, bounds[0].Type)
+}
+
+func TestCosmosRestProcessorsArePresent(t *testing.T) {
+	cs := freshCosmosRest(t, mocks.NewConnectorMockWithType(specs.RestConnector), nil)
+
+	assert.NotNil(t, cs.LowerBoundProcessor())
+	assert.NotNil(t, cs.LabelsProcessor())
+	assert.NotNil(t, cs.BlockProcessor())
+}
+
+// base64Hash builds a deterministic 32-byte base64 hash out of a seed, the way
+// the LCD renders block ids.
+func base64Hash(seed string) string {
+	raw := make([]byte, 32)
+	copy(raw, seed)
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// probedHeightMatches builds a mock matcher for a block-by-height probe whose
+// captured height satisfies the predicate. Matchers must never assert, only
+// report, so a non-probe request simply doesn't match.
+func probedHeightMatches(predicate func(int64) bool) func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		if req.Method() != specific_helpers.CosmosBlockByHeightRoute {
+			return false
+		}
+		restReq, ok := req.(*protocol.UpstreamRestRequest)
+		if !ok {
+			return false
+		}
+		params := restReq.RequestParams()
+		if params == nil || len(params.PathParams) != 1 {
+			return false
+		}
+		height, err := strconv.ParseInt(params.PathParams[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		return predicate(height)
+	}
+}

--- a/internal/upstreams/chains_specific/cosmos_specific/cosmos_rest_specific.go
+++ b/internal/upstreams/chains_specific/cosmos_specific/cosmos_rest_specific.go
@@ -1,0 +1,160 @@
+package cosmos_specific
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/cosmos_labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/cosmos_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/cosmos_validations"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+)
+
+var errUnsupportedHeadSubscriptions = errors.New("cosmos rest: head subscriptions are not supported")
+
+type CosmosRestSpecific struct {
+	ctx          context.Context
+	upstreamId   string
+	connector    connectors.ApiConnector
+	chain        *chains.ConfiguredChain
+	options      *chains.Options
+	pollInterval time.Duration
+}
+
+func newCosmosRestSpecific(
+	ctx context.Context,
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	pollInterval time.Duration,
+	options *chains.Options,
+) (*CosmosRestSpecific, error) {
+	if connector == nil {
+		return nil, errors.New("no connector specified")
+	}
+	if connector.GetType() != specs.RestConnector {
+		return nil, fmt.Errorf("cosmos rest specific supports only the rest connector but not %s", connector.GetType())
+	}
+	return &CosmosRestSpecific{
+		ctx:          ctx,
+		upstreamId:   upstreamId,
+		connector:    connector,
+		chain:        chain,
+		options:      options,
+		pollInterval: pollInterval,
+	}, nil
+}
+
+func (c *CosmosRestSpecific) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
+	raw, err := specific_helpers.FetchCosmosLatestBlock(ctx, c.connector, c.chain.Chain)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+	return c.ParseBlock(raw)
+}
+
+// GetFinalizedBlock - a committed cosmos block is final, so the head is also
+// the finalized block.
+func (c *CosmosRestSpecific) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
+	return c.GetLatestBlock(ctx)
+}
+
+func (c *CosmosRestSpecific) ParseBlock(blockBytes []byte) (protocol.Block, error) {
+	result, err := specific_helpers.ParseCosmosBlock(blockBytes)
+	if err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the cosmos block, reason - %s", err.Error())
+	}
+	height, err := specific_helpers.ParseDecimalHeight(result.Block.Header.Height)
+	if err != nil || height == 0 {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the cosmos block, got '%s'", string(blockBytes))
+	}
+	return protocol.NewBlock(
+		height,
+		0,
+		blockchain.NewHashIdFromString(result.BlockId.Hash),
+		blockchain.NewHashIdFromString(result.Block.Header.LastBlockId.Hash),
+	), nil
+}
+
+func (c *CosmosRestSpecific) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
+	return protocol.ZeroBlock{}, errUnsupportedHeadSubscriptions
+}
+
+func (c *CosmosRestSpecific) SubscribeHeadRequest() (protocol.RequestHolder, error) {
+	return nil, errUnsupportedHeadSubscriptions
+}
+
+func (c *CosmosRestSpecific) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	validators := make([]validations.Validator[protocol.AvailabilityStatus], 0, 1)
+	if *c.options.ValidateSyncing {
+		validators = append(validators, cosmos_validations.NewCosmosSyncingValidator(
+			c.upstreamId, c.chain.Chain, c.connector, c.options.InternalTimeout,
+		))
+	}
+	return validators
+}
+
+func (c *CosmosRestSpecific) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
+	if c.chain == nil || c.chain.ChainId == "" {
+		return nil
+	}
+	if *c.options.DisableChainValidation {
+		return []validations.Validator[validations.ValidationSettingResult]{}
+	}
+	return []validations.Validator[validations.ValidationSettingResult]{
+		cosmos_validations.NewCosmosChainValidator(c.upstreamId, c.connector, c.chain, c.options.InternalTimeout),
+	}
+}
+
+func (c *CosmosRestSpecific) CapDetectors(_ caps.DetectorInput) []caps.CapDetector {
+	return nil
+}
+
+func (c *CosmosRestSpecific) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
+	detectors := []lower_bounds.LowerBoundDetector{
+		cosmos_bounds.NewCosmosLowerBoundDetector(
+			c.upstreamId, c.chain.Chain, c.options.InternalTimeout, c.connector,
+		),
+	}
+	return lower_bounds.NewBaseLowerBoundProcessor(c.ctx, c.upstreamId, c.chain.AverageRemoveSpeed(), detectors)
+}
+
+func (c *CosmosRestSpecific) LabelsProcessor() labels.LabelsProcessor {
+	labelsDetectors := []labels.LabelsDetector{
+		labels.NewClientLabelDetectorHandler(
+			c.upstreamId,
+			c.connector,
+			cosmos_labels.NewCosmosClientLabelsDetector(c.chain.Chain),
+			c.options.InternalTimeout,
+		),
+	}
+	return labels.NewBaseLabelsProcessor(c.ctx, c.upstreamId, labelsDetectors, c.options.ValidationInterval*5)
+}
+
+func (c *CosmosRestSpecific) BlockProcessor() blocks.BlockProcessor {
+	return blocks.NewBaseBlockProcessor(
+		c.ctx,
+		c.upstreamId,
+		c.pollInterval,
+		c.options.InternalTimeout,
+		c.options.FinalizedBlockDetectionDisabled(),
+		true,
+		c.connector,
+		c,
+	)
+}
+
+var _ chains_specific.ChainSpecific = (*CosmosRestSpecific)(nil)

--- a/internal/upstreams/chains_specific/specific_helpers/cosmos.go
+++ b/internal/upstreams/chains_specific/specific_helpers/cosmos.go
@@ -1,0 +1,128 @@
+package specific_helpers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const (
+	CosmosLatestBlockRoute   = "GET#/cosmos/base/tendermint/v1beta1/blocks/latest"
+	CosmosBlockByHeightRoute = "GET#/cosmos/base/tendermint/v1beta1/blocks/*"
+	CosmosNodeInfoRoute      = "GET#/cosmos/base/tendermint/v1beta1/node_info"
+	CosmosSyncingRoute       = "GET#/cosmos/base/tendermint/v1beta1/syncing"
+)
+
+type CosmosNodeInfo struct {
+	DefaultNodeInfo    CosmosDefaultNodeInfo    `json:"default_node_info"`
+	ApplicationVersion CosmosApplicationVersion `json:"application_version"`
+}
+
+type CosmosDefaultNodeInfo struct {
+	Network string `json:"network"`
+	Version string `json:"version"`
+	Moniker string `json:"moniker"`
+}
+
+type CosmosApplicationVersion struct {
+	Name             string `json:"name"`
+	AppName          string `json:"app_name"`
+	Version          string `json:"version"`
+	CosmosSdkVersion string `json:"cosmos_sdk_version"`
+}
+
+type CosmosBlockResult struct {
+	BlockId CosmosBlockId   `json:"block_id"`
+	Block   CosmosBlockData `json:"block"`
+}
+
+type CosmosBlockId struct {
+	Hash string `json:"hash"`
+}
+
+type CosmosBlockData struct {
+	Header CosmosHeader `json:"header"`
+}
+
+type CosmosHeader struct {
+	Height      string        `json:"height"`
+	Time        string        `json:"time"`
+	LastBlockId CosmosBlockId `json:"last_block_id"`
+}
+
+func CosmosNodeInfoRequest(chain chains.Chain) protocol.RequestHolder {
+	return protocol.NewInternalUpstreamRestRequest(CosmosNodeInfoRoute, nil, chain)
+}
+
+func CosmosBlockByHeightRequest(chain chains.Chain, height int64) protocol.RequestHolder {
+	return protocol.NewInternalUpstreamRestRequest(
+		CosmosBlockByHeightRoute,
+		&protocol.RequestParams{PathParams: []string{strconv.FormatInt(height, 10)}},
+		chain,
+	)
+}
+
+func FetchCosmosNodeInfo(
+	ctx context.Context,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+) (*CosmosNodeInfo, error) {
+	response := connector.SendRequest(ctx, CosmosNodeInfoRequest(chain))
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	return ParseCosmosNodeInfo(response.ResponseResult())
+}
+
+func ParseCosmosNodeInfo(raw []byte) (*CosmosNodeInfo, error) {
+	var nodeInfo CosmosNodeInfo
+	if err := sonic.Unmarshal(raw, &nodeInfo); err != nil {
+		return nil, fmt.Errorf("cosmos node_info payload unparseable: %w", err)
+	}
+	return &nodeInfo, nil
+}
+
+func FetchCosmosLatestBlock(
+	ctx context.Context,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+) ([]byte, error) {
+	request := protocol.NewInternalUpstreamRestRequest(CosmosLatestBlockRoute, nil, chain)
+	response := connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	return response.ResponseResult(), nil
+}
+
+func ParseCosmosBlock(raw []byte) (*CosmosBlockResult, error) {
+	var result CosmosBlockResult
+	if err := sonic.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("cosmos block payload unparseable: %w", err)
+	}
+	return &result, nil
+}
+
+func FetchCosmosSyncing(
+	ctx context.Context,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+) (bool, error) {
+	request := protocol.NewInternalUpstreamRestRequest(CosmosSyncingRoute, nil, chain)
+	response := connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return false, response.GetError()
+	}
+	var parsed struct {
+		Syncing bool `json:"syncing"`
+	}
+	if err := sonic.Unmarshal(response.ResponseResult(), &parsed); err != nil {
+		return false, fmt.Errorf("cosmos syncing payload unparseable: %w", err)
+	}
+	return parsed.Syncing, nil
+}

--- a/internal/upstreams/chains_specific/specific_helpers/tendermint.go
+++ b/internal/upstreams/chains_specific/specific_helpers/tendermint.go
@@ -1,0 +1,76 @@
+package specific_helpers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+type TendermintStatus struct {
+	NodeInfo TendermintNodeInfo `json:"node_info"`
+	SyncInfo TendermintSyncInfo `json:"sync_info"`
+}
+
+type TendermintNodeInfo struct {
+	Network string `json:"network"`
+	Version string `json:"version"`
+	Moniker string `json:"moniker"`
+}
+
+type TendermintSyncInfo struct {
+	EarliestBlockHeight string `json:"earliest_block_height"`
+	CatchingUp          bool   `json:"catching_up"`
+}
+
+func TendermintCall(
+	ctx context.Context,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+	method string,
+	params map[string]any,
+) ([]byte, error) {
+	if params == nil {
+		params = map[string]any{}
+	}
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest(method, params, chain)
+	if err != nil {
+		return nil, err
+	}
+	response := connector.SendRequest(ctx, request)
+	if response.HasError() {
+		return nil, response.GetError()
+	}
+	return response.ResponseResult(), nil
+}
+
+func FetchTendermintStatus(
+	ctx context.Context,
+	connector connectors.ApiConnector,
+	chain chains.Chain,
+) (*TendermintStatus, error) {
+	raw, err := TendermintCall(ctx, connector, chain, "status", nil)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTendermintStatus(raw)
+}
+
+func ParseTendermintStatus(raw []byte) (*TendermintStatus, error) {
+	var status TendermintStatus
+	if err := sonic.Unmarshal(raw, &status); err != nil {
+		return nil, fmt.Errorf("tendermint status payload unparseable: %w", err)
+	}
+	return &status, nil
+}
+
+func ParseDecimalHeight(value string) (uint64, error) {
+	if value == "" {
+		return 0, fmt.Errorf("empty height")
+	}
+	return strconv.ParseUint(value, 10, 64)
+}

--- a/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific.go
+++ b/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific.go
@@ -1,0 +1,187 @@
+package tendermint_specific
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
+	"github.com/drpcorg/nodecore/internal/upstreams/caps"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/tendermint_labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/tendermint_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/tendermint_validations"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+)
+
+var errUnsupportedHeadSubscriptions = errors.New("tendermint: head subscriptions are not supported")
+
+type TendermintChainSpecific struct {
+	ctx          context.Context
+	upstreamId   string
+	connector    connectors.ApiConnector
+	chain        *chains.ConfiguredChain
+	options      *chains.Options
+	pollInterval time.Duration
+}
+
+func NewTendermintSpecific(
+	ctx context.Context,
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	pollInterval time.Duration,
+	options *chains.Options,
+) (*TendermintChainSpecific, error) {
+	if connector == nil {
+		return nil, errors.New("no connector specified")
+	}
+	if connector.GetType() != specs.TendermintConnector {
+		return nil, fmt.Errorf("tendermint specific supports only the tendermint connector but not %s", connector.GetType())
+	}
+	return &TendermintChainSpecific{
+		ctx:          ctx,
+		upstreamId:   upstreamId,
+		connector:    connector,
+		chain:        chain,
+		options:      options,
+		pollInterval: pollInterval,
+	}, nil
+}
+
+func (t *TendermintChainSpecific) GetLatestBlock(ctx context.Context) (protocol.Block, error) {
+	raw, err := specific_helpers.TendermintCall(
+		ctx, t.connector, t.chain.Chain, "block", nil,
+	)
+	if err != nil {
+		return protocol.ZeroBlock{}, err
+	}
+	return t.ParseBlock(raw)
+}
+
+// GetFinalizedBlock - CometBFT commits are final the moment they are produced
+// (+2/3 pre-commits), so the latest block is also the finalized one.
+func (t *TendermintChainSpecific) GetFinalizedBlock(ctx context.Context) (protocol.Block, error) {
+	return t.GetLatestBlock(ctx)
+}
+
+func (t *TendermintChainSpecific) ParseBlock(blockBytes []byte) (protocol.Block, error) {
+	var result TendermintBlockResult
+	if err := sonic.Unmarshal(blockBytes, &result); err != nil {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the tendermint block, reason - %s", err.Error())
+	}
+	height, err := specific_helpers.ParseDecimalHeight(result.Block.Header.Height)
+	if err != nil || height == 0 {
+		return protocol.ZeroBlock{}, fmt.Errorf("couldn't parse the tendermint block, got '%s'", string(blockBytes))
+	}
+	return protocol.NewBlock(
+		height,
+		0,
+		blockchain.NewHashIdFromString(result.BlockId.Hash),
+		blockchain.NewHashIdFromString(result.Block.Header.LastBlockId.Hash),
+	), nil
+}
+
+func (t *TendermintChainSpecific) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
+	return protocol.ZeroBlock{}, errUnsupportedHeadSubscriptions
+}
+
+func (t *TendermintChainSpecific) SubscribeHeadRequest() (protocol.RequestHolder, error) {
+	return nil, errUnsupportedHeadSubscriptions
+}
+
+func (t *TendermintChainSpecific) HealthValidators() []validations.Validator[protocol.AvailabilityStatus] {
+	validators := make([]validations.Validator[protocol.AvailabilityStatus], 0, 2)
+	if *t.options.ValidateSyncing {
+		validators = append(validators, tendermint_validations.NewTendermintSyncingValidator(
+			t.upstreamId, t.chain.Chain, t.connector, t.options.InternalTimeout,
+		))
+	}
+	if *t.options.ValidatePeers {
+		validators = append(validators, tendermint_validations.NewTendermintPeersValidator(
+			t.upstreamId, t.chain.Chain, t.connector, t.options,
+		))
+	}
+	return validators
+}
+
+func (t *TendermintChainSpecific) SettingsValidators() []validations.Validator[validations.ValidationSettingResult] {
+	if t.chain == nil || t.chain.ChainId == "" {
+		return nil
+	}
+	if *t.options.DisableChainValidation {
+		return []validations.Validator[validations.ValidationSettingResult]{}
+	}
+	return []validations.Validator[validations.ValidationSettingResult]{
+		tendermint_validations.NewTendermintChainValidator(t.upstreamId, t.connector, t.chain, t.options.InternalTimeout),
+	}
+}
+
+func (t *TendermintChainSpecific) CapDetectors(_ caps.DetectorInput) []caps.CapDetector {
+	return nil
+}
+
+func (t *TendermintChainSpecific) LowerBoundProcessor() lower_bounds.LowerBoundProcessor {
+	detectors := []lower_bounds.LowerBoundDetector{
+		tendermint_bounds.NewTendermintLowerBoundDetector(
+			t.upstreamId, t.chain.Chain, t.options.InternalTimeout, t.connector,
+		),
+	}
+	return lower_bounds.NewBaseLowerBoundProcessor(t.ctx, t.upstreamId, t.chain.AverageRemoveSpeed(), detectors)
+}
+
+func (t *TendermintChainSpecific) LabelsProcessor() labels.LabelsProcessor {
+	labelsDetectors := []labels.LabelsDetector{
+		labels.NewClientLabelDetectorHandler(
+			t.upstreamId,
+			t.connector,
+			tendermint_labels.NewTendermintClientLabelsDetector(t.chain.Chain),
+			t.options.InternalTimeout,
+		),
+	}
+	return labels.NewBaseLabelsProcessor(t.ctx, t.upstreamId, labelsDetectors, t.options.ValidationInterval*5)
+}
+
+func (t *TendermintChainSpecific) BlockProcessor() blocks.BlockProcessor {
+	return blocks.NewBaseBlockProcessor(
+		t.ctx,
+		t.upstreamId,
+		t.pollInterval,
+		t.options.InternalTimeout,
+		t.options.FinalizedBlockDetectionDisabled(),
+		true,
+		t.connector,
+		t,
+	)
+}
+
+type TendermintBlockResult struct {
+	BlockId TendermintBlockId   `json:"block_id"`
+	Block   TendermintBlockData `json:"block"`
+}
+
+type TendermintBlockId struct {
+	Hash string `json:"hash"`
+}
+
+type TendermintBlockData struct {
+	Header TendermintHeader `json:"header"`
+}
+
+type TendermintHeader struct {
+	Height      string            `json:"height"`
+	Time        string            `json:"time"`
+	LastBlockId TendermintBlockId `json:"last_block_id"`
+}
+
+var _ chains_specific.ChainSpecific = (*TendermintChainSpecific)(nil)

--- a/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific_test.go
+++ b/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific_test.go
@@ -1,0 +1,376 @@
+package tendermint_specific_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/tendermint_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds/tendermint_bounds"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations/tendermint_validations"
+	"github.com/drpcorg/nodecore/pkg/blockchain"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/drpcorg/nodecore/pkg/test_utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// matchTendermintJsonRpc asserts the probe went out as a JSON-RPC call - the
+// tendermint connector picks its wire shape from the request type, and every
+// internal probe must use JSON-RPC so the shared response path unwraps
+// CometBFT's result envelope.
+func matchTendermintJsonRpc(method string) func(protocol.RequestHolder) bool {
+	return func(req protocol.RequestHolder) bool {
+		return req.Method() == method && req.RequestType() == protocol.JsonRpc
+	}
+}
+
+func tendermintOK(result string) protocol.ResponseHolder {
+	return protocol.NewSimpleHttpUpstreamResponse("1", []byte(result), protocol.JsonRpc)
+}
+
+// tendermintBlockJSON renders the shape CometBFT's `block` result has: decimal
+// string heights, uppercase hex hashes.
+func tendermintBlockJSON(height uint64, hash, parentHash string) string {
+	return fmt.Sprintf(
+		`{"block_id":{"hash":"%s"},"block":{"header":{"height":"%d","time":"2026-07-27T10:00:00Z","last_block_id":{"hash":"%s"}}}}`,
+		hash, height, parentHash,
+	)
+}
+
+func tendermintStatusJSON(network, version, earliest string, catchingUp bool) string {
+	return fmt.Sprintf(
+		`{"node_info":{"network":"%s","version":"%s"},"sync_info":{"latest_block_height":"100","earliest_block_height":"%s","catching_up":%t}}`,
+		network, version, earliest, catchingUp,
+	)
+}
+
+func tendermintOptions(validatePeers, validateSyncing bool) *chains.Options {
+	return &chains.Options{
+		InternalTimeout:        time.Second,
+		ValidationInterval:     time.Second,
+		MinPeers:               1,
+		ValidatePeers:          new(validatePeers),
+		ValidateSyncing:        new(validateSyncing),
+		DisableChainValidation: new(false),
+	}
+}
+
+func freshTendermint(t *testing.T, connector *mocks.ConnectorMock, opts *chains.Options) *tendermint_specific.TendermintChainSpecific {
+	t.Helper()
+	if opts == nil {
+		opts = tendermintOptions(false, false)
+	}
+	chain := chains.GetChain("cosmos-hub")
+	require.NotNil(t, chain)
+	cs, err := tendermint_specific.NewTendermintSpecific(
+		context.Background(),
+		"upstream-id",
+		connector,
+		chain,
+		100*time.Millisecond,
+		opts,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+	return cs
+}
+
+// ---------- constructor ----------
+
+func TestNewTendermintSpecificRejectsOtherConnectors(t *testing.T) {
+	for _, connectorType := range []specs.ApiConnectorType{
+		specs.RestConnector, specs.JsonRpcConnector, specs.WebsocketConnector,
+	} {
+		cs, err := tendermint_specific.NewTendermintSpecific(
+			context.Background(),
+			"id",
+			mocks.NewConnectorMockWithType(connectorType),
+			chains.GetChain("cosmos-hub"),
+			time.Second,
+			tendermintOptions(false, false),
+		)
+		assert.Nil(t, cs)
+		assert.ErrorContains(t, err, "tendermint specific supports only the tendermint connector")
+	}
+}
+
+func TestNewTendermintSpecificNilConnector(t *testing.T) {
+	cs, err := tendermint_specific.NewTendermintSpecific(
+		context.Background(),
+		"id",
+		nil,
+		chains.GetChain("cosmos-hub"),
+		time.Second,
+		tendermintOptions(false, false),
+	)
+	assert.Nil(t, cs)
+	assert.ErrorContains(t, err, "no connector")
+}
+
+// ---------- head / blocks ----------
+
+func TestTendermintGetLatestBlock(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("block"))).
+		Return(tendermintOK(tendermintBlockJSON(25000000, "AABBCC", "DDEEFF"))).
+		Once()
+
+	cs := freshTendermint(t, connector, nil)
+	block, err := cs.GetLatestBlock(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25000000), block.Height)
+	assert.Equal(t, blockchain.NewHashIdFromString("AABBCC"), block.Hash)
+	assert.Equal(t, blockchain.NewHashIdFromString("DDEEFF"), block.ParentHash)
+	connector.AssertExpectations(t)
+}
+
+// CometBFT commits are final on production, so the finalized block is the head.
+func TestTendermintGetFinalizedBlockIsTheHead(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("block"))).
+		Return(tendermintOK(tendermintBlockJSON(42, "AA", "BB"))).
+		Twice()
+
+	cs := freshTendermint(t, connector, nil)
+	latest, err := cs.GetLatestBlock(context.Background())
+	require.NoError(t, err)
+	finalized, err := cs.GetFinalizedBlock(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, latest, finalized)
+	connector.AssertExpectations(t)
+}
+
+func TestTendermintGetLatestBlockPropagatesError(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.Anything).
+		Return(protocol.NewHttpUpstreamResponseWithError(protocol.ResponseErrorWithData(-32603, "boom", nil))).
+		Once()
+
+	cs := freshTendermint(t, connector, nil)
+	block, err := cs.GetLatestBlock(context.Background())
+
+	assert.True(t, block.IsFullEmpty())
+	assert.Error(t, err)
+	connector.AssertExpectations(t)
+}
+
+func TestTendermintParseBlockRejectsGarbage(t *testing.T) {
+	cs := freshTendermint(t, mocks.NewConnectorMockWithType(specs.TendermintConnector), nil)
+
+	for _, payload := range []string{
+		`not json`,
+		`{}`,
+		`{"block":{"header":{"height":"0"}}}`,
+		`{"block":{"header":{"height":"abc"}}}`,
+	} {
+		block, err := cs.ParseBlock([]byte(payload))
+		assert.True(t, block.IsFullEmpty(), payload)
+		assert.Error(t, err, payload)
+	}
+}
+
+// ---------- subscriptions ----------
+
+func TestTendermintHeadSubscriptionsUnsupported(t *testing.T) {
+	cs := freshTendermint(t, mocks.NewConnectorMockWithType(specs.TendermintConnector), nil)
+
+	req, err := cs.SubscribeHeadRequest()
+	assert.Nil(t, req)
+	assert.ErrorContains(t, err, "head subscriptions are not supported")
+
+	block, err := cs.ParseSubscriptionBlock([]byte(`{}`))
+	assert.True(t, block.IsFullEmpty())
+	assert.ErrorContains(t, err, "head subscriptions are not supported")
+}
+
+// ---------- validators ----------
+
+func TestTendermintHealthValidatorsFollowOptions(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+
+	assert.Empty(t, freshTendermint(t, connector, tendermintOptions(false, false)).HealthValidators())
+
+	syncingOnly := freshTendermint(t, connector, tendermintOptions(false, true)).HealthValidators()
+	require.Len(t, syncingOnly, 1)
+	assert.IsType(t, &tendermint_validations.TendermintSyncingValidator{}, syncingOnly[0])
+
+	peersOnly := freshTendermint(t, connector, tendermintOptions(true, false)).HealthValidators()
+	require.Len(t, peersOnly, 1)
+	assert.IsType(t, &tendermint_validations.TendermintPeersValidator{}, peersOnly[0])
+
+	both := freshTendermint(t, connector, tendermintOptions(true, true)).HealthValidators()
+	assert.Len(t, both, 2)
+}
+
+func TestTendermintSyncingValidatorReadsCatchingUp(t *testing.T) {
+	cases := []struct {
+		catchingUp bool
+		want       protocol.AvailabilityStatus
+	}{
+		{catchingUp: false, want: protocol.Available},
+		{catchingUp: true, want: protocol.Syncing},
+	}
+	for _, c := range cases {
+		connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+		connector.
+			On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("status"))).
+			Return(tendermintOK(tendermintStatusJSON("cosmoshub-4", "0.38.17", "1", c.catchingUp))).
+			Once()
+
+		validator := tendermint_validations.NewTendermintSyncingValidator(
+			"id", chains.GetChain("cosmos-hub").Chain, connector, time.Second,
+		)
+		assert.Equal(t, c.want, validator.Validate())
+		connector.AssertExpectations(t)
+	}
+}
+
+func TestTendermintPeersValidatorParsesStringPeerCount(t *testing.T) {
+	// CometBFT renders n_peers as a decimal string, not a number.
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("net_info"))).
+		Return(tendermintOK(`{"listening":true,"n_peers":"0"}`)).
+		Once()
+
+	options := tendermintOptions(true, false)
+	validator := tendermint_validations.NewTendermintPeersValidator(
+		"id", chains.GetChain("cosmos-hub").Chain, connector, options,
+	)
+	assert.Equal(t, protocol.Immature, validator.Validate())
+	connector.AssertExpectations(t)
+}
+
+func TestTendermintChainValidator(t *testing.T) {
+	chain := chains.GetChain("cosmos-hub")
+	require.Equal(t, "cosmoshub-4", chain.ChainId)
+
+	cases := []struct {
+		name    string
+		network string
+		want    validations.ValidationSettingResult
+	}{
+		{name: "match", network: "cosmoshub-4", want: validations.Valid},
+		{name: "case insensitive", network: "CosmosHub-4", want: validations.Valid},
+		{name: "wrong network", network: "osmosis-1", want: validations.FatalSettingError},
+		// An upstream that answers `status` but reports no network cannot prove
+		// which chain it serves, so it is refused outright rather than retried.
+		{name: "empty network", network: "", want: validations.FatalSettingError},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+			connector.
+				On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("status"))).
+				Return(tendermintOK(tendermintStatusJSON(c.network, "0.38.17", "1", false))).
+				Once()
+
+			validator := tendermint_validations.NewTendermintChainValidator("id", connector, chain, time.Second)
+			assert.Equal(t, c.want, validator.Validate())
+			connector.AssertExpectations(t)
+		})
+	}
+}
+
+func TestTendermintSettingsValidators(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+
+	enabled := freshTendermint(t, connector, tendermintOptions(false, false)).SettingsValidators()
+	require.Len(t, enabled, 1)
+	assert.IsType(t, &tendermint_validations.TendermintChainValidator{}, enabled[0])
+
+	options := tendermintOptions(false, false)
+	options.DisableChainValidation = new(true)
+	assert.Empty(t, freshTendermint(t, connector, options).SettingsValidators())
+}
+
+// ---------- lower bounds / labels / processors ----------
+
+func TestTendermintLowerBoundFromEarliestBlockHeight(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.MatchedBy(matchTendermintJsonRpc("status"))).
+		Return(tendermintOK(tendermintStatusJSON("cosmoshub-4", "0.38.17", "17654321", false))).
+		Once()
+
+	detector := tendermint_bounds.NewTendermintLowerBoundDetector(
+		"id", chains.GetChain("cosmos-hub").Chain, time.Second, connector,
+	)
+	bounds, err := detector.DetectLowerBound(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, bounds, 1)
+	assert.Equal(t, int64(17654321), bounds[0].Bound)
+	assert.Equal(t, protocol.StateBound, bounds[0].Type)
+	connector.AssertExpectations(t)
+}
+
+// earliest_block_height is reported verbatim, including 0 - the detector
+// trusts what the node says rather than second-guessing it.
+func TestTendermintLowerBoundReportsZeroVerbatim(t *testing.T) {
+	connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+	connector.
+		On("SendRequest", mock.Anything, mock.Anything).
+		Return(tendermintOK(tendermintStatusJSON("cosmoshub-4", "0.38.17", "0", false))).
+		Once()
+
+	detector := tendermint_bounds.NewTendermintLowerBoundDetector(
+		"id", chains.GetChain("cosmos-hub").Chain, time.Second, connector,
+	)
+	bounds, err := detector.DetectLowerBound(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, bounds, 1)
+	assert.Equal(t, int64(0), bounds[0].Bound)
+	assert.Equal(t, protocol.StateBound, bounds[0].Type)
+}
+
+// A height that isn't a decimal number is a genuine protocol violation and
+// still fails, so the router keeps the previous value instead of taking a
+// garbage bound.
+func TestTendermintLowerBoundRejectsUnparseableHeight(t *testing.T) {
+	for _, earliest := range []string{"", "abc", "0x10"} {
+		connector := mocks.NewConnectorMockWithType(specs.TendermintConnector)
+		connector.
+			On("SendRequest", mock.Anything, mock.Anything).
+			Return(tendermintOK(tendermintStatusJSON("cosmoshub-4", "0.38.17", earliest, false))).
+			Once()
+
+		detector := tendermint_bounds.NewTendermintLowerBoundDetector(
+			"id", chains.GetChain("cosmos-hub").Chain, time.Second, connector,
+		)
+		bounds, err := detector.DetectLowerBound(context.Background())
+
+		assert.Nil(t, bounds, earliest)
+		assert.ErrorContains(t, err, "earliest_block_height", earliest)
+	}
+}
+
+// The tendermint detector only claims STATE: the earliest retained height is
+// exactly what `status` reports, with no inference about other bound types.
+func TestTendermintLowerBoundSupportedTypes(t *testing.T) {
+	detector := tendermint_bounds.NewTendermintLowerBoundDetector(
+		"id", chains.GetChain("cosmos-hub").Chain, time.Second,
+		mocks.NewConnectorMockWithType(specs.TendermintConnector),
+	)
+	assert.Equal(t, []protocol.LowerBoundType{protocol.StateBound}, detector.SupportedTypes())
+}
+
+func TestTendermintProcessorsArePresent(t *testing.T) {
+	cs := freshTendermint(t, mocks.NewConnectorMockWithType(specs.TendermintConnector), nil)
+
+	assert.NotNil(t, cs.LowerBoundProcessor())
+	assert.NotNil(t, cs.LabelsProcessor())
+	assert.NotNil(t, cs.BlockProcessor())
+}

--- a/internal/upstreams/connectors/http_connector.go
+++ b/internal/upstreams/connectors/http_connector.go
@@ -175,10 +175,17 @@ func (h *HttpConnector) SubscribeStates(_ string) *utils.Subscription[protocol.S
 // and applying its own URL/header semantics; the shared dispatch helper
 // only handles network execution and response framing.
 func (h *HttpConnector) SendRequest(ctx context.Context, request protocol.RequestHolder) protocol.ResponseHolder {
-	if h.GetType() == specs.JsonRpcConnector {
+	switch h.GetType() {
+	case specs.JsonRpcConnector:
 		return h.sendJsonRpc(ctx, request)
+	case specs.TendermintConnector:
+		if request.RequestType() == protocol.JsonRpc {
+			return h.sendJsonRpc(ctx, request)
+		}
+		return h.sendRest(ctx, request)
+	default:
+		return h.sendRest(ctx, request)
 	}
-	return h.sendRest(ctx, request)
 }
 
 // sendJsonRpc forwards a JSON-RPC call. Always POST to the configured

--- a/internal/upstreams/connectors/tendermint_connector_test.go
+++ b/internal/upstreams/connectors/tendermint_connector_test.go
@@ -51,7 +51,7 @@ func newTendermintConnector(t *testing.T, handler http.HandlerFunc) (*connectors
 // and the shared JSON-RPC response path unwraps CometBFT's result envelope.
 func TestTendermintConnectorSendsJsonRpcShape(t *testing.T) {
 	connector, captured := newTendermintConnector(t, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{"sync_info":{"latest_block_height":"25000000"}}}`))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"sync_info":{"latest_block_height":"25000000"}}}`))
 	})
 
 	request, err := protocol.NewInternalUpstreamJsonRpcRequest("status", map[string]any{}, chains.COSMOS_HUB)
@@ -65,7 +65,7 @@ func TestTendermintConnectorSendsJsonRpcShape(t *testing.T) {
 	assert.Equal(t, http.MethodPost, captured.method)
 	assert.Equal(t, "/", captured.path)
 	assert.Empty(t, captured.query)
-	assert.JSONEq(t, `{"id":"1","jsonrpc":"2.0","method":"status","params":{}}`, captured.body)
+	assert.JSONEq(t, `{"id":1,"jsonrpc":"2.0","method":"status","params":{}}`, captured.body)
 }
 
 // The same connector serves a URI-style request as GET /<method>?<args>, which

--- a/internal/upstreams/connectors/tendermint_connector_test.go
+++ b/internal/upstreams/connectors/tendermint_connector_test.go
@@ -1,0 +1,125 @@
+package connectors_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/drpcorg/nodecore/internal/config"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedRequest records what the fake CometBFT endpoint actually received.
+type capturedRequest struct {
+	method string
+	path   string
+	query  string
+	body   string
+}
+
+func newTendermintConnector(t *testing.T, handler http.HandlerFunc) (*connectors.HttpConnector, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.query = r.URL.RawQuery
+		captured.body = string(body)
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	connector, err := connectors.NewHttpConnector(
+		&config.ApiConnectorConfig{Url: srv.URL},
+		specs.TendermintConnector,
+		"",
+		"test-upstream",
+	)
+	require.NoError(t, err)
+	return connector, captured
+}
+
+// A JSON-RPC request is POSTed to the endpoint root with the body verbatim,
+// and the shared JSON-RPC response path unwraps CometBFT's result envelope.
+func TestTendermintConnectorSendsJsonRpcShape(t *testing.T) {
+	connector, captured := newTendermintConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"1","result":{"sync_info":{"latest_block_height":"25000000"}}}`))
+	})
+
+	request, err := protocol.NewInternalUpstreamJsonRpcRequest("status", map[string]any{}, chains.COSMOS_HUB)
+	require.NoError(t, err)
+
+	response := connector.SendRequest(context.Background(), request)
+
+	require.False(t, response.HasError())
+	assert.JSONEq(t, `{"sync_info":{"latest_block_height":"25000000"}}`, string(response.ResponseResult()))
+
+	assert.Equal(t, http.MethodPost, captured.method)
+	assert.Equal(t, "/", captured.path)
+	assert.Empty(t, captured.query)
+	assert.JSONEq(t, `{"id":"1","jsonrpc":"2.0","method":"status","params":{}}`, captured.body)
+}
+
+// The same connector serves a URI-style request as GET /<method>?<args>, which
+// is how a REST client reaches the very same tendermint methods.
+func TestTendermintConnectorSendsRestShape(t *testing.T) {
+	connector, captured := newTendermintConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":-1,"result":{"block_id":{"hash":"AABB"}}}`))
+	})
+
+	request := protocol.NewUpstreamRestRequest(
+		"1",
+		"GET#/block",
+		&protocol.RequestParams{QueryParams: map[string][]string{"height": {"25000000"}}},
+		nil,
+		"cosmos",
+	)
+
+	response := connector.SendRequest(context.Background(), request)
+
+	require.False(t, response.HasError())
+	// REST bodies are opaque pass-through, so the client sees the envelope the
+	// node produced - exactly what a direct call to 26657 returns.
+	assert.JSONEq(t,
+		`{"jsonrpc":"2.0","id":-1,"result":{"block_id":{"hash":"AABB"}}}`,
+		string(response.ResponseResult()),
+	)
+
+	assert.Equal(t, http.MethodGet, captured.method)
+	assert.Equal(t, "/block", captured.path)
+	assert.Equal(t, "height=25000000", captured.query)
+	assert.Empty(t, captured.body)
+}
+
+// Path wildcards still expand, so a tendermint spec is free to use them.
+func TestTendermintConnectorExpandsRestPathParams(t *testing.T) {
+	connector, captured := newTendermintConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	request := protocol.NewUpstreamRestRequest(
+		"1",
+		"GET#/tx/*",
+		&protocol.RequestParams{PathParams: []string{"0xdeadbeef"}},
+		nil,
+		"cosmos",
+	)
+
+	response := connector.SendRequest(context.Background(), request)
+
+	require.False(t, response.HasError())
+	assert.Equal(t, "/tx/0xdeadbeef", captured.path)
+}
+
+func TestTendermintConnectorReportsType(t *testing.T) {
+	connector, _ := newTendermintConnector(t, func(w http.ResponseWriter, _ *http.Request) {})
+	assert.Equal(t, specs.TendermintConnector, connector.GetType())
+}

--- a/internal/upstreams/labels/cosmos_labels/cosmos_detectors.go
+++ b/internal/upstreams/labels/cosmos_labels/cosmos_detectors.go
@@ -1,0 +1,35 @@
+package cosmos_labels
+
+import (
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels/tendermint_labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+type CosmosClientLabelsDetector struct {
+	chain chains.Chain
+}
+
+func NewCosmosClientLabelsDetector(chain chains.Chain) *CosmosClientLabelsDetector {
+	return &CosmosClientLabelsDetector{chain: chain}
+}
+
+func (c *CosmosClientLabelsDetector) NodeTypeRequest() (protocol.RequestHolder, error) {
+	return specific_helpers.CosmosNodeInfoRequest(c.chain), nil
+}
+
+func (c *CosmosClientLabelsDetector) ClientVersionAndType(data []byte) (string, string, error) {
+	nodeInfo, err := specific_helpers.ParseCosmosNodeInfo(data)
+	if err != nil {
+		return "", "", err
+	}
+	version := nodeInfo.ApplicationVersion.Version
+	if version == "" {
+		version = nodeInfo.DefaultNodeInfo.Version
+	}
+	return version, tendermint_labels.CosmosClient, nil
+}
+
+var _ labels.ClientLabelsDetector = (*CosmosClientLabelsDetector)(nil)

--- a/internal/upstreams/labels/tendermint_labels/tendermint_detectors.go
+++ b/internal/upstreams/labels/tendermint_labels/tendermint_detectors.go
@@ -1,0 +1,32 @@
+package tendermint_labels
+
+import (
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/labels"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const CosmosClient = "cosmos"
+
+type TendermintClientLabelsDetector struct {
+	chain chains.Chain
+}
+
+func NewTendermintClientLabelsDetector(chain chains.Chain) *TendermintClientLabelsDetector {
+	return &TendermintClientLabelsDetector{chain: chain}
+}
+
+func (t *TendermintClientLabelsDetector) NodeTypeRequest() (protocol.RequestHolder, error) {
+	return protocol.NewInternalUpstreamJsonRpcRequest("status", map[string]any{}, t.chain)
+}
+
+func (t *TendermintClientLabelsDetector) ClientVersionAndType(data []byte) (string, string, error) {
+	status, err := specific_helpers.ParseTendermintStatus(data)
+	if err != nil {
+		return "", "", err
+	}
+	return status.NodeInfo.Version, CosmosClient, nil
+}
+
+var _ labels.ClientLabelsDetector = (*TendermintClientLabelsDetector)(nil)

--- a/internal/upstreams/lower_bounds/cosmos_bounds/cosmos_lower_bound_detector.go
+++ b/internal/upstreams/lower_bounds/cosmos_bounds/cosmos_lower_bound_detector.go
@@ -1,0 +1,128 @@
+package cosmos_bounds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const cosmosLowerBoundPeriod = 3 * time.Minute
+
+var cosmosSupportedBoundTypes = []protocol.LowerBoundType{
+	protocol.StateBound,
+}
+
+type CosmosLowerBoundDetector struct {
+	*lower_bounds.LowerBoundSearchCalculator
+
+	connector       connectors.ApiConnector
+	chain           chains.Chain
+	internalTimeout time.Duration
+}
+
+func NewCosmosLowerBoundDetector(
+	upstreamId string,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *CosmosLowerBoundDetector {
+	return &CosmosLowerBoundDetector{
+		LowerBoundSearchCalculator: lower_bounds.NewLowerBoundSearchCalculatorWithSupportedTypes(
+			upstreamId,
+			protocol.StateBound,
+			cosmosSupportedBoundTypes,
+			cosmosLowerBoundPeriod,
+		),
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (c *CosmosLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	return c.LowerBoundSearchCalculator.DetectLowerBound(ctx, c.fetchLatestHeight, c.probe)
+}
+
+func (c *CosmosLowerBoundDetector) fetchLatestHeight(ctx context.Context) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.internalTimeout)
+	defer cancel()
+
+	raw, err := specific_helpers.FetchCosmosLatestBlock(ctx, c.connector, c.chain)
+	if err != nil {
+		return 0, err
+	}
+	result, err := specific_helpers.ParseCosmosBlock(raw)
+	if err != nil {
+		return 0, err
+	}
+	height, err := specific_helpers.ParseDecimalHeight(result.Block.Header.Height)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"cosmos upstream '%s' latest block has an unparseable height '%s': %w",
+			c.UpstreamId, result.Block.Header.Height, err,
+		)
+	}
+	return int64(height), nil
+}
+
+// probe reports whether the upstream still serves the given height. A pruned
+// height comes back as a 4xx with a "could not find results for height" style
+// body; anything else (5xx, transport failure) is returned as an error so the
+// calculator retries instead of treating an outage as pruning.
+func (c *CosmosLowerBoundDetector) probe(ctx context.Context, height int64) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.internalTimeout)
+	defer cancel()
+
+	response := c.connector.SendRequest(ctx, specific_helpers.CosmosBlockByHeightRequest(c.chain, height))
+	if response.HasError() {
+		code := response.ResponseCode()
+		if code >= 400 && code < 500 {
+			return false, nil
+		}
+		respErr := response.GetError()
+		if respErr != nil && isPrunedMessage(respErr.Message) {
+			return false, nil
+		}
+		return false, respErr
+	}
+
+	result, err := specific_helpers.ParseCosmosBlock(response.ResponseResult())
+	if err != nil {
+		return false, err
+	}
+	parsed, err := specific_helpers.ParseDecimalHeight(result.Block.Header.Height)
+	if err != nil || parsed == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func isPrunedMessage(message string) bool {
+	if message == "" {
+		return false
+	}
+	lower := strings.ToLower(message)
+	for _, hint := range prunedHints {
+		if strings.Contains(lower, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+var prunedHints = []string{
+	"could not find results for height",
+	"is not available",
+	"is pruned",
+	"height is not available",
+	"lowest height is",
+}
+
+var _ lower_bounds.LowerBoundDetector = (*CosmosLowerBoundDetector)(nil)

--- a/internal/upstreams/lower_bounds/tendermint_bounds/tendermint_lower_bound_detector.go
+++ b/internal/upstreams/lower_bounds/tendermint_bounds/tendermint_lower_bound_detector.go
@@ -1,0 +1,67 @@
+package tendermint_bounds
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/lower_bounds"
+	"github.com/drpcorg/nodecore/pkg/chains"
+)
+
+const tendermintLowerBoundPeriod = 3 * time.Minute
+
+type TendermintLowerBoundDetector struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           chains.Chain
+	internalTimeout time.Duration
+}
+
+func NewTendermintLowerBoundDetector(
+	upstreamId string,
+	chain chains.Chain,
+	internalTimeout time.Duration,
+	connector connectors.ApiConnector,
+) *TendermintLowerBoundDetector {
+	return &TendermintLowerBoundDetector{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (t *TendermintLowerBoundDetector) DetectLowerBound(ctx context.Context) ([]protocol.LowerBoundData, error) {
+	ctx, cancel := context.WithTimeout(ctx, t.internalTimeout)
+	defer cancel()
+
+	status, err := specific_helpers.FetchTendermintStatus(ctx, t.connector, t.chain)
+	if err != nil {
+		return nil, err
+	}
+	bound, err := specific_helpers.ParseDecimalHeight(status.SyncInfo.EarliestBlockHeight)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"tendermint upstream '%s' returned an unparseable earliest_block_height '%s': %w",
+			t.upstreamId, status.SyncInfo.EarliestBlockHeight, err,
+		)
+	}
+
+	return []protocol.LowerBoundData{
+		protocol.NewLowerBoundDataNow(int64(bound), protocol.StateBound),
+	}, nil
+}
+
+func (t *TendermintLowerBoundDetector) SupportedTypes() []protocol.LowerBoundType {
+	return []protocol.LowerBoundType{protocol.StateBound}
+}
+
+func (t *TendermintLowerBoundDetector) Period() time.Duration {
+	return tendermintLowerBoundPeriod
+}
+
+var _ lower_bounds.LowerBoundDetector = (*TendermintLowerBoundDetector)(nil)

--- a/internal/upstreams/upstream_factory.go
+++ b/internal/upstreams/upstream_factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/aztec_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/beacon_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/bitcoin_specific"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/cosmos_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/evm_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/near_specific"
 	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/solana_specific"
@@ -143,6 +144,8 @@ func createConnector(
 			return nil, err
 		}
 		return connectors.NewWsConnector(wsProcessor), nil
+	case specs.TendermintConnector:
+		return connectors.NewHttpConnector(connectorConfig, specs.TendermintConnector, torProxyUrl, upId)
 	case specs.RestConnector:
 		return connectors.NewHttpConnector(connectorConfig, specs.RestConnector, torProxyUrl, upId)
 	case specs.RestIndexer:
@@ -284,6 +287,15 @@ func getChainSpecific(
 			conf.PollInterval,
 			conf.Options,
 		), nil
+	case chains.Cosmos:
+		return cosmos_specific.NewCosmosSpecific(
+			ctx,
+			conf.Id,
+			upstreamConnectorsInfo.internalRequestConnector,
+			configuredChain,
+			conf.PollInterval,
+			conf.Options,
+		)
 	case chains.Starknet:
 		return starknet_specific.NewStarknetChainSpecificObject(
 			ctx,

--- a/internal/upstreams/validations/cosmos_validations/cosmos_chain_validator.go
+++ b/internal/upstreams/validations/cosmos_validations/cosmos_chain_validator.go
@@ -1,0 +1,61 @@
+package cosmos_validations
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+type CosmosChainValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           *chains.ConfiguredChain
+	internalTimeout time.Duration
+}
+
+func NewCosmosChainValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+) *CosmosChainValidator {
+	return &CosmosChainValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (c *CosmosChainValidator) Validate() validations.ValidationSettingResult {
+	expected := strings.TrimSpace(c.chain.ChainId)
+	if expected == "" {
+		return validations.Valid
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.internalTimeout)
+	defer cancel()
+
+	nodeInfo, err := specific_helpers.FetchCosmosNodeInfo(ctx, c.connector, c.chain.Chain)
+	if err != nil {
+		log.Error().Err(err).Msgf("failed to fetch the cosmos node_info for upstream '%s'", c.upstreamId)
+		return validations.SettingsError
+	}
+	if strings.EqualFold(nodeInfo.DefaultNodeInfo.Network, expected) {
+		return validations.Valid
+	}
+
+	log.Error().Msgf(
+		"'%s' is configured with chain-id '%s' but cosmos upstream '%s' reports network '%s'",
+		c.chain.Chain.String(), expected, c.upstreamId, nodeInfo.DefaultNodeInfo.Network,
+	)
+	return validations.FatalSettingError
+}
+
+var _ validations.SettingsValidator = (*CosmosChainValidator)(nil)

--- a/internal/upstreams/validations/cosmos_validations/cosmos_health_validator.go
+++ b/internal/upstreams/validations/cosmos_validations/cosmos_health_validator.go
@@ -1,0 +1,51 @@
+package cosmos_validations
+
+import (
+	"context"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+type CosmosSyncingValidator struct {
+	upstreamId      string
+	chain           chains.Chain
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+}
+
+func NewCosmosSyncingValidator(
+	upstreamId string,
+	chain chains.Chain,
+	connector connectors.ApiConnector,
+	internalTimeout time.Duration,
+) *CosmosSyncingValidator {
+	return &CosmosSyncingValidator{
+		upstreamId:      upstreamId,
+		chain:           chain,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (c *CosmosSyncingValidator) Validate() protocol.AvailabilityStatus {
+	ctx, cancel := context.WithTimeout(context.Background(), c.internalTimeout)
+	defer cancel()
+
+	syncing, err := specific_helpers.FetchCosmosSyncing(ctx, c.connector, c.chain)
+	if err != nil {
+		log.Error().Err(err).Msgf("unable to get the syncing state of upstream '%s'", c.upstreamId)
+		return protocol.Unavailable
+	}
+	if syncing {
+		return protocol.Syncing
+	}
+	return protocol.Available
+}
+
+var _ validations.HealthValidator = (*CosmosSyncingValidator)(nil)

--- a/internal/upstreams/validations/tendermint_validations/tendermint_chain_validator.go
+++ b/internal/upstreams/validations/tendermint_validations/tendermint_chain_validator.go
@@ -1,0 +1,61 @@
+package tendermint_validations
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+type TendermintChainValidator struct {
+	upstreamId      string
+	connector       connectors.ApiConnector
+	chain           *chains.ConfiguredChain
+	internalTimeout time.Duration
+}
+
+func NewTendermintChainValidator(
+	upstreamId string,
+	connector connectors.ApiConnector,
+	chain *chains.ConfiguredChain,
+	internalTimeout time.Duration,
+) *TendermintChainValidator {
+	return &TendermintChainValidator{
+		upstreamId:      upstreamId,
+		connector:       connector,
+		chain:           chain,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (t *TendermintChainValidator) Validate() validations.ValidationSettingResult {
+	expected := strings.TrimSpace(t.chain.ChainId)
+	if expected == "" {
+		return validations.Valid
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), t.internalTimeout)
+	defer cancel()
+
+	status, err := specific_helpers.FetchTendermintStatus(ctx, t.connector, t.chain.Chain)
+	if err != nil {
+		log.Error().Err(err).Msgf("failed to fetch the tendermint status for upstream '%s'", t.upstreamId)
+		return validations.SettingsError
+	}
+	if strings.EqualFold(status.NodeInfo.Network, expected) {
+		return validations.Valid
+	}
+
+	log.Error().Msgf(
+		"'%s' is configured with chain-id '%s' but tendermint upstream '%s' reports network '%s'",
+		t.chain.Chain.String(), expected, t.upstreamId, status.NodeInfo.Network,
+	)
+	return validations.FatalSettingError
+}
+
+var _ validations.SettingsValidator = (*TendermintChainValidator)(nil)

--- a/internal/upstreams/validations/tendermint_validations/tendermint_health_validator.go
+++ b/internal/upstreams/validations/tendermint_validations/tendermint_health_validator.go
@@ -1,0 +1,110 @@
+package tendermint_validations
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/chains_specific/specific_helpers"
+	"github.com/drpcorg/nodecore/internal/upstreams/connectors"
+	"github.com/drpcorg/nodecore/internal/upstreams/validations"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/rs/zerolog/log"
+)
+
+type TendermintSyncingValidator struct {
+	upstreamId      string
+	chain           chains.Chain
+	connector       connectors.ApiConnector
+	internalTimeout time.Duration
+}
+
+func NewTendermintSyncingValidator(
+	upstreamId string,
+	chain chains.Chain,
+	connector connectors.ApiConnector,
+	internalTimeout time.Duration,
+) *TendermintSyncingValidator {
+	return &TendermintSyncingValidator{
+		upstreamId:      upstreamId,
+		chain:           chain,
+		connector:       connector,
+		internalTimeout: internalTimeout,
+	}
+}
+
+func (t *TendermintSyncingValidator) Validate() protocol.AvailabilityStatus {
+	ctx, cancel := context.WithTimeout(context.Background(), t.internalTimeout)
+	defer cancel()
+
+	status, err := specific_helpers.FetchTendermintStatus(ctx, t.connector, t.chain)
+	if err != nil {
+		log.Error().Err(err).Msgf("unable to get the status of upstream '%s'", t.upstreamId)
+		return protocol.Unavailable
+	}
+	if status.SyncInfo.CatchingUp {
+		return protocol.Syncing
+	}
+	return protocol.Available
+}
+
+type TendermintPeersValidator struct {
+	upstreamId string
+	chain      chains.Chain
+	connector  connectors.ApiConnector
+	options    *chains.Options
+}
+
+func NewTendermintPeersValidator(
+	upstreamId string,
+	chain chains.Chain,
+	connector connectors.ApiConnector,
+	options *chains.Options,
+) *TendermintPeersValidator {
+	return &TendermintPeersValidator{
+		upstreamId: upstreamId,
+		chain:      chain,
+		connector:  connector,
+		options:    options,
+	}
+}
+
+func (t *TendermintPeersValidator) Validate() protocol.AvailabilityStatus {
+	ctx, cancel := context.WithTimeout(context.Background(), t.options.InternalTimeout)
+	defer cancel()
+
+	raw, err := specific_helpers.TendermintCall(
+		ctx, t.connector, t.chain, "net_info", nil,
+	)
+	if err != nil {
+		log.Error().Err(err).Msgf("unable to get net_info of upstream '%s'", t.upstreamId)
+		return protocol.Unavailable
+	}
+
+	var parsed struct {
+		NPeers string `json:"n_peers"`
+	}
+	if err := sonic.Unmarshal(raw, &parsed); err != nil {
+		log.Error().
+			Err(err).
+			Msgf("unable to unmarshal net_info of upstream '%s', response - %s", t.upstreamId, string(raw))
+		return protocol.Unavailable
+	}
+	peers, err := strconv.ParseInt(parsed.NPeers, 10, 64)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Msgf("unable to parse n_peers of upstream '%s', response - %s", t.upstreamId, string(raw))
+		return protocol.Unavailable
+	}
+
+	if peers < t.options.MinPeers {
+		return protocol.Immature
+	}
+	return protocol.Available
+}
+
+var _ validations.HealthValidator = (*TendermintSyncingValidator)(nil)
+var _ validations.HealthValidator = (*TendermintPeersValidator)(nil)

--- a/pkg/chains/chains.go
+++ b/pkg/chains/chains.go
@@ -363,6 +363,8 @@ func getMethodSpecName(blockchainType BlockchainType, methodSpecName string) str
 		return "starknet"
 	case Ton:
 		return "ton"
+	case Cosmos:
+		return "cosmos"
 	}
 
 	return ""

--- a/pkg/chains/cosmos_chains_test.go
+++ b/pkg/chains/cosmos_chains_test.go
@@ -1,0 +1,38 @@
+package chains
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Every cosmos-family chain shares one method spec: the CometBFT RPC and the
+// SDK LCD are the same on all of them, so none of them sets method-spec in
+// chains.yaml and the blockchain type supplies the default.
+func TestCosmosChainsResolveTheCosmosMethodSpec(t *testing.T) {
+	shortNames := []string{
+		"cosmos-hub", "cosmos-hub-testnet",
+		"axelar", "osmosis", "neutron", "babylon",
+		"agoric", "coreum", "fetch-ai", "provenance",
+		"initia", "injective", "mantra",
+	}
+	for _, shortName := range shortNames {
+		chain := GetChain(shortName)
+		assert.NotEqual(t, UnknownChain, chain, shortName)
+		assert.Equal(t, Cosmos, chain.Type, shortName)
+		assert.Equal(t, "cosmos", chain.MethodSpec, shortName)
+	}
+}
+
+// Cosmos chain ids are opaque strings, not hex numbers - the chain validators
+// compare them literally rather than parsing them.
+func TestCosmosChainIdsAreOpaqueStrings(t *testing.T) {
+	assert.Equal(t, "cosmoshub-4", GetChain("cosmos-hub").ChainId)
+	assert.Equal(t, "osmosis-1", GetChain("osmosis").ChainId)
+	assert.Equal(t, "injective-1", GetChain("injective").ChainId)
+}
+
+func TestCosmosBlockchainTypeIsValid(t *testing.T) {
+	assert.True(t, IsValidBlockchainType("cosmos"))
+	assert.Equal(t, "cosmos", GetMethodSpecNameByChain(COSMOS_HUB))
+}

--- a/pkg/methods/cosmos_spec_test.go
+++ b/pkg/methods/cosmos_spec_test.go
@@ -1,0 +1,146 @@
+package specs_test
+
+import (
+	"strings"
+	"testing"
+
+	specs "github.com/drpcorg/nodecore/pkg/methods"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTendermintApiConnectorType(t *testing.T) {
+	assert.Equal(t, specs.TendermintConnector, specs.GetApiConnectorType("tendermint"))
+	assert.Equal(t, "tendermint", specs.TendermintConnector.String())
+	assert.NoError(t, specs.ValidateApiConnectorType("tendermint"))
+	assert.False(t, specs.IsAdditionalApiConnectorType(specs.TendermintConnector))
+	assert.Contains(t, specs.GetPlainApiConnectorType(), specs.TendermintConnector)
+}
+
+// The tendermint connector must win over rest when both are configured, so it
+// is the one that drives head/health/labels/lower-bound accounting.
+func TestTendermintIsPreferredOverRest(t *testing.T) {
+	assert.Less(t, specs.TendermintConnector, specs.RestConnector)
+	assert.Less(t, specs.JsonRpcConnector, specs.TendermintConnector)
+}
+
+func TestCosmosBundleCarriesBothConnectorFamilies(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	assert.ElementsMatch(t,
+		[]specs.ApiConnectorType{specs.TendermintConnector, specs.RestConnector},
+		specs.GetSpecConnectors("cosmos"),
+	)
+
+	tendermintOnly := specs.GetSpecMethodsByConnectors("cosmos", []specs.ApiConnectorType{specs.TendermintConnector})
+	require.NotNil(t, tendermintOnly)
+	tendermintMethods := tendermintOnly[specs.DefaultMethodGroup]
+	assert.Contains(t, tendermintMethods, "status")
+	assert.Contains(t, tendermintMethods, "GET#/status")
+	assert.NotContains(t, tendermintMethods, "GET#/cosmos/bank/v1beta1/params")
+
+	restOnly := specs.GetSpecMethodsByConnectors("cosmos", []specs.ApiConnectorType{specs.RestConnector})
+	require.NotNil(t, restOnly)
+	restMethods := restOnly[specs.DefaultMethodGroup]
+	assert.Contains(t, restMethods, "GET#/cosmos/bank/v1beta1/params")
+	assert.NotContains(t, restMethods, "status")
+}
+
+// Every tendermint method is reachable both as a JSON-RPC name and as a URI
+// call, because CometBFT serves both shapes on the same port.
+func TestTendermintMethodsAreDeclaredInBothShapes(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	groups := specs.GetSpecMethodsByConnectors("cosmos-tendermint", []specs.ApiConnectorType{specs.TendermintConnector})
+	require.NotNil(t, groups)
+	methods := groups[specs.DefaultMethodGroup]
+	require.NotEmpty(t, methods)
+
+	for name := range methods {
+		if strings.HasPrefix(name, "GET#/") {
+			assert.Contains(t, methods, strings.TrimPrefix(name, "GET#/"), "json-rpc twin of %s", name)
+			continue
+		}
+		assert.Contains(t, methods, "GET#/"+name, "rest twin of %s", name)
+	}
+}
+
+func TestCosmosMethodsAreNotCacheable(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	for _, connectorType := range []specs.ApiConnectorType{specs.TendermintConnector, specs.RestConnector} {
+		groups := specs.GetSpecMethodsByConnectors("cosmos", []specs.ApiConnectorType{connectorType})
+		require.NotEmpty(t, groups[specs.DefaultMethodGroup], "methods for %s", connectorType)
+		for name, method := range groups[specs.DefaultMethodGroup] {
+			assert.False(t, method.IsCacheable(), "%s must not be cacheable", name)
+		}
+	}
+}
+
+// The broadcast group exists so an operator can disable transaction
+// submission as a set. Fan-out is deliberately not declared on the tendermint
+// side yet, so those methods must carry no dispatch policy.
+func TestCosmosBroadcastGroup(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	broadcastGroup := specs.GetSpecMethodsByConnectors("cosmos", nil)["broadcast"]
+	assert.Len(t, broadcastGroup, 9)
+
+	for _, name := range []string{
+		"broadcast_tx_sync", "broadcast_tx_async", "broadcast_tx_commit", "broadcast_evidence",
+		"GET#/broadcast_tx_sync", "GET#/broadcast_tx_async", "GET#/broadcast_tx_commit", "GET#/broadcast_evidence",
+	} {
+		method := specs.GetSpecMethod("cosmos", name)
+		require.NotNil(t, method, name)
+		assert.Contains(t, broadcastGroup, name)
+		assert.False(t, method.IsBroadcastDispatch(), "%s must not declare a dispatch policy", name)
+	}
+}
+
+// dump_consensus_state / consensus_state leak validator-level detail, so they
+// ship declared-but-disabled (dshackle marks them "not safe").
+func TestCosmosUnsafeMethodsAreDisabled(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	for _, name := range []string{
+		"dump_consensus_state", "consensus_state",
+		"GET#/dump_consensus_state", "GET#/consensus_state",
+	} {
+		assert.Nil(t, specs.GetSpecMethod("cosmos", name), "%s must not be enabled by default", name)
+	}
+}
+
+func TestCosmosRestPathMatching(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+
+	cases := []struct {
+		path         string
+		wantTemplate string
+		wantParams   []string
+	}{
+		// tendermint URI calls sit at the root
+		{"GET#/status", "GET#/status", nil},
+		{"GET#/block", "GET#/block", nil},
+		{"GET#/abci_query", "GET#/abci_query", nil},
+		// cosmos LCD routes
+		{"GET#/cosmos/base/tendermint/v1beta1/blocks/latest", "GET#/cosmos/base/tendermint/v1beta1/blocks/latest", nil},
+		{"GET#/cosmos/base/tendermint/v1beta1/blocks/25000000", "GET#/cosmos/base/tendermint/v1beta1/blocks/*", []string{"25000000"}},
+		{"GET#/cosmos/bank/v1beta1/balances/cosmos1abc", "GET#/cosmos/bank/v1beta1/balances/*", []string{"cosmos1abc"}},
+		{"GET#/cosmos/bank/v1beta1/balances/cosmos1abc/by_denom", "GET#/cosmos/bank/v1beta1/balances/*/by_denom", []string{"cosmos1abc"}},
+		{"GET#/cosmos/staking/v1beta1/validators/cosmosvaloper1x/delegations/cosmos1y/unbonding_delegation", "GET#/cosmos/staking/v1beta1/validators/*/delegations/*/unbonding_delegation", []string{"cosmosvaloper1x", "cosmos1y"}},
+		{"POST#/cosmos/tx/v1beta1/txs", "POST#/cosmos/tx/v1beta1/txs", nil},
+		{"GET#/cosmos/tx/v1beta1/txs/ABCDEF", "GET#/cosmos/tx/v1beta1/txs/*", []string{"ABCDEF"}},
+		{"GET#/cosmos/tx/v1beta1/txs/block/123", "GET#/cosmos/tx/v1beta1/txs/block/*", []string{"123"}},
+		// literal segments win over the wildcard sibling
+		{"GET#/cosmwasm/wasm/v1/contract/build_address", "GET#/cosmwasm/wasm/v1/contract/build_address", nil},
+		{"GET#/cosmwasm/wasm/v1/contract/cosmos1c", "GET#/cosmwasm/wasm/v1/contract/*", []string{"cosmos1c"}},
+		{"GET#/cosmwasm/wasm/v1/contract/cosmos1c/smart/eyJhIjoxfQ==", "GET#/cosmwasm/wasm/v1/contract/*/smart/*", []string{"cosmos1c", "eyJhIjoxfQ=="}},
+		{"GET#/ibc/core/channel/v1/channels/channel-0/ports/transfer/packet_commitments/7/unreceived_acks", "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_commitments/*/unreceived_acks", []string{"channel-0", "transfer", "7"}},
+	}
+	for _, c := range cases {
+		template, params, ok := specs.MatchRestMethod("cosmos", c.path)
+		assert.True(t, ok, "expected %s to match", c.path)
+		assert.Equal(t, c.wantTemplate, template, "template for %s", c.path)
+		assert.Equal(t, c.wantParams, params, "params for %s", c.path)
+	}
+}

--- a/pkg/methods/data.go
+++ b/pkg/methods/data.go
@@ -226,9 +226,14 @@ func GetSpecType(name string) SpecType {
 
 type ApiConnectorType int
 
+// The declaration order is significant: GetBestConnector picks the lowest
+// value in default mode ("simplest") and the highest in strict mode ("most
+// capable"), and that choice becomes both the head connector and the
+// internal-request connector.
 const (
 	UnknownType ApiConnectorType = iota
 	JsonRpcConnector
+	TendermintConnector // Tendermint/CometBFT RPC - the same methods over JSON-RPC (POST /) and URI calls (GET /<method>)
 	RestConnector
 	RestIndexer // a self-contained indexer REST API next to the node API (e.g. the TON v3 indexer); a plain type - may be an upstream's only connector
 	GrpcConnector
@@ -252,12 +257,15 @@ func (a ApiConnectorType) String() string {
 		return "rest-indexer"
 	case RestAdditional:
 		return "rest-additional"
+	case TendermintConnector:
+		return "tendermint"
 	}
 	return ""
 }
 
 var apiConnectors = map[string]ApiConnectorType{
 	"json-rpc":        JsonRpcConnector,
+	"tendermint":      TendermintConnector,
 	"rest":            RestConnector,
 	"grpc":            GrpcConnector,
 	"websocket":       WebsocketConnector,
@@ -266,6 +274,7 @@ var apiConnectors = map[string]ApiConnectorType{
 }
 var plainApiConnectorTypes = []ApiConnectorType{
 	JsonRpcConnector,
+	TendermintConnector,
 	RestConnector,
 	GrpcConnector,
 	WebsocketConnector,

--- a/pkg/methods/specs/cosmos-rest.json
+++ b/pkg/methods/specs/cosmos-rest.json
@@ -1,0 +1,1242 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Cosmos SDK LCD REST methods",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "cosmos-rest",
+    "api-connectors": [
+      "rest"
+    ],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/node_info",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/syncing",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/blocks/latest",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/blocks/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/validatorsets/latest",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/validatorsets/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/tendermint/v1beta1/abci_query",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/node/v1beta1/config",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/base/node/v1beta1/status",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/tx/v1beta1/txs",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/txs",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/tx/v1beta1/txs/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/tx/v1beta1/txs/block/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/simulate",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/decode",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/encode",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/decode/amino",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/cosmos/tx/v1beta1/encode/amino",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/accounts",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/accounts/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/account_info/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/address_by_id/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/module_accounts",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/module_accounts/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/bech32",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/auth/v1beta1/bech32/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/authz/v1beta1/grants",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/authz/v1beta1/grants/granter/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/authz/v1beta1/grants/grantee/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/balances/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/balances/*/by_denom",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/spendable_balances/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/spendable_balances/*/by_denom",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/supply",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/supply/by_denom",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/denoms_metadata",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/denoms_metadata/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/denoms_metadata_by_query_string",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/denom_owners/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/denom_owners_by_query",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/bank/v1beta1/send_enabled",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/circuit/v1/accounts",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/circuit/v1/accounts/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/circuit/v1/disable_list",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/consensus/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/community_pool",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/validators/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/validators/*/commission",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/validators/*/outstanding_rewards",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/validators/*/slashes",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/delegators/*/rewards",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/delegators/*/rewards/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/delegators/*/validators",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/distribution/v1beta1/delegators/*/withdraw_address",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/evidence/v1beta1/evidence",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/evidence/v1beta1/evidence/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/feegrant/v1beta1/allowance/*/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/feegrant/v1beta1/allowances/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/feegrant/v1beta1/issued/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/constitution",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/params/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*/deposits",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*/deposits/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*/tally",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*/votes",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1/proposals/*/votes/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/params/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*/deposits",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*/deposits/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*/tally",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*/votes",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/gov/v1beta1/proposals/*/votes/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/groups",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/group_info/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/group_members/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/group_policy_info/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/group_policies_by_group/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/group_policies_by_admin/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/groups_by_admin/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/groups_by_member/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/proposal/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/proposals_by_group_policy/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/tally_result/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/vote_by_proposal_voter/*/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/votes_by_proposal/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/group/v1/votes_by_voter/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/mint/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/mint/v1beta1/inflation",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/mint/v1beta1/annual_provisions",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/balance/*/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/owner/*/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/supply/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/nfts",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/nfts/*/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/classes",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/nft/v1beta1/classes/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/params/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/params/v1beta1/subspaces",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/slashing/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/slashing/v1beta1/signing_infos",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/slashing/v1beta1/signing_infos/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/pool",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/historical_info/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/delegations/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/delegators/*/redelegations",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/delegators/*/unbonding_delegations",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/delegators/*/validators",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/delegators/*/validators/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators/*/delegations",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators/*/delegations/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators/*/delegations/*/unbonding_delegation",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/staking/v1beta1/validators/*/unbonding_delegations",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/upgrade/v1beta1/authority",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/upgrade/v1beta1/current_plan",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/upgrade/v1beta1/applied_plan/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/upgrade/v1beta1/module_versions",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmos/upgrade/v1beta1/upgraded_consensus_state/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/code",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/code/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/code/*/contracts",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/codes/pinned",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/build_address",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/*/history",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/*/state",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/*/raw/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contract/*/smart/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/cosmwasm/wasm/v1/contracts/creator/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/client_states",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/client_states/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/client_status/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/consensus_states/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/consensus_states/*/heights",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/consensus_states/*/revision/*/height/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/upgraded_client_states",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/client/v1/upgraded_consensus_states",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/connections",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/connections/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/connections/*/client_state",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/connections/*/consensus_state/revision/*/height/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/connection/v1/client_connections/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/client_state",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/consensus_state/revision/*/height/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/next_sequence",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_acks/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_commitments",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_commitments/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_commitments/*/unreceived_acks",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_commitments/*/unreceived_packets",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/channels/*/ports/*/packet_receipts/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/core/channel/v1/connections/*/channels",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denoms",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denoms/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denoms/*/total_escrow",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denom_traces",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denom_traces/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/denom_hashes/*",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/ibc/apps/transfer/v1/channels/*/ports/*/escrow_address",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
+  ]
+}

--- a/pkg/methods/specs/cosmos-tendermint.json
+++ b/pkg/methods/specs/cosmos-tendermint.json
@@ -1,0 +1,424 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Tendermint/CometBFT RPC methods",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "cosmos-tendermint",
+    "api-connectors": [
+      "tendermint"
+    ],
+    "type": "plain"
+  },
+  "methods": [
+    {
+      "name": "health",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/health",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "status",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/status",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "net_info",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/net_info",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "blockchain",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/blockchain",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "block",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/block",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "block_by_hash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/block_by_hash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "block_results",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/block_results",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "header",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/header",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "header_by_hash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/header_by_hash",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "commit",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/commit",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "validators",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/validators",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "consensus_params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/consensus_params",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "genesis",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/genesis",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "genesis_chunked",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/genesis_chunked",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "unconfirmed_txs",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/unconfirmed_txs",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "num_unconfirmed_txs",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/num_unconfirmed_txs",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "tx",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/tx",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "tx_search",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/tx_search",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "block_search",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/block_search",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "check_tx",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/check_tx",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "abci_info",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/abci_info",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "abci_query",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/abci_query",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "broadcast_tx_sync",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/broadcast_tx_sync",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "broadcast_tx_async",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/broadcast_tx_async",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "broadcast_tx_commit",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/broadcast_tx_commit",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "broadcast_evidence",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/broadcast_evidence",
+      "group": "broadcast",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "dump_consensus_state",
+      "group": "unsafe",
+      "enabled": false,
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/dump_consensus_state",
+      "group": "unsafe",
+      "enabled": false,
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "consensus_state",
+      "group": "unsafe",
+      "enabled": false,
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/consensus_state",
+      "group": "unsafe",
+      "enabled": false,
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    }
+  ]
+}

--- a/pkg/methods/specs/cosmos.json
+++ b/pkg/methods/specs/cosmos.json
@@ -1,0 +1,15 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "title": "Cosmos SDK chain methods - Tendermint RPC and LCD REST",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "name": "cosmos",
+    "type": "bundle"
+  },
+  "spec-imports": [
+    "cosmos-tendermint",
+    "cosmos-rest"
+  ]
+}


### PR DESCRIPTION
# Cosmos SDK family support (Tendermint JSON-RPC + Tendermint REST + Cosmos LCD)

## Summary

Adds first-class support for the **Cosmos SDK** chain family (`BlockchainType = "cosmos"`),
covering the 12 `type: cosmos` protocols already registered in `chains.yaml` (cosmos-hub,
axelar, osmosis, neutron, babylon, agoric, coreum, fetchai, provenance, initia, injective,
mantra — 19 networks including testnets).

Clients reach a cosmos node over all three surfaces it actually exposes:

1. **Tendermint/CometBFT RPC as JSON-RPC** — `POST /` `{"method":"status"}` (port 26657)
2. **The same Tendermint methods as URI calls** — `GET /status?…`
3. **The Cosmos SDK LCD** — `GET /cosmos/bank/v1beta1/…` (port 1317)

(1) and (2) are served by a **new `tendermint` connector type**, which is the first connector
whose wire shape is a property of the *request* rather than of the connector.

## Motivation

Before this change a `type: cosmos` upstream **panicked at startup**: `getChainSpecific` had no
`chains.Cosmos` case, and `getMethodSpecName` had no `Cosmos` case, so those chains resolved to
the empty method spec. The registry entries existed, but the family was unusable.

dshackle supports cosmos over the Tendermint JSON-RPC **only**
(`BlockchainType.COSMOS → ApiType.JSON_RPC`, 24 methods in `DefaultCosmosMethods`) — it can
serve neither the Tendermint URI form nor the LCD. This covers all three.

## What changed

### New `tendermint` connector type

CometBFT serves an identical method set as JSON-RPC on `POST /` and as URI calls on
`GET /<method>?<args>`, both answering with the same `{"jsonrpc":…,"result":…}` envelope. So the
connector forwards a request in whichever shape it arrived:

```go
case specs.TendermintConnector:
	if request.RequestType() == protocol.JsonRpc {
		return h.sendJsonRpc(ctx, request)
	}
	return h.sendRest(ctx, request)
```

Nothing else in `HttpConnector` changes — `sendRest` already builds `GET /status` from the
`GET#/status` template, and `sendJsonRpc` already POSTs the body verbatim to the endpoint root.

`TendermintConnector` is inserted **between** `JsonRpcConnector` and `RestConnector` in the
`ApiConnectorType` iota. The order is load-bearing: `GetBestConnector(DefaultMode)` takes the
minimum, so on an upstream carrying both cosmos APIs the tendermint one wins the head /
internal-request role. The enum values are never serialized, so inserting mid-enum is safe.

### Method specs

- `cosmos-tendermint` (plain, `api-connectors: ["tendermint"]`) — **28 methods × 2 shapes = 56
  entries**. Each method is declared twice, `status` *and* `GET#/status`. This needs **zero
  framework change**: `buildRestMatcher` already keys REST routing off the `#` in a method name
  and JSON-RPC resolution is exact-name, so each form carries its own name to the connector and
  no cross-mapping is needed. The set is dshackle's 24, plus `header` / `header_by_hash`
  (CometBFT ≥ 0.35, which dshackle's list predates), plus `dump_consensus_state` /
  `consensus_state` shipped `"enabled": false` — dshackle marks those two "not safe", and
  declaring them disabled documents the decision while letting an operator opt in via
  `methods.enable`.
- `cosmos-rest` (plain, `api-connectors: ["rest"]`) — **175 routes**: every standard SDK module
  plus CosmWasm and IBC. Chain-specific modules (`osmosis/*`, `injective/*`,
  interchain-security) are deliberately not declared.
- `cosmos` (bundle) — imports both. The two share no method names: tendermint URI paths live at
  the root (`/status`, `/block`) while LCD routes are namespaced (`/cosmos/*`, `/cosmwasm/*`,
  `/ibc/*`), so there is no collision in the shared path matcher.

The four `broadcast_*` methods sit in a `broadcast` group so transaction submission can be
toggled as a set. No method declares a `dispatch` policy — dshackle gives the broadcast methods
`BroadcastQuorum`, but fan-out for cosmos is deferred.

### Chain specifics

`tendermint_specific.TendermintChainSpecific` gets its **own package**, because the CometBFT
consensus API is shared by every Cosmos SDK chain *and* by non-SDK CometBFT chains (BeaconKit,
Heimdall), independently of whether an LCD sits next to it. All its internal probes go out as
JSON-RPC so the shared `parseJsonRpcBody` path unwraps CometBFT's `result` envelope.

`cosmos_specific.NewCosmosSpecific` is the complex specific, dispatching on the primary
connector exactly like `NewTronSpecific`: `tendermint` → `TendermintChainSpecific`, `rest` →
`CosmosRestSpecific`, anything else → error.

| Signal | `tendermint` | `rest` (LCD) |
|---|---|---|
| Head | `block` (no height ⇒ latest) | `blocks/latest` |
| Finalized | = head (CometBFT commits are final) | = head |
| Safe | n/a — safe detection disabled | n/a |
| Syncing | `status` → `sync_info.catching_up` | `GET /…/syncing` |
| Peers | `net_info` → `n_peers` (a decimal *string*) | not exposed |
| Chain validation | `status` → `node_info.network` | `default_node_info.network` |
| Lower bound | `status` → `earliest_block_height`, one call | binary search over `blocks/{height}` |
| Labels | `client_type=cosmos`, CometBFT version | `client_type=cosmos`, SDK app version |

The syncing validator improves on dshackle, which calls `health` and ignores the payload: it
reads the node's own `catching_up` flag.

### Supporting packages

`internal/upstreams/chains_specific/specific_helpers/` holds the shared request/response
plumbing — LCD route templates, the wire DTOs both families unmarshal into, and the fetch/parse
helpers. It is its own package because the specifics, validators, label detectors and
lower-bound detectors all call it; a `validations` package should hold validators, not transport
helpers for three other subtrees. Alongside it: `{tendermint,cosmos}_validations`,
`{tendermint,cosmos}_labels`, `{tendermint,cosmos}_bounds`.

## Config

```yaml
# Normal deployment: both APIs of one node on one upstream
upstreams:
  - id: cosmos-hub-node
    chain: cosmos-hub
    connectors:
      - type: tendermint
        url: http://cosmos-node:26657
      - type: rest
        url: http://cosmos-node:1317

# LCD-only (a provider that exposes 1317 but not 26657)
  - id: cosmos-hub-lcd
    chain: cosmos-hub
    connectors:
      - type: rest
        url: https://cosmos-rest.example.com
```

Unlike TON's two APIs, 26657 and 1317 are served by the **same process over the same store**, so
they share a head and a retention window. Both connectors on one upstream is the *normal*
deployment, not a degraded one — **no warning is logged** (TON logs one). Each upstream only
advertises the methods its connector types carry, so a tendermint method sent to an LCD-only
upstream is rejected with `-32601` rather than misrouted.

## Notes / impact

- **Nothing is cacheable.** Every cosmos method ships `cacheable: false`, for two independent
  reasons: the LCD selects historical state with the **`x-cosmos-block-height` header**, which
  `calculateRestHash` deliberately excludes from the cache key (a cached balance would be served
  to a request asking for a different height); and CometBFT's `height` argument is **optional**
  (omitted ⇒ latest), which no tag parser detects, so caching `block` would pin a stale head.
  Enabling caching later needs a decimal-height `ParserReturnType` (`isHexNumberOrTag` accepts
  only `0x…` or an EVM tag) and header-aware REST hashing — both in shared code used by every
  chain, so they are out of this diff.
- **Hash encodings agree across the two connectors.** CometBFT renders block hashes as uppercase
  hex, the LCD as base64. `blockchain.NewHashIdFromString` tries hex then base64, and a 32-byte
  base64 hash is 44 chars ending in `=` which cannot hex-decode — so both reduce to the same
  bytes and a tendermint-driven and an LCD-driven upstream of the same chain report the same head
  hash. Covered by an explicit test.
- **Chain validation is strict.** Any non-match — including an empty `network` — is a
  `FatalSettingError`. Settings validation runs synchronously before an upstream starts, so an
  upstream that answers the probe but cannot say which chain it serves is refused at startup
  rather than retried on the next tick.
- **Head tracking is poll-only.** CometBFT's `/websocket` `tm.event` subscriptions are not used
  (dshackle leaves its `NewBlockHeader` subscription commented out too).
- **`type: eth` cosmos-EVM chains are untouched** (cronos, evmos, haqq, kava, zeta-chain,
  dymension, sei, okt, xrpl, tac, mezo — see `cosmos-nodes.md`). Attaching these connectors to
  those chains is a separate change with a much larger blast radius.

## Docs

- `docs/nodecore/05-upstream-config.md` — the `tendermint` connector type, a **Cosmos
  deployment** section (per-signal table, deployment examples), 9 new rows in **Validators and
  labels**, and cosmos added to the `validate-syncing` / `validate-peers` bullets.
- `docs/nodecore/11-method-specs.md` — `tendermint` in the allowed `api-connectors`, a
  **dual-shape methods** section explaining the two-entries-per-method convention, and the spec
  tables.
- `docs/superpowers/specs/2026-07-27-cosmos-support-design.md` — design doc, including a
  *Deltas from the original design* section for the points where the shipped code diverges from
  the approved plan.
- `README.md` — Cosmos SDK in the supported-chains and interfaces lists.

## Testing

48 new tests across 6 files (~1.1k lines):

- **Specs** (`pkg/methods/cosmos_spec_test.go`): the `tendermint` connector type parses and
  sorts ahead of `rest`; the `cosmos` bundle exposes both method families and each connector
  projection sees only its own; **every tendermint method is declared in both shapes** (asserted
  by iterating the resolved set, so a half-added method fails); nothing is cacheable; the
  broadcast group has 9 members and declares no dispatch; unsafe methods are off; REST path
  matching, including literal-beats-wildcard (`/contract/build_address` vs `/contract/*`).
- **Specifics** (`tendermint_chain_specific_test.go`, `cosmos_chain_specific_test.go`):
  connector dispatch (incl. rejection paths and nil connector), head/finalized parsing, decimal
  string heights, subscription methods erroring, the validator matrix over
  `validate-syncing` / `validate-peers` / `disable-chain-validation`, `n_peers` as a string,
  lower bounds (one-call for tendermint, binary search for the LCD), and the
  **hex-vs-base64 hash-agreement invariant**.
- **Connector** (`tendermint_connector_test.go`, `httptest`): a JSON-RPC request POSTs to the
  endpoint root with the body verbatim and the envelope is unwrapped; a REST request GETs
  `/status` with the query passed through; path wildcards expand.
- **Registry / config**: cosmos chains resolve `MethodSpec == "cosmos"`; chain-ids stay opaque
  strings; `type: tendermint` is accepted, is valid as `head-connector`, and beats `rest` as the
  best connector.

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), and `go test -race ./...`
all pass. The two `internal/caches/*_e2e` packages fail in environments without Docker — they
spin up containers in `TestMain` — and fail identically on a clean checkout.

Additionally verified end-to-end against a stub CometBFT + LCD node (the container-based e2e
suite also needs Docker): all three surfaces route; head tracked identically on a
tendermint-driven and an LCD-driven upstream of the same chain; chain validation passes; labels
resolve to `0.38.17` (CometBFT) vs `v21.0.0` (gaia) per connector; the LCD bound search converges
24218821 → … → 24000045 → 24000000; and an LCD-only upstream returns `-32601` for tendermint
methods in both shapes.
