### PR TITLE
fix: detect classic hyperliquid node as hl client type

### DIFF
--- a/internal/upstreams/labels/eth_labels/eth_client_detector.go
+++ b/internal/upstreams/labels/eth_labels/eth_client_detector.go
@@ -14,6 +14,7 @@ import (
 const (
 	UnknownClientVersion = "unknown"
 	DefaultClient        = "default client"
+	HlClientType         = "hl"
 )
 
 var semverLikeRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+`)
@@ -61,6 +62,11 @@ func NewEthClientLabelsDetector(
 }
 
 func (e *EthClientLabelsDetector) clientVersion(client string) string {
+	// The classic HyperLiquid node reports no version at all ("hyperliquid evm Mainnet")
+	if isHlNode(client) {
+		return UnknownClientVersion
+	}
+
 	if i := strings.IndexByte(client, '/'); i != -1 {
 		client = client[i+1:]
 
@@ -98,6 +104,11 @@ func (e *EthClientLabelsDetector) clientType(client string) string {
 		return DefaultClient
 	}
 
+	// The classic HyperLiquid node reports e.g. "hyperliquid evm Mainnet"
+	if isHlNode(client) {
+		return HlClientType
+	}
+
 	// Has a slash — type is everything before it
 	if i := strings.IndexByte(client, '/'); i != -1 {
 		clientPart := client[:i]
@@ -123,6 +134,12 @@ func (e *EthClientLabelsDetector) clientType(client string) string {
 
 func isSemverLike(version string) bool {
 	return semverLikeRe.MatchString(version)
+}
+
+// isHlNode reports whether web3_clientVersion belongs to the classic
+// HyperLiquid node, which answers e.g. "hyperliquid evm Mainnet"
+func isHlNode(client string) bool {
+	return strings.HasPrefix(strings.ToLower(client), "hyperliquid")
 }
 
 var _ labels.ClientLabelsDetector = (*EthClientLabelsDetector)(nil)

--- a/internal/upstreams/labels/eth_labels/eth_client_detector_test.go
+++ b/internal/upstreams/labels/eth_labels/eth_client_detector_test.go
@@ -116,6 +116,18 @@ func TestEthClientLabelsDetectorClientVersionAndType(t *testing.T) {
 			expectedClientType: "nethermind",
 		},
 		{
+			name:               "detects classic hyperliquid node as hl",
+			raw:                "hyperliquid evm Mainnet",
+			expectedVersion:    eth_labels.UnknownClientVersion,
+			expectedClientType: eth_labels.HlClientType,
+		},
+		{
+			name:               "detects classic hyperliquid testnet node as hl",
+			raw:                "Hyperliquid evm Testnet",
+			expectedVersion:    eth_labels.UnknownClientVersion,
+			expectedClientType: eth_labels.HlClientType,
+		},
+		{
 			name:               "falls back to raw dotted version",
 			raw:                "client.build.2024",
 			expectedVersion:    "client.build.2024",


### PR DESCRIPTION
## Problem

The classic HyperLiquid node answers `web3_clientVersion` with:

```
"hyperliquid evm Mainnet"
```

The parser in `clientType()` found no `/` and no `.`, so it fell into the "single word" branch and returned the whole lowercased string as the client type: `client_type: "hyperliquid evm mainnet"`. The version fell through to `unknown` with a warn log on every detection cycle.

reth nodes (`reth/v0.1.0-.../x86_64-unknown-linux-gnu`) were already parsed correctly and are unaffected.

## Fix

- New `isHlNode()` helper: responses prefixed with `hyperliquid` (case-insensitive, covers Mainnet and Testnet) are detected as the classic HL node
- `clientType()` returns `hl` (new `HlClientType` constant) for such responses
- `clientVersion()` returns `unknown` immediately without the warn-log spam (the classic node reports no version at all)

## Testing

- Added mainnet + testnet cases to `TestEthClientLabelsDetectorClientVersionAndType` (verified failing before the fix)
- `go test ./internal/upstreams/labels/...` is green
- Response formats verified against live classic and reth nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)