### PR TITLE
Add missing TON indexer v3 methods

### DIFF
--- a/pkg/methods/methods_spec_test.go
+++ b/pkg/methods/methods_spec_test.go
@@ -286,6 +286,10 @@ func TestTonSpecLoads(t *testing.T) {
 
 	restIndexerMethods := specs.GetSpecMethodsByConnectors("ton", []specs.ApiConnectorType{specs.RestIndexer})
 	assert.Contains(t, restIndexerMethods[specs.DefaultMethodGroup], "GET#/api/v3/masterchainInfo")
+	assert.Contains(t, restIndexerMethods[specs.DefaultMethodGroup], "GET#/api/v3/traces")
+	assert.Contains(t, restIndexerMethods[specs.DefaultMethodGroup], "GET#/api/v3/pendingTraces")
+	assert.Contains(t, restIndexerMethods[specs.DefaultMethodGroup], "GET#/api/v3/multisig/wallets")
+	assert.Contains(t, restIndexerMethods[specs.DefaultMethodGroup], "POST#/api/v3/decode")
 	assert.NotContains(t, restIndexerMethods[specs.DefaultMethodGroup], "GET#/getMasterchainInfo")
 
 	template, params, ok := specs.MatchRestMethod("ton", "GET#/getAddressBalance")

--- a/pkg/methods/specs/ton-index-v3.json
+++ b/pkg/methods/specs/ton-index-v3.json
@@ -48,6 +48,13 @@
       }
     },
     {
+      "name": "GET#/api/v3/traces",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
       "name": "GET#/api/v3/addressInformation",
       "params": [],
       "settings": {
@@ -196,6 +203,83 @@
     },
     {
       "name": "GET#/api/v3/topAccountsByBalance",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/decode",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "POST#/api/v3/decode",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/metadata",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/dns/records",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/multisig/orders",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/multisig/wallets",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/nft/sales",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/pendingActions",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/pendingTraces",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/pendingTransactions",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
+      "name": "GET#/api/v3/vesting",
       "params": [],
       "settings": {
         "cacheable": false


### PR DESCRIPTION
## What

`pkg/methods/specs/ton-index-v3.json` listed 27 of the paths our TON indexer serves. Adds the 12 that were missing:

`traces`, `pendingTraces`, `pendingActions`, `pendingTransactions`, `decode` (GET+POST), `metadata`, `nft/sales`, `vesting`, `dns/records`, `multisig/orders`, `multisig/wallets`

## Why

A path absent from the spec never matches in `MatchRestMethod`, so `rest_parser.go:42` falls through and keeps the raw literal (`GET#/api/v3/traces`) as the method name. `MethodMatcher` admits an upstream only if `state.UpstreamMethods.HasMethod(m.method)`, and upstream method sets are built from the same spec — so no upstream matches and the request is rejected with `method %s is not supported` at upstream selection, before any proxying happens.

## How the list was verified

Not from the swagger — `/doc.json` under-reports. `GET /api/v3/events` is absent from it on both our node and public toncenter, yet answers `200` with data. Two builds both reporting `TON Index (Go) 1.2.6` also expose different path sets (38 vs 49 paths), so version alone proves nothing.

Each candidate was probed directly against `cherry-eu-bcn-02-ton-mainnet-ton-index-v3`. All 12 added paths answer `200` or `422` (missing-required-param); a `500 {"error":"...Cannot GET <path>"}` means the route does not exist.

Deliberately **not** added — documented upstream but `500 Cannot GET` on our node:

- `staking/nominatorPools/*` (6)
- `validators/*` (4)
- `dns/activeAuctions`

Listing them would swap a clean "not supported" for a node-side error. If some indexer in the fleet does have those workers, `methods.enable` on that specific upstream is the better lever than a chain-wide spec entry.

## Notes

- `"params": []` on the new entries is not a field `MethodData` parses — it is dead weight, kept only to match the 27 existing entries in the file. Not cleaned up here to keep the diff scoped.
- No Go changes: the spec set is the source of truth, loaded at startup.

## Test plan

- `make lint` — 0 issues
- `go test ./pkg/methods/... ./internal/server/...` — pass
- Four assertions added to `TestTonSpecLoads` covering a pending path, a nested path and the POST variant
- `make test` also fails on `caches/postgres_e2e` and `caches/redis_e2e` — pre-existing, reproduced on a clean tree without this change
