### PR TITLE
fix: archive detection for chains with late EVM activation

### DIFF
--- a/internal/upstreams/labels/eth_labels/eth_archive_detector.go
+++ b/internal/upstreams/labels/eth_labels/eth_archive_detector.go
@@ -18,6 +18,7 @@ const (
 	ArbitrumNitroBlock   = "0x152DD47"
 	OptimismBedrockBlock = "0x645C277"
 	EvmosGenesisBlock    = "0xe54d"
+	BittensorEvmBlock    = "0x424ED4" // 4345556, first block with EVM runtime (spec 210)
 	EarliestBlock        = "0x2710"
 )
 
@@ -109,6 +110,8 @@ func (e *EthArchiveLabelsDetector) readEarliestBlock() string {
 		return OptimismBedrockBlock
 	case chains.EVMOS:
 		return EvmosGenesisBlock
+	case chains.BITTENSOR:
+		return BittensorEvmBlock
 	default:
 		return EarliestBlock
 	}

--- a/internal/upstreams/labels/eth_labels/eth_archive_detector_test.go
+++ b/internal/upstreams/labels/eth_labels/eth_archive_detector_test.go
@@ -40,6 +40,11 @@ func TestEthArchiveLabelsDetectorDetectLabelsReturnsArchiveLabel(t *testing.T) {
 			chain:         chains.EVMOS,
 			expectedBlock: eth_labels.EvmosGenesisBlock,
 		},
+		{
+			name:          "uses bittensor evm block",
+			chain:         chains.BITTENSOR,
+			expectedBlock: eth_labels.BittensorEvmBlock,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Bittensor got its EVM runtime (spec 210) at finney block 4345556, so state bound 1 is unreachable via detection and the archive probe at block 10000 always fails, leaving true archive nodes marked non-archive.

- eth archive detector: chain-specific earliest block for Bittensor, same as Arbitrum Nitro / Optimism Bedrock
- gold bounds: support block-only STATE gold bound - state present at the gold block reports bound 1 (mirrors the tx/receipts short-circuit)

Mirrors the same fix in dshackle.