### PR TITLE
chore(ci): disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":disableDependencyDashboard"
   ],
   "enabledManagers": [
     "custom.regex"


### PR DESCRIPTION
## What

Adds the `:disableDependencyDashboard` preset to `renovate.json`.

## Why

`config:recommended` pulls in `:dependencyDashboard`, which is why the bot opened #323 right after Renovate was configured in #321. Renovate here manages exactly one dependency — the `golangci-lint` version pin in `.github/workflows/lint.yml`, via the custom regex manager — so a permanently-open dashboard issue is pure noise. Everything else (gomod, docker, github-actions) is handled by Dependabot.

Closing the issue by hand doesn't stick: Renovate calls `ensureIssue()` on every run and reopens it. Disabling it in config is the only way to make it stay closed.

Trade-off: we lose the dashboard's "run Renovate now" checkbox and the ability to resurrect an update PR that was closed without merging. Both are marginal for a single lint-version bump.

Closes #323