### PR TITLE
fix: retry dRPC public endpoint rate limits

### DIFF
--- a/internal/protocol/data_test.go
+++ b/internal/protocol/data_test.go
@@ -32,6 +32,11 @@ func TestIsRetryable(t *testing.T) {
 			response: protocol.NewHttpUpstreamResponse("1", []byte(`{"id":"23r23","jsonrpc":"2.0","error":{"message":"missing trie node","code":2}}`), 200, protocol.JsonRpc),
 		},
 		{
+			name:     "base response with dRPC public endpoint rate limit error",
+			expected: true,
+			response: protocol.NewHttpUpstreamResponse("1", []byte(`{"id":1,"jsonrpc":"2.0","error":{"message":"You reached Public endpoint rate limit, please upgrade to paid plan","code":15}}`), 200, protocol.JsonRpc),
+		},
+		{
 			name:     "reply error with TotalFailure",
 			expected: false,
 			response: protocol.NewReplyError("1", nil, protocol.JsonRpc, protocol.TotalFailure),

--- a/pkg/errors_config/errors.yaml
+++ b/pkg/errors_config/errors.yaml
@@ -122,6 +122,7 @@ retryable-errors:
   - str: server shutting down
   - str: <!DOCTYPE html>
   - str: Public RPC Rate Limit Hit
+  - str: Public endpoint rate limit
   - str: the containing module is disabled
   - str: historical state not available
   - str: node does not have console


### PR DESCRIPTION
## Summary

- classify the dRPC `Public endpoint rate limit` response as retryable
- cover the exact live JSON-RPC error message and code with a protocol regression test

## Why

The retry list already recognizes multiple quota variants, including `Public RPC Rate Limit Hit`, but matching is case-sensitive and does not cover dRPC public endpoints returning `You reached Public endpoint rate limit, please upgrade to paid plan` with error code 15. NodeCore therefore returns that provider error instead of retrying another upstream.

The added fragment is deliberately vendor-specific and narrower than a generic `rate limit` match.

## Validation

- `make generate-networks`
- `go test ./internal/protocol ./pkg/errors_config`
- all non-integration Go packages passed (`postgres_e2e` and `redis_e2e` excluded because they require local service containers)