### PR TITLE
feat: add getchaintips method for Bitcoin

### DIFF
--- a/pkg/methods/specs/bitcoin-json-rpc.json
+++ b/pkg/methods/specs/bitcoin-json-rpc.json
@@ -107,6 +107,13 @@
       }
     },
     {
+      "name": "getchaintips",
+      "params": [],
+      "settings": {
+        "cacheable": false
+      }
+    },
+    {
       "name": "getconnectioncount",
       "params": [],
       "settings": {


### PR DESCRIPTION
Adds `getchaintips` to the `bitcoin-json-rpc` method spec.

- `cacheable: false` — the response changes with every new block or reorg, same as `getblockchaininfo` / `getbestblockhash`.
- No routing special-casing: not a head-verified method and not a rewrite alias, so it goes through as a plain passthrough.
- Nothing to add in `pkg/chains/public` — that submodule only carries networks/meta and per-client `excluded-methods`; `getchaintips` is supported by Bitcoin Core and forks, so there is nothing to exclude.

`go test ./pkg/methods/...` passes.