### PR TITLE
Support grpc requests in NativeCall

### DIFF
--- a/docs/superpowers/specs/2026-08-28-native-call-grpc-items-design.md
+++ b/docs/superpowers/specs/2026-08-28-native-call-grpc-items-design.md
@@ -1,0 +1,178 @@
+# NativeCall gRPC items — design
+
+Date: 2026-08-28. Branch: `grpc-nativecall`.
+
+## Goal
+
+Let a dshackle client send native gRPC calls (Sui `sui.rpc.v2.*` unary methods) to nodecore
+through the existing dshackle `Blockchain.NativeCall` stream, exactly the way it
+already sends JSON-RPC and REST items. Unary only: a gRPC item produces one
+buffered reply item. The traffic path stays bytes-only (see
+`2026-08-19-grpc-support-v1-design.md`, principle 1).
+
+## Out of scope (separate tasks)
+
+- **NativeSubscribe for gRPC server-stream methods** — the emerald server still
+  builds a JSON-RPC envelope there; a gRPC branch is its own task.
+- **Quorum for gRPC** — quorum params are only read from the HTTP query
+  (`http_server.go`, `quorum.ParamsFromQuery`), so quorum is unreachable via
+  NativeCall for every request type today. Enabling it needs a request-side
+  contract (metadata on the ingress, a field/selector on NativeCall), a
+  `protocol.Grpc` case in `flow.hasHttpConnector`, and a QR request-id
+  convention with the drpc signer. Parked.
+- Caching for gRPC (all Sui methods are `cacheable:false`).
+
+## Contract change (`drpcorg/public`, `proto/blockchain.proto`)
+
+```proto
+message NativeCallItem {
+    ...
+    oneof data {
+        bytes payload = 4;
+        RestData rest_data = 8;
+        GrpcData grpc_data = 9;
+    }
+}
+
+// A native gRPC call. method carries the full method name
+// ("/sui.rpc.v2.LedgerService/GetObject").
+message GrpcData {
+    bytes payload = 1;              // serialized request message; no 5-byte wire frame prefix
+    repeated KeyValue metadata = 2; // call metadata to forward to the upstream
+}
+
+message NativeCallReplyItem {
+    ...
+    repeated KeyValue response_headers = 14;  // existing: upstream headers / initial metadata
+    bytes error_as_is = 15;                   // existing
+    repeated KeyValue response_trailers = 16; // NEW: upstream trailers (gRPC only today)
+}
+```
+
+`response_headers` and `response_trailers` are set on both successful and
+failed reply items. Trailers are kept separate because a gRPC client must
+receive trailers as trailers (rate-limit hints etc. live there); folding them
+into headers would be lossy.
+
+The proto edit and the module release are done by hand by the maintainer;
+nodecore then bumps `github.com/drpcorg/public`.
+
+## Reply-item mapping for a gRPC item
+
+### Success
+
+| field | value |
+|---|---|
+| `succeed` | true |
+| `payload` | response message bytes verbatim (`ResponseResult()`) |
+| `chunked` / `final_chunk` | false — `chunk_size` is ignored: a unary gRPC reply is one message and `UpstreamGrpcRequest.IsStream()` is always false |
+| `signature` | as today, over `payload` (`buildReplySignature`) |
+| `upstream_id`, `upstream_node_version`, `finalization` | as today |
+| `response_headers` / `response_trailers` | upstream metadata via the `HasResponseHeaders` / `HasResponseTrailers` capabilities |
+
+### Error
+
+The reply reuses the existing error fields; a gRPC item never fills
+`error_data`.
+
+| field | value |
+|---|---|
+| `succeed` | false |
+| `item_error_code` | a **canonical gRPC code (0–16)**, never `ResponseError.Code` (which is `GrpcErrorCodeBase + code` for upstream statuses, and collides with the canonical range for nodecore's own codes) |
+| `error_message` | the status message |
+| `error_as_is` | serialized `google.rpc.Status` when the upstream attached typed details (`GrpcStatus.StatusProto`); empty otherwise |
+| `response_headers` / `response_trailers` | from the error response when it carries them (`*ReplyError` does for e.g. RESOURCE_EXHAUSTED with rate-limit hints) |
+
+The code/message come from one shared function: `grpcStatusFromResponseError`
+moves from `internal/server/grpc_ingress/chain_ingress.go` into `protocol`
+(exported, e.g. `protocol.GrpcStatusOf(*ResponseError) *status.Status`),
+unchanged in behaviour:
+
+- an upstream `GrpcStatus` in `ResponseError.Data` is replayed verbatim
+  (`status.FromProto` of `StatusProto` when present, else code+message);
+- nodecore's own errors map onto the closed 17-code model
+  (`NoAvailableUpstreams`/`NoApiConnectors` → UNAVAILABLE, `AuthErrorCode` →
+  PERMISSION_DENIED, `ClientErrorCode`/`WrongChain` → INVALID_ARGUMENT,
+  `RequestTimeout`/`CtxErrorCode` → DEADLINE_EXCEEDED, `RateLimitExceeded` →
+  RESOURCE_EXHAUSTED, `NoSupportedMethod` → UNIMPLEMENTED,
+  `SubscribeTotalFailure` → UNAVAILABLE, default INTERNAL).
+
+Result: the client owns no mapping table. For a failed gRPC item it does
+`status.FromProto(error_as_is)` when `error_as_is` is non-empty, else
+`status.New(item_error_code, error_message)`. The proto3 presence trap
+(`Status{code:0}` serializes to zero bytes) does not bite: an error item never
+carries code OK.
+
+## nodecore changes
+
+### `protocol`
+
+- `GrpcStatusOf(respError *ResponseError) *status.Status` — the moved
+  `grpcStatusFromResponseError`. `grpc_ingress` calls it instead of its local
+  copy.
+
+### `internal/server/emerald/native_call_adapter.go`
+
+- `adapterFor`: `item.GetGrpcData() != nil` → `grpcNativeCallAdapter{}`.
+- `grpcNativeCallAdapter.BuildRequest`:
+  1. `grpc_data` missing → client error (mirrors the REST adapter).
+  2. spec lookup `specs.GetSpecMethod(chain.MethodSpec, item.GetMethod())`;
+     nil → `NoSupportedMethod` error item (same message shape as the ingress:
+     `unknown method %s`), so an unknown method answers precisely instead of
+     "no available upstreams".
+  3. `specMethod.GrpcCallType().IsServerStream()` → client error
+     "server-stream method %s must be called via NativeSubscribe" (the flow
+     would otherwise route it as a subscription).
+  4. metadata: `server_ctx.SanitizeForwardedHeaders(keyValueListToMap(md))`
+     into `RequestParams.Headers` — same reserved-key filtering as the ingress.
+  5. selectors via `mapNativeCallSelectors` as the other adapters.
+  6. `protocol.NewUpstreamGrpcRequest(requestID, method, params, payload, chain.MethodSpec, selectors...)`.
+     `chunk_size` is ignored (documented in a comment).
+- `grpcNativeCallAdapter.SendReply` → `sendReply(..., passThroughStream)`; the
+  stream branch is unreachable for gRPC.
+
+### `sendReply` / `nativeCallErrorItem` (shared by all adapters)
+
+- Metadata extraction switches from the `*protocol.GenericUpstreamResponse`
+  type assertion to the `protocol.HasResponseHeaders` /
+  `protocol.HasResponseTrailers` interfaces, and trailers are stamped on
+  success and error items (`ResponseTrailers` field). JSON-RPC/REST items are
+  unaffected (their responses have no trailers; headers behave as before —
+  `*ReplyError` headers, previously dropped, now ride along too, which is
+  harmless and correct).
+- Error rendering branches on the request type: `wrapper.Response` for a gRPC
+  request → `protocol.GrpcStatusOf(err)` fills `item_error_code` (canonical),
+  `error_message`, and `error_as_is` (= `GrpcStatus.StatusProto` when set);
+  `error_data` stays empty. Other request types keep the current
+  `nativeCallErrorItem` behaviour exactly. The request type is known from the
+  adapter (each adapter owns its `SendReply`), so no type sniffing of the
+  response is needed: the gRPC adapter passes a gRPC error renderer into
+  `sendReply`.
+- Pre-dispatch failures (`BuildRequest` errors, signing unavailable) for gRPC
+  items go through the same gRPC error renderer so `item_error_code` is a
+  canonical code there too.
+
+### Tests (`internal/server/emerald`)
+
+- gRPC item success: payload verbatim, `response_headers` + `response_trailers`
+  populated, signature over the payload when a nonce is given, not chunked even
+  with `chunk_size > 0`.
+- upstream status with typed details: `item_error_code` = canonical code,
+  `error_message`, `error_as_is` round-trips through `status.FromProto`
+  (details preserved), trailers present on the error item.
+- upstream status without details: `error_as_is` empty, `error_data` empty.
+- nodecore error (no available upstreams): `item_error_code` = UNAVAILABLE (14).
+- unknown method → UNIMPLEMENTED (12); server-stream method → INVALID_ARGUMENT
+  pointing at NativeSubscribe; missing `grpc_data` → INVALID_ARGUMENT.
+- metadata sanitizing: reserved client headers are not forwarded.
+- regression: JSON-RPC and REST items unchanged (`error_data` still filled,
+  `response_trailers` empty).
+- `grpc_ingress` tests keep passing against `protocol.GrpcStatusOf`.
+
+## Order of work
+
+1. `drpcorg/public`: proto edit, regenerate `pkg/dshackle`, release (manual).
+2. nodecore: `go get github.com/drpcorg/public@<tag>`, `go mod tidy`.
+3. `protocol.GrpcStatusOf` + ingress switch (independent of the bump; can go
+   first).
+4. gRPC adapter + `sendReply` metadata/error changes + tests.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.9.0
 	github.com/dop251/goja v0.0.0-20250531102226-cb187b08699c
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
-	github.com/drpcorg/public v1.0.0
+	github.com/drpcorg/public v1.1.0
 	github.com/ethereum/go-ethereum v1.17.5
 	github.com/evanw/esbuild v0.28.2
 	github.com/failsafe-go/failsafe-go v0.9.7

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/dop251/goja v0.0.0-20250531102226-cb187b08699c h1:In87uFQZsuGfjDDNfWn
 github.com/dop251/goja v0.0.0-20250531102226-cb187b08699c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0 h1:fuHXpEVTTk7TilRdfGRLHpiTD6tnT0ihEowCfWjlFvw=
 github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0/go.mod h1:Tb7Xxye4LX7cT3i8YLvmPMGCV92IOi4CDZvm/V8ylc0=
-github.com/drpcorg/public v1.0.0 h1:ESY18ZOdOPyyWz7iv8JNIijJ0nUxuSADW2DUMCkwgy8=
-github.com/drpcorg/public v1.0.0/go.mod h1:8xCqKA4+rHTlfjbavAiD6cdn9m+/v+tFWWZNOUf4eQM=
+github.com/drpcorg/public v1.1.0 h1:XnA/u/35Y4tB/GPd04s7eYWZ0uc9lmv04l9ymorGoDU=
+github.com/drpcorg/public v1.1.0/go.mod h1:8xCqKA4+rHTlfjbavAiD6cdn9m+/v+tFWWZNOUf4eQM=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=

--- a/internal/protocol/grpc_status.go
+++ b/internal/protocol/grpc_status.go
@@ -1,7 +1,10 @@
 package protocol
 
 import (
+	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // GrpcStatus is the upstream's verbatim gRPC status. It rides through the
@@ -111,4 +114,46 @@ func IsGrpcRateLimited(response ResponseHolder) bool {
 	}
 	grpcStatus, ok := GrpcStatusFromError(response.GetError())
 	return ok && grpcStatus.Code == codes.ResourceExhausted
+}
+
+// GrpcStatusOf turns a flow error into the *status.Status a gRPC client
+// receives. An upstream gRPC status rides through verbatim - typed details
+// included; nodecore's own error codes are mapped onto the closed 17-code
+// model. Shared by every gRPC-facing ingress so no client needs its own table.
+func GrpcStatusOf(respError *ResponseError) *status.Status {
+	if respError == nil {
+		return status.New(codes.Internal, "internal server error")
+	}
+	if grpcStatus, ok := GrpcStatusFromError(respError); ok {
+		if len(grpcStatus.StatusProto) > 0 {
+			var statusProto spb.Status
+			if err := proto.Unmarshal(grpcStatus.StatusProto, &statusProto); err == nil {
+				return status.FromProto(&statusProto)
+			}
+		}
+		return status.New(grpcStatus.Code, grpcStatus.Message)
+	}
+
+	var code codes.Code
+	switch respError.Code {
+	case NoAvailableUpstreams, NoApiConnectors:
+		code = codes.Unavailable
+	case AuthErrorCode:
+		code = codes.PermissionDenied
+	case ClientErrorCode, WrongChain:
+		code = codes.InvalidArgument
+	case RequestTimeout, CtxErrorCode:
+		code = codes.DeadlineExceeded
+	case RateLimitExceeded:
+		code = codes.ResourceExhausted
+	case NoSupportedMethod:
+		code = codes.Unimplemented
+	case SubscribeTotalFailure:
+		// the node ended a subscription without a status, or the client fell
+		// too far behind
+		code = codes.Unavailable
+	default:
+		code = codes.Internal
+	}
+	return status.New(code, respError.Message)
 }

--- a/internal/protocol/grpc_status.go
+++ b/internal/protocol/grpc_status.go
@@ -120,18 +120,23 @@ func IsGrpcRateLimited(response ResponseHolder) bool {
 // receives. An upstream gRPC status rides through verbatim - typed details
 // included; nodecore's own error codes are mapped onto the closed 17-code
 // model. Shared by every gRPC-facing ingress so no client needs its own table.
-func GrpcStatusOf(respError *ResponseError) *status.Status {
+//
+// fromStatusProto reports that the status was reconstructed from the carried
+// google.rpc.Status bytes, i.e. those bytes are valid and may go on the wire
+// verbatim; false covers nodecore errors, statuses without proto bytes, and
+// bytes that failed to unmarshal (the code/message fallback).
+func GrpcStatusOf(respError *ResponseError) (grpcStatus *status.Status, fromStatusProto bool) {
 	if respError == nil {
-		return status.New(codes.Internal, "internal server error")
+		return status.New(codes.Internal, "internal server error"), false
 	}
-	if grpcStatus, ok := GrpcStatusFromError(respError); ok {
-		if len(grpcStatus.StatusProto) > 0 {
+	if upstreamStatus, ok := GrpcStatusFromError(respError); ok {
+		if len(upstreamStatus.StatusProto) > 0 {
 			var statusProto spb.Status
-			if err := proto.Unmarshal(grpcStatus.StatusProto, &statusProto); err == nil {
-				return status.FromProto(&statusProto)
+			if err := proto.Unmarshal(upstreamStatus.StatusProto, &statusProto); err == nil {
+				return status.FromProto(&statusProto), true
 			}
 		}
-		return status.New(grpcStatus.Code, grpcStatus.Message)
+		return status.New(upstreamStatus.Code, upstreamStatus.Message), false
 	}
 
 	var code codes.Code
@@ -155,5 +160,5 @@ func GrpcStatusOf(respError *ResponseError) *status.Status {
 	default:
 		code = codes.Internal
 	}
-	return status.New(code, respError.Message)
+	return status.New(code, respError.Message), false
 }

--- a/internal/protocol/grpc_status_of_test.go
+++ b/internal/protocol/grpc_status_of_test.go
@@ -18,8 +18,9 @@ func TestGrpcStatusOfReplaysUpstreamStatusWithDetails(t *testing.T) {
 	statusProto, err := proto.Marshal(upstream.Proto())
 	require.NoError(t, err)
 
-	got := GrpcStatusOf(NewGrpcStatusResponseError(&GrpcStatus{Code: codes.NotFound, Message: "object not found", StatusProto: statusProto}))
+	got, fromStatusProto := GrpcStatusOf(NewGrpcStatusResponseError(&GrpcStatus{Code: codes.NotFound, Message: "object not found", StatusProto: statusProto}))
 
+	assert.True(t, fromStatusProto)
 	assert.Equal(t, codes.NotFound, got.Code())
 	assert.Equal(t, "object not found", got.Message())
 	require.Len(t, got.Details(), 1)
@@ -27,7 +28,8 @@ func TestGrpcStatusOfReplaysUpstreamStatusWithDetails(t *testing.T) {
 }
 
 func TestGrpcStatusOfReplaysUpstreamStatusWithoutDetails(t *testing.T) {
-	got := GrpcStatusOf(NewGrpcStatusError(codes.ResourceExhausted, "slow down"))
+	got, fromStatusProto := GrpcStatusOf(NewGrpcStatusError(codes.ResourceExhausted, "slow down"))
+	assert.False(t, fromStatusProto)
 	assert.Equal(t, codes.ResourceExhausted, got.Code())
 	assert.Equal(t, "slow down", got.Message())
 	assert.Empty(t, got.Details())
@@ -49,7 +51,8 @@ func TestGrpcStatusOfMapsNodecoreErrors(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GrpcStatusOf(tc.err)
+			got, fromStatusProto := GrpcStatusOf(tc.err)
+			assert.False(t, fromStatusProto)
 			assert.Equal(t, tc.code, got.Code())
 			assert.Equal(t, tc.err.Message, got.Message())
 		})
@@ -57,6 +60,16 @@ func TestGrpcStatusOfMapsNodecoreErrors(t *testing.T) {
 }
 
 func TestGrpcStatusOfNilIsInternal(t *testing.T) {
-	got := GrpcStatusOf(nil)
+	got, fromStatusProto := GrpcStatusOf(nil)
+	assert.False(t, fromStatusProto)
 	assert.Equal(t, codes.Internal, got.Code())
+}
+
+func TestGrpcStatusOfCorruptStatusProtoFallsBackToCodeAndMessage(t *testing.T) {
+	got, fromStatusProto := GrpcStatusOf(NewGrpcStatusResponseError(
+		&GrpcStatus{Code: codes.NotFound, Message: "object not found", StatusProto: []byte{0xff}}))
+
+	assert.False(t, fromStatusProto)
+	assert.Equal(t, codes.NotFound, got.Code())
+	assert.Equal(t, "object not found", got.Message())
 }

--- a/internal/protocol/grpc_status_of_test.go
+++ b/internal/protocol/grpc_status_of_test.go
@@ -1,0 +1,62 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGrpcStatusOfReplaysUpstreamStatusWithDetails(t *testing.T) {
+	upstream, err := status.New(codes.NotFound, "object not found").
+		WithDetails(&errdetails.ErrorInfo{Reason: "OBJECT_PRUNED", Domain: "sui.io"})
+	require.NoError(t, err)
+	statusProto, err := proto.Marshal(upstream.Proto())
+	require.NoError(t, err)
+
+	got := GrpcStatusOf(NewGrpcStatusResponseError(&GrpcStatus{Code: codes.NotFound, Message: "object not found", StatusProto: statusProto}))
+
+	assert.Equal(t, codes.NotFound, got.Code())
+	assert.Equal(t, "object not found", got.Message())
+	require.Len(t, got.Details(), 1)
+	assert.Equal(t, "OBJECT_PRUNED", got.Details()[0].(*errdetails.ErrorInfo).Reason)
+}
+
+func TestGrpcStatusOfReplaysUpstreamStatusWithoutDetails(t *testing.T) {
+	got := GrpcStatusOf(NewGrpcStatusError(codes.ResourceExhausted, "slow down"))
+	assert.Equal(t, codes.ResourceExhausted, got.Code())
+	assert.Equal(t, "slow down", got.Message())
+	assert.Empty(t, got.Details())
+}
+
+func TestGrpcStatusOfMapsNodecoreErrors(t *testing.T) {
+	cases := map[string]struct {
+		err  *ResponseError
+		code codes.Code
+	}{
+		"no upstreams":       {NoAvailableUpstreamsError(), codes.Unavailable},
+		"wrong chain":        {WrongChainError("x"), codes.InvalidArgument},
+		"client":             {ClientError(assert.AnError), codes.InvalidArgument},
+		"not supported":      {NotSupportedMethodError("m"), codes.Unimplemented},
+		"rate limit":         {&ResponseError{Code: RateLimitExceeded, Message: "rl"}, codes.ResourceExhausted},
+		"timeout":            {&ResponseError{Code: RequestTimeout, Message: "t"}, codes.DeadlineExceeded},
+		"auth":               {&ResponseError{Code: AuthErrorCode, Message: "a"}, codes.PermissionDenied},
+		"internal (default)": {ServerError(), codes.Internal},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GrpcStatusOf(tc.err)
+			assert.Equal(t, tc.code, got.Code())
+			assert.Equal(t, tc.err.Message, got.Message())
+		})
+	}
+}
+
+func TestGrpcStatusOfNilIsInternal(t *testing.T) {
+	got := GrpcStatusOf(nil)
+	assert.Equal(t, codes.Internal, got.Code())
+}

--- a/internal/protocol/json_rpc_stream.go
+++ b/internal/protocol/json_rpc_stream.go
@@ -22,6 +22,11 @@ type StreamHint interface {
 	Type() RequestType
 }
 
+// NoResultStart is the ResultStart value meaning no "result" value was
+// located in the first chunk. Consumers must treat it as "do not unwrap"
+// rather than as an offset - the zero value would silently mean offset 0.
+const NoResultStart = -1
+
 // JsonRpcResultStreamHint is the StreamHint for unwrapping the "result" value
 // of a JSON-RPC envelope: where the value begins in the first chunk and a
 // counter primed for its JSON type so the consumer can detect where it ends.
@@ -29,6 +34,10 @@ type JsonRpcResultStreamHint struct {
 	ResultStart int
 	Counter     ResultCounter
 }
+
+// NoJsonRpcResultStreamHint is the hint of a response that carries no
+// unwrapping information; unwrapping it fails instead of truncating.
+var NoJsonRpcResultStreamHint = JsonRpcResultStreamHint{ResultStart: NoResultStart}
 
 func (JsonRpcResultStreamHint) Type() RequestType { return JsonRpc }
 
@@ -42,7 +51,7 @@ type FirstChunkAnalysis struct {
 	// envelope-level "error" key was seen in the first chunk.
 	Streamable bool
 	// ResultStart is the byte offset of the "result" value within the first
-	// chunk, or -1 if none was found.
+	// chunk, or NoResultStart if none was found.
 	ResultStart int
 	// Counter is primed for the "result" value's JSON type (valid only when
 	// Streamable).
@@ -76,7 +85,7 @@ func AnalyzeFirstChunk(reader *bufio.Reader, chunkSize int) FirstChunkAnalysis {
 		// buffered in the first chunk, so there is nothing to stream - let the
 		// buffered path parse/validate/cache it. Any other Peek error also
 		// means we shouldn't stream.
-		return FirstChunkAnalysis{ResultStart: -1}
+		return FirstChunkAnalysis{ResultStart: NoResultStart}
 	}
 	return AnalyzeChunk(body)
 }
@@ -86,7 +95,7 @@ func AnalyzeFirstChunk(reader *bufio.Reader, chunkSize int) FirstChunkAnalysis {
 // the gRPC consumer's tests can locate a result value in a chunk without a
 // reader. See AnalyzeFirstChunk for the walk's semantics.
 func AnalyzeChunk(buf []byte) FirstChunkAnalysis {
-	res := FirstChunkAnalysis{ResultStart: -1}
+	res := FirstChunkAnalysis{ResultStart: NoResultStart}
 	dec := json.NewDecoder(bytes.NewReader(buf))
 	tok, err := dec.Token()
 	if err != nil {
@@ -103,16 +112,16 @@ func AnalyzeChunk(buf []byte) FirstChunkAnalysis {
 		}
 		key, ok := keyTok.(string)
 		if !ok {
-			return FirstChunkAnalysis{ResultStart: -1}
+			return FirstChunkAnalysis{ResultStart: NoResultStart}
 		}
 		if key == "error" {
 			// Envelope-level error: do not stream, regardless of result.
-			return FirstChunkAnalysis{ResultStart: -1}
+			return FirstChunkAnalysis{ResultStart: NoResultStart}
 		}
 		if key == "result" {
 			start, counter, ok := resultValueStart(buf, int(dec.InputOffset()))
 			if !ok {
-				return FirstChunkAnalysis{ResultStart: -1}
+				return FirstChunkAnalysis{ResultStart: NoResultStart}
 			}
 			res.ResultStart = start
 			res.Counter = counter

--- a/internal/protocol/response.go
+++ b/internal/protocol/response.go
@@ -27,6 +27,21 @@ type HasResponseTrailers interface {
 	ResponseTrailers() map[string][]string
 }
 
+// ResponseMetadata reads the optional transport metadata of a response through
+// the two capabilities above. It takes any because callers hold values behind
+// different interfaces (ResponseHolder, SubResponse).
+func ResponseMetadata(response any) (http.Header, map[string][]string) {
+	var headers http.Header
+	var trailers map[string][]string
+	if headerBearer, ok := response.(HasResponseHeaders); ok {
+		headers = headerBearer.ResponseHeaders()
+	}
+	if trailerBearer, ok := response.(HasResponseTrailers); ok {
+		trailers = trailerBearer.ResponseTrailers()
+	}
+	return headers, trailers
+}
+
 // noStreamHint is embedded by response types that never carry a streaming
 // result hint (subscriptions, ws, errors); it satisfies the GetStreamHint part
 // of ResponseHolder with a nil hint.

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -71,18 +70,18 @@ func (s *GrpcBlockchainService) NativeCall(request *dshackle.NativeCallRequest, 
 		return err
 	}
 	if request == nil {
-		return stream.Send(nativeCallErrorItem(0, protocol.ClientError(fmt.Errorf("request is nil")), flow.NoUpstream, nil, nil))
+		return stream.Send(noUpstreamErrorItem(0, protocol.ClientError(fmt.Errorf("request is nil"))))
 	}
 	if s.appCtx == nil || s.appCtx.UpstreamSupervisor == nil {
-		return stream.Send(nativeCallErrorItem(0, protocol.NoAvailableUpstreamsError(), flow.NoUpstream, nil, nil))
+		return stream.Send(noUpstreamErrorItem(0, protocol.NoAvailableUpstreamsError()))
 	}
 
 	configuredChain, chainSupervisor := s.resolveChain(request.GetChain())
 	if configuredChain == nil {
-		return stream.Send(nativeCallErrorItem(0, protocol.WrongChainError(strconv.Itoa(int(request.GetChain()))), flow.NoUpstream, nil, nil))
+		return stream.Send(noUpstreamErrorItem(0, protocol.WrongChainError(strconv.Itoa(int(request.GetChain())))))
 	}
 	if chainSupervisor == nil {
-		return stream.Send(nativeCallErrorItem(0, protocol.NoAvailableUpstreamsError(), flow.NoUpstream, nil, nil))
+		return stream.Send(noUpstreamErrorItem(0, protocol.NoAvailableUpstreamsError()))
 	}
 
 	requests, items, preResponses := s.buildNativeCallRequests(configuredChain, request)
@@ -118,7 +117,9 @@ func (s *GrpcBlockchainService) NativeCall(request *dshackle.NativeCallRequest, 
 			// Without the originating item we don't know its nonce, so a success
 			// here could silently drop a signature the client asked for.
 			log.Warn().Msgf("no request found for id %s, cannot build a reply", wrapper.RequestId)
-			if err := stream.Send(nativeCallErrorItem(parseCallItemID(wrapper.RequestId), protocol.ServerError(), wrapper.UpstreamId, nil, nil)); err != nil {
+			replyItem := nativeCallErrorItem(parseCallItemID(wrapper.RequestId), protocol.ServerError(), nil)
+			replyItem.UpstreamId = wrapper.UpstreamId
+			if err := stream.Send(replyItem); err != nil {
 				return err
 			}
 			continue
@@ -261,12 +262,12 @@ func (s *GrpcBlockchainService) buildNativeCallRequests(
 	preResponses := make([]*dshackle.NativeCallReplyItem, 0)
 
 	for _, item := range request.GetItems() {
+		adapter := adapterFor(item)
 		if err := signingUnavailable(item.GetNonce(), s.signer); err != nil {
 			log.Warn().Msgf("item %d requested a signature but response signing is not configured", item.GetId())
-			preResponses = append(preResponses, nativeCallErrorItem(item.GetId(), protocol.ServerErrorWithCause(err), flow.NoUpstream, nil, nil))
+			preResponses = append(preResponses, adapter.ErrorItem(item.GetId(), protocol.ServerErrorWithCause(err)))
 			continue
 		}
-		adapter := adapterFor(item)
 		builtRequest, failure := adapter.BuildRequest(configuredChain, item, request.GetSelector(), request.GetChunkSize())
 		if failure != nil {
 			preResponses = append(preResponses, failure)
@@ -283,18 +284,11 @@ func (s *GrpcBlockchainService) buildNativeCallRequests(
 // buffered response is always a single unchunked item however large: chunk_size
 // selects a streaming request, it is not a framing size for in-memory payloads.
 // Chunked replies come from streamNativeCallBody instead.
-func nativeCallSuccessItem(
-	requestID uint32,
-	upstreamID string,
-	payload []byte,
-	headers http.Header,
-) *dshackle.NativeCallReplyItem {
+func nativeCallSuccessItem(requestID uint32, payload []byte) *dshackle.NativeCallReplyItem {
 	return &dshackle.NativeCallReplyItem{
-		Id:              requestID,
-		Succeed:         true,
-		Payload:         payload,
-		UpstreamId:      upstreamID,
-		ResponseHeaders: mapHeaders(headers),
+		Id:      requestID,
+		Succeed: true,
+		Payload: payload,
 	}
 }
 
@@ -361,24 +355,16 @@ func (e *nativeCallChunkEmitter) Finish() error {
 	return e.WriteChunk(nil, true)
 }
 
-func nativeCallErrorItem(
-	requestID uint32,
-	responseError *protocol.ResponseError,
-	upstreamID string,
-	errorAsIs []byte,
-	headers http.Header,
-) *dshackle.NativeCallReplyItem {
+func nativeCallErrorItem(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem {
 	if responseError == nil {
 		responseError = protocol.ServerError()
 	}
 
 	replyItem := &dshackle.NativeCallReplyItem{
-		Id:              requestID,
-		Succeed:         false,
-		ErrorMessage:    responseError.Message,
-		ItemErrorCode:   int32(responseError.Code),
-		UpstreamId:      upstreamID,
-		ResponseHeaders: mapHeaders(headers),
+		Id:            requestID,
+		Succeed:       false,
+		ErrorMessage:  responseError.Message,
+		ItemErrorCode: int32(responseError.Code),
 	}
 	if responseError.Data != nil {
 		replyItem.ErrorData = nativeCallErrorData(responseError.Data)
@@ -390,7 +376,14 @@ func nativeCallErrorItem(
 	return replyItem
 }
 
-func mapHeaders(headers http.Header) []*dshackle.KeyValue {
+// noUpstreamErrorItem is a failure raised before any upstream was involved.
+func noUpstreamErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
+	replyItem := nativeCallErrorItem(requestID, responseError, nil)
+	replyItem.UpstreamId = flow.NoUpstream
+	return replyItem
+}
+
+func mapHeaders[M ~map[string][]string](headers M) []*dshackle.KeyValue {
 	keyValueHeaders := make([]*dshackle.KeyValue, 0, len(headers))
 	for key, values := range headers {
 		for _, value := range values {

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -70,18 +70,20 @@ func (s *GrpcBlockchainService) NativeCall(request *dshackle.NativeCallRequest, 
 		return err
 	}
 	if request == nil {
-		return stream.Send(noUpstreamErrorItem(0, protocol.ClientError(fmt.Errorf("request is nil"))))
+		// no items to correlate with or to pick a vocabulary from: this is the
+		// one failure a client can only observe as id 0 with a nodecore code
+		return stream.Send(withNoUpstreamId(nativeCallErrorItem(0, protocol.ClientError(fmt.Errorf("request is nil")), nil)))
 	}
 	if s.appCtx == nil || s.appCtx.UpstreamSupervisor == nil {
-		return stream.Send(noUpstreamErrorItem(0, protocol.NoAvailableUpstreamsError()))
+		return sendRequestFailure(stream, request, protocol.NoAvailableUpstreamsError())
 	}
 
 	configuredChain, chainSupervisor := s.resolveChain(request.GetChain())
 	if configuredChain == nil {
-		return stream.Send(noUpstreamErrorItem(0, protocol.WrongChainError(strconv.Itoa(int(request.GetChain())))))
+		return sendRequestFailure(stream, request, protocol.WrongChainError(strconv.Itoa(int(request.GetChain()))))
 	}
 	if chainSupervisor == nil {
-		return stream.Send(noUpstreamErrorItem(0, protocol.NoAvailableUpstreamsError()))
+		return sendRequestFailure(stream, request, protocol.NoAvailableUpstreamsError())
 	}
 
 	requests, items, preResponses := s.buildNativeCallRequests(configuredChain, request)
@@ -115,7 +117,11 @@ func (s *GrpcBlockchainService) NativeCall(request *dshackle.NativeCallRequest, 
 		item, ok := items[wrapper.RequestId]
 		if !ok {
 			// Without the originating item we don't know its nonce, so a success
-			// here could silently drop a signature the client asked for.
+			// here could silently drop a signature the client asked for. The item
+			// kind is unknown too (this lookup is what failed), so - as a
+			// documented exception to the per-kind error vocabulary - the failure
+			// is rendered with the nodecore code 500. Defensive: the flow only
+			// answers ids this loop built.
 			log.Warn().Msgf("no request found for id %s, cannot build a reply", wrapper.RequestId)
 			replyItem := nativeCallErrorItem(parseCallItemID(wrapper.RequestId), protocol.ServerError(), nil)
 			replyItem.UpstreamId = wrapper.UpstreamId
@@ -265,7 +271,7 @@ func (s *GrpcBlockchainService) buildNativeCallRequests(
 		adapter := adapterFor(item)
 		if err := signingUnavailable(item.GetNonce(), s.signer); err != nil {
 			log.Warn().Msgf("item %d requested a signature but response signing is not configured", item.GetId())
-			preResponses = append(preResponses, adapter.ErrorItem(item.GetId(), protocol.ServerErrorWithCause(err)))
+			preResponses = append(preResponses, withNoUpstreamId(adapter.ErrorItem(item.GetId(), protocol.ServerErrorWithCause(err), nil)))
 			continue
 		}
 		builtRequest, failure := adapter.BuildRequest(configuredChain, item, request.GetSelector(), request.GetChunkSize())
@@ -376,11 +382,21 @@ func nativeCallErrorItem(requestID uint32, responseError *protocol.ResponseError
 	return replyItem
 }
 
-// noUpstreamErrorItem is a failure raised before any upstream was involved.
-func noUpstreamErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
-	replyItem := nativeCallErrorItem(requestID, responseError, nil)
-	replyItem.UpstreamId = flow.NoUpstream
-	return replyItem
+// sendRequestFailure answers a request-level failure (unknown chain, no
+// upstreams) once per item, each in its own kind's error vocabulary and under
+// its own id - a gRPC item must see a canonical code, and id 0 would match
+// nothing the client sent.
+func sendRequestFailure(
+	stream dshackle.Blockchain_NativeCallServer,
+	request *dshackle.NativeCallRequest,
+	responseError *protocol.ResponseError,
+) error {
+	for _, item := range request.GetItems() {
+		if err := stream.Send(withNoUpstreamId(adapterFor(item).ErrorItem(item.GetId(), responseError, nil))); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func mapHeaders[M ~map[string][]string](headers M) []*dshackle.KeyValue {

--- a/internal/server/emerald/grpc_blockchain_test.go
+++ b/internal/server/emerald/grpc_blockchain_test.go
@@ -13,14 +13,18 @@ import (
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/signature"
 	"github.com/drpcorg/nodecore/internal/upstreams"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/public/pkg/dshackle"
 	specs "github.com/drpcorg/public/pkg/methods"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // subMethodsChainSupervisor is a ChainSupervisor stub exposing a fixed
@@ -214,7 +218,7 @@ func TestStreamNativeCallBodyUnwrapsJsonRpcResult(t *testing.T) {
 	stream := &testNativeCallStream{ctx: context.Background()}
 	a := protocol.AnalyzeChunk([]byte(body))
 
-	err := streamNativeCallBody(7, "upstream-1", "erigon/2.60", nil, reader, unwrapJsonRpcResultStream, a.ResultStart, a.Counter, nil, stream)
+	err := streamNativeCallBody(stream, reader, unwrapJsonRpcResultStream, protocol.JsonRpcResultStreamHint{ResultStart: a.ResultStart, Counter: a.Counter}, replyMeta{requestID: 7, upstreamID: "upstream-1", upstreamNodeVersion: "erigon/2.60"})
 	require.NoError(t, err)
 	// The whole result arrives in one read and ends within it, so end-of-stream
 	// is folded into that single data frame - no trailing empty frame.
@@ -233,7 +237,7 @@ func TestStreamNativeCallBodyPassesThroughRestBody(t *testing.T) {
 	reader := strings.NewReader(`{"hello":"world"}`)
 	stream := &testNativeCallStream{ctx: context.Background()}
 
-	err := streamNativeCallBody(7, "upstream-1", "", nil, reader, passThroughStream, -1, protocol.ResultCounter{}, nil, stream)
+	err := streamNativeCallBody(stream, reader, passThroughStream, protocol.JsonRpcResultStreamHint{ResultStart: -1}, replyMeta{requestID: 7, upstreamID: "upstream-1"})
 	require.NoError(t, err)
 	// The whole body is forwarded as a single frame plus the terminal empty frame.
 	require.Len(t, stream.sent, 2)
@@ -264,7 +268,7 @@ func TestStreamNativeCallBodyEmitsTerminalEmptyFinalChunkFallback(t *testing.T) 
 	stream := &testNativeCallStream{ctx: context.Background()}
 	a := protocol.AnalyzeChunk([]byte(body)[:protocol.MaxChunkSize])
 
-	err := streamNativeCallBody(7, "upstream-1", "", nil, reader, unwrapJsonRpcResultStream, a.ResultStart, a.Counter, nil, stream)
+	err := streamNativeCallBody(stream, reader, unwrapJsonRpcResultStream, protocol.JsonRpcResultStreamHint{ResultStart: a.ResultStart, Counter: a.Counter}, replyMeta{requestID: 7, upstreamID: "upstream-1"})
 	require.NoError(t, err)
 	require.Len(t, stream.sent, 3)
 
@@ -640,4 +644,241 @@ func TestBuildNativeCallRequestsRejectsConflictingRequestAndItemSortSelectorsAtM
 	assert.False(t, failures[0].GetSucceed())
 	assert.Equal(t, int32(400), failures[0].GetItemErrorCode())
 	assert.Contains(t, failures[0].GetErrorMessage(), "conflicting selector sort hints")
+}
+
+func flattenKeyValues(items []*dshackle.KeyValue) map[string][]string {
+	out := make(map[string][]string, len(items))
+	for _, kv := range items {
+		out[kv.GetKey()] = append(out[kv.GetKey()], kv.GetValue())
+	}
+	return out
+}
+
+func TestSendReplyForwardsTrailersOnSuccess(t *testing.T) {
+	resp := protocol.NewGrpcUpstreamResponse("7", []byte{0x0a, 0x01, 0x41}).
+		WithResponseHeaders(http.Header{"content-type": {"application/grpc"}}).
+		WithResponseTrailers(map[string][]string{"x-ratelimit-remaining": {"99"}})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "7", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, restNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+
+	assert.Equal(t, []string{"application/grpc"}, flattenKeyValues(stream.sent[0].GetResponseHeaders())["content-type"])
+	assert.Equal(t, []string{"99"}, flattenKeyValues(stream.sent[0].GetResponseTrailers())["x-ratelimit-remaining"])
+}
+
+// A retryable upstream error surfaces as *ReplyError, which carries metadata
+// too (RESOURCE_EXHAUSTED with rate-limit hints). Both must reach the client.
+func TestSendReplyForwardsHeadersAndTrailersOnReplyError(t *testing.T) {
+	request := protocol.NewUpstreamGrpcRequest("7", "/sui.rpc.v2.LedgerService/GetObject", nil, nil, "sui")
+	resp := protocol.NewGrpcUpstreamErrorResponse(request, &protocol.GrpcStatus{Code: codes.ResourceExhausted, Message: "slow down"}).(*protocol.ReplyError).
+		WithResponseHeaders(http.Header{"x-upstream": {"a"}}).
+		WithResponseTrailers(map[string][]string{"retry-after-ms": {"250"}})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "7", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, restNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+
+	assert.False(t, stream.sent[0].GetSucceed())
+	assert.Equal(t, []string{"a"}, flattenKeyValues(stream.sent[0].GetResponseHeaders())["x-upstream"])
+	assert.Equal(t, []string{"250"}, flattenKeyValues(stream.sent[0].GetResponseTrailers())["retry-after-ms"])
+}
+
+func TestSendReplyLeavesTrailersEmptyForJsonRpc(t *testing.T) {
+	wrapper := &protocol.ResponseHolderWrapper{
+		UpstreamId: "upstream-1",
+		RequestId:  "1",
+		Response:   protocol.NewSimpleHttpUpstreamResponse("1", []byte(`"0x1"`), protocol.JsonRpc),
+	}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, jsonRpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.Empty(t, stream.sent[0].GetResponseTrailers())
+}
+
+func grpcItem(id uint32, method string, payload []byte, md ...*dshackle.KeyValue) *dshackle.NativeCallItem {
+	return &dshackle.NativeCallItem{
+		Id:     id,
+		Method: method,
+		Data:   &dshackle.NativeCallItem_GrpcData{GrpcData: &dshackle.GrpcData{Payload: payload, Metadata: md}},
+	}
+}
+
+func TestBuildNativeCallRequestsBuildsGrpcRequest(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	configuredChain := &chains.ConfiguredChain{MethodSpec: "sui"}
+	request := &dshackle.NativeCallRequest{
+		ChunkSize: 1024, // ignored for gRPC: a unary reply is one message
+		Items: []*dshackle.NativeCallItem{
+			grpcItem(5, "/sui.rpc.v2.LedgerService/GetObject", []byte{0x0a, 0x02, 0x68, 0x69},
+				&dshackle.KeyValue{Key: "x-client", Value: "a"},
+				&dshackle.KeyValue{Key: "x-nodecore-key", Value: "secret"},
+				&dshackle.KeyValue{Key: "authorization", Value: "Bearer t"}),
+		},
+	}
+
+	requests, items, failures := service.buildNativeCallRequests(configuredChain, request)
+	require.Empty(t, failures)
+	require.Len(t, requests, 1)
+	assert.IsType(t, grpcNativeCallAdapter{}, items[requests[0].Id()].adapter)
+
+	grpcReq, ok := requests[0].(*protocol.UpstreamGrpcRequest)
+	require.True(t, ok)
+	assert.Equal(t, protocol.Grpc, grpcReq.RequestType())
+	assert.Equal(t, "5", grpcReq.Id())
+	assert.Equal(t, "/sui.rpc.v2.LedgerService/GetObject", grpcReq.Method())
+	body, err := grpcReq.Body()
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x0a, 0x02, 0x68, 0x69}, body)
+	assert.False(t, grpcReq.IsStream())
+	// reserved credential metadata never reaches an upstream
+	assert.Equal(t, map[string][]string{"x-client": {"a"}}, grpcReq.RequestParams().Headers)
+}
+
+func TestBuildNativeCallRequestsGrpcUnknownMethodIsUnimplemented(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	request := &dshackle.NativeCallRequest{Items: []*dshackle.NativeCallItem{grpcItem(3, "/sui.rpc.v2.LedgerService/Nope", nil)}}
+
+	requests, _, failures := service.buildNativeCallRequests(&chains.ConfiguredChain{MethodSpec: "sui"}, request)
+	require.Empty(t, requests)
+	require.Len(t, failures, 1)
+	assert.Equal(t, uint32(3), failures[0].GetId())
+	assert.False(t, failures[0].GetSucceed())
+	assert.Equal(t, int32(codes.Unimplemented), failures[0].GetItemErrorCode())
+	assert.Contains(t, failures[0].GetErrorMessage(), "/sui.rpc.v2.LedgerService/Nope")
+}
+
+func TestBuildNativeCallRequestsGrpcServerStreamMethodIsRejected(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	request := &dshackle.NativeCallRequest{Items: []*dshackle.NativeCallItem{grpcItem(4, "/sui.rpc.v2.LedgerService/ListTransactions", nil)}}
+
+	requests, _, failures := service.buildNativeCallRequests(&chains.ConfiguredChain{MethodSpec: "sui"}, request)
+	require.Empty(t, requests)
+	require.Len(t, failures, 1)
+	assert.Equal(t, int32(codes.InvalidArgument), failures[0].GetItemErrorCode())
+	assert.Contains(t, failures[0].GetErrorMessage(), "NativeSubscribe")
+}
+
+func TestBuildNativeCallRequestsGrpcMissingDataIsInvalidArgument(t *testing.T) {
+	// an empty GrpcData is a valid empty request message; only a nil oneof
+	// branch can be "missing", which adapterFor never routes here - so the
+	// guard is exercised directly
+	_, failure := grpcNativeCallAdapter{}.BuildRequest(&chains.ConfiguredChain{MethodSpec: "sui"},
+		&dshackle.NativeCallItem{Id: 9, Method: "/sui.rpc.v2.LedgerService/GetObject"}, nil, 0)
+	require.NotNil(t, failure)
+	assert.Equal(t, int32(codes.InvalidArgument), failure.GetItemErrorCode())
+}
+
+func TestBuildNativeCallRequestsGrpcSigningUnavailableIsInternal(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	item := grpcItem(6, "/sui.rpc.v2.LedgerService/GetObject", nil)
+	item.Nonce = 42
+	request := &dshackle.NativeCallRequest{Items: []*dshackle.NativeCallItem{item}}
+
+	requests, _, failures := service.buildNativeCallRequests(&chains.ConfiguredChain{MethodSpec: "sui"}, request)
+	require.Empty(t, requests)
+	require.Len(t, failures, 1)
+	assert.Equal(t, int32(codes.Internal), failures[0].GetItemErrorCode())
+}
+
+func TestGrpcSendReplySuccessIsOneUnchunkedItemWithMetadata(t *testing.T) {
+	message := bytes.Repeat([]byte{0x0a}, 5_000)
+	resp := protocol.NewGrpcUpstreamResponse("5", message).
+		WithResponseHeaders(http.Header{"content-type": {"application/grpc"}}).
+		WithResponseTrailers(map[string][]string{"x-ratelimit-remaining": {"99"}})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "5", Response: resp, UpstreamNodeVersion: "sui-node/1.50.0"}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, grpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+
+	item := stream.sent[0]
+	assert.True(t, item.GetSucceed())
+	assert.False(t, item.GetChunked())
+	assert.Equal(t, message, item.GetPayload())
+	assert.Equal(t, uint32(5), item.GetId())
+	assert.Equal(t, "sui-1", item.GetUpstreamId())
+	assert.Equal(t, "sui-node/1.50.0", item.GetUpstreamNodeVersion())
+	assert.Equal(t, []string{"application/grpc"}, flattenKeyValues(item.GetResponseHeaders())["content-type"])
+	assert.Equal(t, []string{"99"}, flattenKeyValues(item.GetResponseTrailers())["x-ratelimit-remaining"])
+}
+
+func TestGrpcSendReplyUpstreamStatusWithDetailsRidesVerbatim(t *testing.T) {
+	upstreamStatus, err := status.New(codes.NotFound, "object not found").
+		WithDetails(&errdetails.ErrorInfo{Reason: "OBJECT_PRUNED", Domain: "sui.io"})
+	require.NoError(t, err)
+	statusProto, err := proto.Marshal(upstreamStatus.Proto())
+	require.NoError(t, err)
+
+	request := protocol.NewUpstreamGrpcRequest("5", "/sui.rpc.v2.LedgerService/GetObject", nil, nil, "sui")
+	resp := protocol.NewGrpcUpstreamErrorResponse(request, &protocol.GrpcStatus{Code: codes.NotFound, Message: "object not found", StatusProto: statusProto})
+	resp.(*protocol.GenericUpstreamResponse).WithResponseTrailers(map[string][]string{"x-trace": {"abc"}})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "5", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, grpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+
+	item := stream.sent[0]
+	assert.False(t, item.GetSucceed())
+	assert.Equal(t, int32(codes.NotFound), item.GetItemErrorCode())
+	assert.Equal(t, "object not found", item.GetErrorMessage())
+	assert.Empty(t, item.GetErrorData())
+	assert.Equal(t, []string{"abc"}, flattenKeyValues(item.GetResponseTrailers())["x-trace"])
+
+	var decoded spb.Status
+	require.NoError(t, proto.Unmarshal(item.GetErrorAsIs(), &decoded))
+	replayed := status.FromProto(&decoded)
+	assert.Equal(t, codes.NotFound, replayed.Code())
+	require.Len(t, replayed.Details(), 1)
+	assert.Equal(t, "OBJECT_PRUNED", replayed.Details()[0].(*errdetails.ErrorInfo).Reason)
+}
+
+func TestGrpcSendReplyUpstreamStatusWithoutDetailsHasNoErrorAsIs(t *testing.T) {
+	request := protocol.NewUpstreamGrpcRequest("5", "/sui.rpc.v2.LedgerService/GetObject", nil, nil, "sui")
+	resp := protocol.NewGrpcUpstreamErrorResponse(request, &protocol.GrpcStatus{Code: codes.InvalidArgument, Message: "bad digest"})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "5", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, grpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.Equal(t, int32(codes.InvalidArgument), stream.sent[0].GetItemErrorCode())
+	assert.Equal(t, "bad digest", stream.sent[0].GetErrorMessage())
+	assert.Empty(t, stream.sent[0].GetErrorAsIs())
+	assert.Empty(t, stream.sent[0].GetErrorData())
+}
+
+func TestGrpcSendReplyNodecoreErrorIsMappedToCanonicalCode(t *testing.T) {
+	request := protocol.NewUpstreamGrpcRequest("5", "/sui.rpc.v2.LedgerService/GetObject", nil, nil, "sui")
+	resp := protocol.NewTotalFailure(request, protocol.NoAvailableUpstreamsError())
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: flow.NoUpstream, RequestId: "5", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, grpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.Equal(t, int32(codes.Unavailable), stream.sent[0].GetItemErrorCode())
+	assert.Equal(t, protocol.NoAvailableUpstreamsError().Message, stream.sent[0].GetErrorMessage())
+	assert.Empty(t, stream.sent[0].GetErrorAsIs())
+}
+
+// JSON-RPC items must keep their current error vocabulary (nodecore codes,
+// error_data) - the gRPC renderer applies to gRPC items only.
+func TestJsonRpcSendReplyKeepsNodecoreErrorCodes(t *testing.T) {
+	wrapper := &protocol.ResponseHolderWrapper{
+		UpstreamId: flow.NoUpstream,
+		RequestId:  "1",
+		Response:   protocol.NewHttpUpstreamResponseWithError(protocol.NoAvailableUpstreamsError()),
+	}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, jsonRpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.Equal(t, int32(protocol.NoAvailableUpstreams), stream.sent[0].GetItemErrorCode())
 }

--- a/internal/server/emerald/grpc_blockchain_test.go
+++ b/internal/server/emerald/grpc_blockchain_test.go
@@ -237,7 +237,7 @@ func TestStreamNativeCallBodyPassesThroughRestBody(t *testing.T) {
 	reader := strings.NewReader(`{"hello":"world"}`)
 	stream := &testNativeCallStream{ctx: context.Background()}
 
-	err := streamNativeCallBody(stream, reader, passThroughStream, protocol.JsonRpcResultStreamHint{ResultStart: -1}, replyMeta{requestID: 7, upstreamID: "upstream-1"})
+	err := streamNativeCallBody(stream, reader, passThroughStream, protocol.NoJsonRpcResultStreamHint, replyMeta{requestID: 7, upstreamID: "upstream-1"})
 	require.NoError(t, err)
 	// The whole body is forwarded as a single frame plus the terminal empty frame.
 	require.Len(t, stream.sent, 2)
@@ -881,4 +881,32 @@ func TestJsonRpcSendReplyKeepsNodecoreErrorCodes(t *testing.T) {
 	require.NoError(t, jsonRpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
 	require.Len(t, stream.sent, 1)
 	assert.Equal(t, int32(protocol.NoAvailableUpstreams), stream.sent[0].GetItemErrorCode())
+}
+
+// A grpc_data item naming a method the chain serves over JSON-RPC must be
+// rejected at the edge: routed on, its proto bytes would reach the HTTP
+// connector, which cannot build a response of type Grpc.
+func TestBuildNativeCallRequestsGrpcItemForJsonRpcMethodIsUnimplemented(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	request := &dshackle.NativeCallRequest{Items: []*dshackle.NativeCallItem{grpcItem(8, "eth_chainId", []byte{0x0a})}}
+
+	requests, _, failures := service.buildNativeCallRequests(&chains.ConfiguredChain{MethodSpec: "eth"}, request)
+	require.Empty(t, requests)
+	require.Len(t, failures, 1)
+	assert.Equal(t, int32(codes.Unimplemented), failures[0].GetItemErrorCode())
+	assert.Contains(t, failures[0].GetErrorMessage(), "eth_chainId")
+}
+
+// A streamed JSON-RPC response without an unwrap hint must surface as an
+// error item, never as a truncated success.
+func TestSendReplyStreamWithoutHintIsAnError(t *testing.T) {
+	resp := protocol.NewHttpUpstreamResponseStream("1", strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":[1,2,3]}`), protocol.JsonRpc)
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "upstream-1", RequestId: "1", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, jsonRpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.False(t, stream.sent[0].GetSucceed())
+	assert.Contains(t, stream.sent[0].GetErrorMessage(), "result field is missing")
 }

--- a/internal/server/emerald/grpc_blockchain_test.go
+++ b/internal/server/emerald/grpc_blockchain_test.go
@@ -910,3 +910,51 @@ func TestSendReplyStreamWithoutHintIsAnError(t *testing.T) {
 	assert.False(t, stream.sent[0].GetSucceed())
 	assert.Contains(t, stream.sent[0].GetErrorMessage(), "result field is missing")
 }
+
+// A request-level failure (here: no upstream supervisor) must answer every
+// item under its own id and in its own kind's error vocabulary - a gRPC item
+// with a canonical code, a JSON-RPC item with a nodecore code.
+func TestNativeCallRequestFailureIsRenderedPerItem(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	service := NewGrpcBlockchainService(nil, nil, signature.NewDisabledSigner())
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	err := service.NativeCall(&dshackle.NativeCallRequest{
+		Chain: dshackle.ChainRef_CHAIN_ETHEREUM__MAINNET,
+		Items: []*dshackle.NativeCallItem{
+			grpcItem(3, "/sui.rpc.v2.LedgerService/GetObject", nil),
+			{Id: 7, Method: "eth_chainId", Data: &dshackle.NativeCallItem_Payload{Payload: []byte(`[]`)}},
+		},
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.sent, 2)
+
+	grpcFailure, jsonRpcFailure := stream.sent[0], stream.sent[1]
+	assert.Equal(t, uint32(3), grpcFailure.GetId())
+	assert.Equal(t, int32(codes.Unavailable), grpcFailure.GetItemErrorCode())
+	assert.Equal(t, uint32(7), jsonRpcFailure.GetId())
+	assert.Equal(t, int32(protocol.NoAvailableUpstreams), jsonRpcFailure.GetItemErrorCode())
+	for _, failure := range stream.sent {
+		assert.False(t, failure.GetSucceed())
+		assert.Equal(t, flow.NoUpstream, failure.GetUpstreamId())
+	}
+}
+
+// StatusProto bytes that do not unmarshal must not reach the wire: the
+// contract tells the client to prefer status.FromProto(error_as_is).
+func TestGrpcSendReplyDropsUnparseableStatusProto(t *testing.T) {
+	request := protocol.NewUpstreamGrpcRequest("5", "/sui.rpc.v2.LedgerService/GetObject", nil, nil, "sui")
+	resp := protocol.NewGrpcUpstreamErrorResponse(request, &protocol.GrpcStatus{
+		Code:        codes.NotFound,
+		Message:     "object not found",
+		StatusProto: []byte{0xff}, // invalid wire tag
+	})
+	wrapper := &protocol.ResponseHolderWrapper{UpstreamId: "sui-1", RequestId: "5", Response: resp}
+	stream := &testNativeCallStream{ctx: context.Background()}
+
+	require.NoError(t, grpcNativeCallAdapter{}.SendReply(stream, wrapper, 0, signature.NewDisabledSigner()))
+	require.Len(t, stream.sent, 1)
+	assert.Empty(t, stream.sent[0].GetErrorAsIs())
+	assert.Equal(t, int32(codes.NotFound), stream.sent[0].GetItemErrorCode())
+	assert.Equal(t, "object not found", stream.sent[0].GetErrorMessage())
+}

--- a/internal/server/emerald/native_call_adapter.go
+++ b/internal/server/emerald/native_call_adapter.go
@@ -1,17 +1,13 @@
 package emerald
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/signature"
-	"github.com/drpcorg/nodecore/internal/upstreams/flow"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/public/pkg/dshackle"
 	"github.com/rs/zerolog/log"
@@ -36,11 +32,24 @@ type nativeCallAdapter interface {
 		nonce uint64,
 		signer signature.ResponseSigner,
 	) error
+
+	// ErrorItem renders a failure that happened before or outside the flow
+	// (no upstream) in the item's own error vocabulary.
+	ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem
 }
+
+// errorItemRenderer builds the error reply item in the vocabulary of the item's
+// API kind: JSON-RPC and REST items carry nodecore error codes and error_data,
+// gRPC items carry a canonical gRPC status. Response-level metadata is not the
+// renderer's business - sendReply stamps it via replyMeta.
+type errorItemRenderer func(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem
 
 func adapterFor(item *dshackle.NativeCallItem) nativeCallAdapter {
 	if item.GetRestData() != nil {
 		return restNativeCallAdapter{}
+	}
+	if item.GetGrpcData() != nil {
+		return grpcNativeCallAdapter{}
 	}
 	return jsonRpcNativeCallAdapter{}
 }
@@ -52,109 +61,6 @@ func mapNativeCallSelectors(requestSelector *dshackle.Selector, itemSelectors []
 	}
 	selectors = append(selectors, mapDshackleSelectors(itemSelectors)...)
 	return rejectConflictingSortSelectors(selectors)
-}
-
-type jsonRpcNativeCallAdapter struct{}
-
-func (jsonRpcNativeCallAdapter) BuildRequest(
-	chain *chains.ConfiguredChain,
-	item *dshackle.NativeCallItem,
-	requestSelector *dshackle.Selector,
-	chunkSize uint32,
-) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
-	payload := item.GetPayload()
-	if len(payload) == 0 {
-		payload = []byte("[]")
-	}
-	if !json.Valid(payload) {
-		return nil, nativeCallErrorItem(
-			item.GetId(),
-			protocol.ClientError(fmt.Errorf("payload is not a valid JSON value")),
-			flow.NoUpstream,
-			nil,
-			nil,
-		)
-	}
-
-	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
-	body := protocol.JsonRpcRequestBody{Id: []byte(requestID), Method: item.GetMethod(), Params: payload}
-	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
-	if err != nil {
-		return nil, nativeCallErrorItem(item.GetId(), protocol.ClientError(err), flow.NoUpstream, nil, nil)
-	}
-	if chunkSize > 0 {
-		return protocol.NewStreamUpstreamJsonRpcRequest(requestID, body, chain.MethodSpec, selectors...), nil
-	}
-	return protocol.NewUpstreamJsonRpcRequest(requestID, body, false, chain.MethodSpec, selectors...), nil
-}
-
-func (jsonRpcNativeCallAdapter) SendReply(
-	stream dshackle.Blockchain_NativeCallServer,
-	wrapper *protocol.ResponseHolderWrapper,
-	nonce uint64,
-	signer signature.ResponseSigner,
-) error {
-	return sendReply(stream, wrapper, nonce, signer, unwrapJsonRpcResultStream)
-}
-
-type restNativeCallAdapter struct{}
-
-func (restNativeCallAdapter) BuildRequest(
-	chain *chains.ConfiguredChain,
-	item *dshackle.NativeCallItem,
-	requestSelector *dshackle.Selector,
-	chunkSize uint32,
-) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
-	restData := item.GetRestData()
-	if restData == nil {
-		return nil, nativeCallErrorItem(
-			item.GetId(),
-			protocol.ClientError(fmt.Errorf("rest_data is missing")),
-			flow.NoUpstream,
-			nil,
-			nil,
-		)
-	}
-
-	if err := validateRestMethodTemplate(item.GetMethod()); err != nil {
-		return nil, nativeCallErrorItem(
-			item.GetId(),
-			protocol.ClientError(err),
-			flow.NoUpstream,
-			nil,
-			nil,
-		)
-	}
-
-	// gRPC clients already deliver path/headers/query params pre-structured,
-	// so we plumb them straight into RequestParams instead of recomputing
-	// anything. item.GetMethod() is taken as authoritative for the canonical
-	// method template; the HTTP connector will expand it at send time using
-	// PathParams to fill in any "*" wildcards.
-	requestParams := &protocol.RequestParams{
-		PathParams:  append([]string(nil), restData.GetPathParams()...),
-		Headers:     keyValueListToMap(restData.GetHeaders()),
-		QueryParams: keyValueListToMap(restData.GetQueryParams()),
-	}
-
-	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
-	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
-	if err != nil {
-		return nil, nativeCallErrorItem(item.GetId(), protocol.ClientError(err), flow.NoUpstream, nil, nil)
-	}
-	if chunkSize > 0 {
-		return protocol.NewStreamUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
-	}
-	return protocol.NewUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
-}
-
-func (restNativeCallAdapter) SendReply(
-	stream dshackle.Blockchain_NativeCallServer,
-	wrapper *protocol.ResponseHolderWrapper,
-	nonce uint64,
-	signer signature.ResponseSigner,
-) error {
-	return sendReply(stream, wrapper, nonce, signer, passThroughStream)
 }
 
 type streamMode int
@@ -173,42 +79,27 @@ func sendReply(
 	nonce uint64,
 	signer signature.ResponseSigner,
 	mode streamMode,
+	renderError errorItemRenderer,
 ) error {
 	if wrapper == nil || wrapper.Response == nil {
 		return fmt.Errorf("response wrapper is empty")
 	}
-	var headers http.Header
-	if resp, ok := wrapper.Response.(*protocol.GenericUpstreamResponse); ok {
-		headers = resp.ResponseHeaders()
-	}
-	resultStart := -1
-	var resultCounter protocol.ResultCounter
-	if hint, ok := wrapper.Response.GetStreamHint().(protocol.JsonRpcResultStreamHint); ok {
-		resultStart = hint.ResultStart
-		resultCounter = hint.Counter
-	}
-	requestID := parseCallItemID(wrapper.RequestId)
-	finalizationData := nativeCallFinalizationData(wrapper)
+	meta := newReplyMeta(wrapper)
+	response := wrapper.Response
 
-	if wrapper.Response.HasError() {
-		replyItem := nativeCallErrorItem(requestID, wrapper.Response.GetError(), wrapper.UpstreamId, wrapper.Response.ResponseResult(), headers)
-		replyItem.UpstreamNodeVersion = wrapper.UpstreamNodeVersion
-		replyItem.Finalization = finalizationData
-		return stream.Send(replyItem)
+	if response.HasError() {
+		return stream.Send(meta.stamp(renderError(meta.requestID, response.GetError(), response.ResponseResult())))
 	}
 
-	if wrapper.Response.HasStream() {
-		reader := wrapper.Response.EncodeResponse([]byte("0"))
-		if err := streamNativeCallBody(requestID, wrapper.UpstreamId, wrapper.UpstreamNodeVersion, finalizationData, reader, mode, resultStart, resultCounter, headers, stream); err != nil {
-			replyItem := nativeCallErrorItem(requestID, protocol.ServerErrorWithCause(err), wrapper.UpstreamId, nil, headers)
-			replyItem.UpstreamNodeVersion = wrapper.UpstreamNodeVersion
-			replyItem.Finalization = finalizationData
-			return stream.Send(replyItem)
+	if response.HasStream() {
+		hint, _ := response.GetStreamHint().(protocol.JsonRpcResultStreamHint)
+		if err := streamNativeCallBody(stream, response.EncodeResponse([]byte("0")), mode, hint, meta); err != nil {
+			return stream.Send(meta.stamp(renderError(meta.requestID, protocol.ServerErrorWithCause(err), nil)))
 		}
 		return nil
 	}
 
-	payload := append([]byte(nil), wrapper.Response.ResponseResult()...)
+	payload := append([]byte(nil), response.ResponseResult()...)
 	replySignature, err := buildReplySignature(signer, nonce, payload, wrapper.UpstreamId)
 	if err != nil {
 		log.Warn().Err(err).Msgf("unable to sign a response of request %s", wrapper.RequestId)
@@ -219,17 +110,60 @@ func sendReply(
 		if errors.Is(err, signature.ErrSigningNotConfigured) {
 			responseError = protocol.ServerErrorWithCause(err)
 		}
-		replyItem := nativeCallErrorItem(requestID, responseError, wrapper.UpstreamId, nil, headers)
-		replyItem.UpstreamNodeVersion = wrapper.UpstreamNodeVersion
-		replyItem.Finalization = finalizationData
-		return stream.Send(replyItem)
+		return stream.Send(meta.stamp(renderError(meta.requestID, responseError, nil)))
 	}
 
-	replyItem := nativeCallSuccessItem(requestID, wrapper.UpstreamId, payload, headers)
-	replyItem.UpstreamNodeVersion = wrapper.UpstreamNodeVersion
-	replyItem.Finalization = finalizationData
+	replyItem := meta.stamp(nativeCallSuccessItem(meta.requestID, payload))
 	replyItem.Signature = replySignature
 	return stream.Send(replyItem)
+}
+
+// replyMeta is the response-level metadata every reply item of one request
+// carries: who served it and what the upstream said around the body. It is
+// stamped on a buffered item, or on the first chunk of a streamed one.
+type replyMeta struct {
+	requestID           uint32
+	upstreamID          string
+	upstreamNodeVersion string
+	finalization        *dshackle.FinalizationData
+	headers             []*dshackle.KeyValue
+	trailers            []*dshackle.KeyValue
+}
+
+func newReplyMeta(wrapper *protocol.ResponseHolderWrapper) replyMeta {
+	headers, trailers := responseMetadata(wrapper.Response)
+	return replyMeta{
+		requestID:           parseCallItemID(wrapper.RequestId),
+		upstreamID:          wrapper.UpstreamId,
+		upstreamNodeVersion: wrapper.UpstreamNodeVersion,
+		finalization:        nativeCallFinalizationData(wrapper),
+		headers:             mapHeaders(headers),
+		trailers:            mapHeaders(trailers),
+	}
+}
+
+func (m replyMeta) stamp(item *dshackle.NativeCallReplyItem) *dshackle.NativeCallReplyItem {
+	item.UpstreamId = m.upstreamID
+	item.UpstreamNodeVersion = m.upstreamNodeVersion
+	item.Finalization = m.finalization
+	item.ResponseHeaders = m.headers
+	item.ResponseTrailers = m.trailers
+	return item
+}
+
+// responseMetadata reads the upstream's response metadata through the optional
+// capabilities, so success responses and error replies (a RESOURCE_EXHAUSTED
+// with rate-limit hints in its trailers is a *ReplyError) are treated alike.
+func responseMetadata(response protocol.ResponseHolder) (http.Header, map[string][]string) {
+	var headers http.Header
+	var trailers map[string][]string
+	if headerBearer, ok := response.(protocol.HasResponseHeaders); ok {
+		headers = headerBearer.ResponseHeaders()
+	}
+	if trailerBearer, ok := response.(protocol.HasResponseTrailers); ok {
+		trailers = trailerBearer.ResponseTrailers()
+	}
+	return headers, trailers
 }
 
 func nativeCallFinalizationData(wrapper *protocol.ResponseHolderWrapper) *dshackle.FinalizationData {
@@ -246,21 +180,15 @@ func nativeCallFinalizationData(wrapper *protocol.ResponseHolderWrapper) *dshack
 }
 
 func streamNativeCallBody(
-	requestID uint32,
-	upstreamID string,
-	upstreamNodeVersion string,
-	finalization *dshackle.FinalizationData,
+	stream dshackle.Blockchain_NativeCallServer,
 	reader io.Reader,
 	mode streamMode,
-	resultStart int,
-	resultCounter protocol.ResultCounter,
-	header http.Header,
-	stream dshackle.Blockchain_NativeCallServer,
+	hint protocol.JsonRpcResultStreamHint,
+	meta replyMeta,
 ) error {
-	headerKVs := mapHeaders(header)
 	emitter := newNativeCallChunkEmitter(func(chunk []byte, first, final bool) error {
 		item := &dshackle.NativeCallReplyItem{
-			Id:         requestID,
+			Id:         meta.requestID,
 			Succeed:    true,
 			Payload:    chunk,
 			Chunked:    true,
@@ -268,10 +196,7 @@ func streamNativeCallBody(
 		}
 		// Response-level metadata travels on the first chunk only.
 		if first {
-			item.UpstreamId = upstreamID
-			item.UpstreamNodeVersion = upstreamNodeVersion
-			item.Finalization = finalization
-			item.ResponseHeaders = headerKVs
+			meta.stamp(item)
 		}
 		return stream.Send(item)
 	})
@@ -279,7 +204,7 @@ func streamNativeCallBody(
 	ctx := stream.Context()
 	switch mode {
 	case unwrapJsonRpcResultStream:
-		if err := streamJsonRPCResult(ctx, reader, emitter, resultStart, resultCounter); err != nil {
+		if err := streamJsonRPCResult(ctx, reader, emitter, hint.ResultStart, hint.Counter); err != nil {
 			return err
 		}
 	case passThroughStream:
@@ -295,17 +220,6 @@ func streamNativeCallBody(
 		return fmt.Errorf("unknown stream mode %d", mode)
 	}
 	return emitter.Finish()
-}
-
-// validateRestMethodTemplate checks that a gRPC-supplied method string is
-// well-formed: "VERB#/path", both halves non-empty. The actual verb/path
-// split happens inside the HTTP connector when the request is sent.
-func validateRestMethodTemplate(method string) error {
-	parts := strings.SplitN(method, protocol.MethodSeparator, 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("rest method must be in form VERB%spath, got %q", protocol.MethodSeparator, method)
-	}
-	return nil
 }
 
 // keyValueListToMap collapses a dshackle KeyValue repeated field into the

--- a/internal/server/emerald/native_call_adapter.go
+++ b/internal/server/emerald/native_call_adapter.go
@@ -92,7 +92,11 @@ func sendReply(
 	}
 
 	if response.HasStream() {
-		hint, _ := response.GetStreamHint().(protocol.JsonRpcResultStreamHint)
+		// a missing hint must fail the unwrap, not read as "result at offset 0"
+		hint := protocol.NoJsonRpcResultStreamHint
+		if h, ok := response.GetStreamHint().(protocol.JsonRpcResultStreamHint); ok {
+			hint = h
+		}
 		if err := streamNativeCallBody(stream, response.EncodeResponse([]byte("0")), mode, hint, meta); err != nil {
 			return stream.Send(meta.stamp(renderError(meta.requestID, protocol.ServerErrorWithCause(err), nil)))
 		}

--- a/internal/server/emerald/native_call_adapter.go
+++ b/internal/server/emerald/native_call_adapter.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/signature"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/public/pkg/dshackle"
 	"github.com/rs/zerolog/log"
@@ -33,16 +33,19 @@ type nativeCallAdapter interface {
 		signer signature.ResponseSigner,
 	) error
 
-	// ErrorItem renders a failure that happened before or outside the flow
-	// (no upstream) in the item's own error vocabulary.
-	ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem
+	// ErrorItem renders a failure in the item's own error vocabulary: JSON-RPC
+	// and REST items carry nodecore error codes and error_data, gRPC items a
+	// canonical gRPC status. Neither response-level metadata nor the upstream
+	// id are its business - sendReply stamps them via replyMeta, pre-dispatch
+	// callers mark flow.NoUpstream via withNoUpstreamId.
+	ErrorItem(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem
 }
 
-// errorItemRenderer builds the error reply item in the vocabulary of the item's
-// API kind: JSON-RPC and REST items carry nodecore error codes and error_data,
-// gRPC items carry a canonical gRPC status. Response-level metadata is not the
-// renderer's business - sendReply stamps it via replyMeta.
-type errorItemRenderer func(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem
+// withNoUpstreamId marks a failure raised before any upstream was involved.
+func withNoUpstreamId(item *dshackle.NativeCallReplyItem) *dshackle.NativeCallReplyItem {
+	item.UpstreamId = flow.NoUpstream
+	return item
+}
 
 func adapterFor(item *dshackle.NativeCallItem) nativeCallAdapter {
 	if item.GetRestData() != nil {
@@ -79,7 +82,7 @@ func sendReply(
 	nonce uint64,
 	signer signature.ResponseSigner,
 	mode streamMode,
-	renderError errorItemRenderer,
+	renderError func(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem,
 ) error {
 	if wrapper == nil || wrapper.Response == nil {
 		return fmt.Errorf("response wrapper is empty")
@@ -135,7 +138,7 @@ type replyMeta struct {
 }
 
 func newReplyMeta(wrapper *protocol.ResponseHolderWrapper) replyMeta {
-	headers, trailers := responseMetadata(wrapper.Response)
+	headers, trailers := protocol.ResponseMetadata(wrapper.Response)
 	return replyMeta{
 		requestID:           parseCallItemID(wrapper.RequestId),
 		upstreamID:          wrapper.UpstreamId,
@@ -153,21 +156,6 @@ func (m replyMeta) stamp(item *dshackle.NativeCallReplyItem) *dshackle.NativeCal
 	item.ResponseHeaders = m.headers
 	item.ResponseTrailers = m.trailers
 	return item
-}
-
-// responseMetadata reads the upstream's response metadata through the optional
-// capabilities, so success responses and error replies (a RESOURCE_EXHAUSTED
-// with rate-limit hints in its trailers is a *ReplyError) are treated alike.
-func responseMetadata(response protocol.ResponseHolder) (http.Header, map[string][]string) {
-	var headers http.Header
-	var trailers map[string][]string
-	if headerBearer, ok := response.(protocol.HasResponseHeaders); ok {
-		headers = headerBearer.ResponseHeaders()
-	}
-	if trailerBearer, ok := response.(protocol.HasResponseTrailers); ok {
-		trailers = trailerBearer.ResponseTrailers()
-	}
-	return headers, trailers
 }
 
 func nativeCallFinalizationData(wrapper *protocol.ResponseHolderWrapper) *dshackle.FinalizationData {
@@ -198,7 +186,10 @@ func streamNativeCallBody(
 			Chunked:    true,
 			FinalChunk: final,
 		}
-		// Response-level metadata travels on the first chunk only.
+		// Response-level metadata travels on the first chunk only. That holds
+		// for trailers too: streamed responses are HTTP-only (a gRPC reply is
+		// always buffered) and HTTP responses carry no trailers here, so
+		// nothing arrives after the body that this could miss.
 		if first {
 			meta.stamp(item)
 		}

--- a/internal/server/emerald/native_call_adapter_grpc.go
+++ b/internal/server/emerald/native_call_adapter_grpc.go
@@ -2,6 +2,7 @@ package emerald
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -34,8 +35,10 @@ func (a grpcNativeCallAdapter) BuildRequest(
 	// Unknown methods answer precisely here instead of "no available upstreams",
 	// and server streams belong to NativeSubscribe (the flow would route them
 	// as subscriptions).
+	// A method without the grpc connector is not a gRPC method on this chain:
+	// letting it through would route proto bytes to an HTTP connector.
 	specMethod := specs.GetSpecMethod(chain.MethodSpec, item.GetMethod())
-	if specMethod == nil {
+	if specMethod == nil || !slices.Contains(specMethod.GetApiConnectorTypes(), specs.GrpcConnector) {
 		return nil, a.ErrorItem(item.GetId(), protocol.NotSupportedMethodError(item.GetMethod()))
 	}
 	if specMethod.GrpcCallType().IsServerStream() {

--- a/internal/server/emerald/native_call_adapter_grpc.go
+++ b/internal/server/emerald/native_call_adapter_grpc.go
@@ -1,0 +1,90 @@
+package emerald
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/server/server_ctx"
+	"github.com/drpcorg/nodecore/internal/signature"
+	"github.com/drpcorg/nodecore/internal/upstreams/flow"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/public/pkg/dshackle"
+	specs "github.com/drpcorg/public/pkg/methods"
+)
+
+// grpcNativeCallAdapter serves a native unary gRPC call carried in
+// NativeCallItem.grpc_data: the full method name in item.method, the
+// serialized request message in payload (no wire frame prefix) and the call
+// metadata to forward. The payload is never parsed.
+type grpcNativeCallAdapter struct{}
+
+func (a grpcNativeCallAdapter) BuildRequest(
+	chain *chains.ConfiguredChain,
+	item *dshackle.NativeCallItem,
+	requestSelector *dshackle.Selector,
+	_ uint32, // chunk_size: a unary gRPC reply is always one unchunked message
+) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
+	grpcData := item.GetGrpcData()
+	if grpcData == nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("grpc_data is missing")))
+	}
+
+	// arity is not on the gRPC wire - only the spec knows a method's shape.
+	// Unknown methods answer precisely here instead of "no available upstreams",
+	// and server streams belong to NativeSubscribe (the flow would route them
+	// as subscriptions).
+	specMethod := specs.GetSpecMethod(chain.MethodSpec, item.GetMethod())
+	if specMethod == nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.NotSupportedMethodError(item.GetMethod()))
+	}
+	if specMethod.GrpcCallType().IsServerStream() {
+		return nil, a.ErrorItem(item.GetId(),
+			protocol.ClientError(fmt.Errorf("server-stream method %s must be called via NativeSubscribe", item.GetMethod())))
+	}
+
+	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
+	if err != nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+	}
+
+	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
+	requestParams := &protocol.RequestParams{
+		Headers: server_ctx.SanitizeForwardedHeaders(keyValueListToMap(grpcData.GetMetadata())),
+	}
+	return protocol.NewUpstreamGrpcRequest(requestID, item.GetMethod(), requestParams, grpcData.GetPayload(), chain.MethodSpec, selectors...), nil
+}
+
+func (grpcNativeCallAdapter) SendReply(
+	stream dshackle.Blockchain_NativeCallServer,
+	wrapper *protocol.ResponseHolderWrapper,
+	nonce uint64,
+	signer signature.ResponseSigner,
+) error {
+	return sendReply(stream, wrapper, nonce, signer, passThroughStream, grpcNativeCallErrorItem)
+}
+
+func (grpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
+	replyItem := grpcNativeCallErrorItem(requestID, responseError, nil)
+	replyItem.UpstreamId = flow.NoUpstream
+	return replyItem
+}
+
+// grpcNativeCallErrorItem renders an error for a gRPC item: item_error_code is
+// always a canonical gRPC code, error_message the status message, error_as_is
+// the serialized google.rpc.Status when the upstream attached typed details.
+// error_data is never used for gRPC items, and the "as is" body of other API
+// kinds has no gRPC counterpart.
+func grpcNativeCallErrorItem(requestID uint32, responseError *protocol.ResponseError, _ []byte) *dshackle.NativeCallReplyItem {
+	grpcStatus := protocol.GrpcStatusOf(responseError)
+	replyItem := &dshackle.NativeCallReplyItem{
+		Id:            requestID,
+		Succeed:       false,
+		ErrorMessage:  grpcStatus.Message(),
+		ItemErrorCode: int32(grpcStatus.Code()),
+	}
+	if upstreamStatus, ok := protocol.GrpcStatusFromError(responseError); ok && len(upstreamStatus.StatusProto) > 0 {
+		replyItem.ErrorAsIs = append([]byte(nil), upstreamStatus.StatusProto...)
+	}
+	return replyItem
+}

--- a/internal/server/emerald/native_call_adapter_grpc.go
+++ b/internal/server/emerald/native_call_adapter_grpc.go
@@ -8,7 +8,6 @@ import (
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/server/server_ctx"
 	"github.com/drpcorg/nodecore/internal/signature"
-	"github.com/drpcorg/nodecore/internal/upstreams/flow"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/public/pkg/dshackle"
 	specs "github.com/drpcorg/public/pkg/methods"
@@ -28,7 +27,7 @@ func (a grpcNativeCallAdapter) BuildRequest(
 ) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
 	grpcData := item.GetGrpcData()
 	if grpcData == nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("grpc_data is missing")))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("grpc_data is missing")), nil))
 	}
 
 	// arity is not on the gRPC wire - only the spec knows a method's shape.
@@ -39,16 +38,16 @@ func (a grpcNativeCallAdapter) BuildRequest(
 	// letting it through would route proto bytes to an HTTP connector.
 	specMethod := specs.GetSpecMethod(chain.MethodSpec, item.GetMethod())
 	if specMethod == nil || !slices.Contains(specMethod.GetApiConnectorTypes(), specs.GrpcConnector) {
-		return nil, a.ErrorItem(item.GetId(), protocol.NotSupportedMethodError(item.GetMethod()))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.NotSupportedMethodError(item.GetMethod()), nil))
 	}
 	if specMethod.GrpcCallType().IsServerStream() {
-		return nil, a.ErrorItem(item.GetId(),
-			protocol.ClientError(fmt.Errorf("server-stream method %s must be called via NativeSubscribe", item.GetMethod())))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(),
+			protocol.ClientError(fmt.Errorf("server-stream method %s must be called via NativeSubscribe", item.GetMethod())), nil))
 	}
 
 	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
 	if err != nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(err), nil))
 	}
 
 	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
@@ -64,13 +63,11 @@ func (grpcNativeCallAdapter) SendReply(
 	nonce uint64,
 	signer signature.ResponseSigner,
 ) error {
-	return sendReply(stream, wrapper, nonce, signer, passThroughStream, grpcNativeCallErrorItem)
+	return sendReply(stream, wrapper, nonce, signer, passThroughStream, grpcNativeCallAdapter{}.ErrorItem)
 }
 
-func (grpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
-	replyItem := grpcNativeCallErrorItem(requestID, responseError, nil)
-	replyItem.UpstreamId = flow.NoUpstream
-	return replyItem
+func (grpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem {
+	return grpcNativeCallErrorItem(requestID, responseError, errorAsIs)
 }
 
 // grpcNativeCallErrorItem renders an error for a gRPC item: item_error_code is
@@ -79,15 +76,21 @@ func (grpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol
 // error_data is never used for gRPC items, and the "as is" body of other API
 // kinds has no gRPC counterpart.
 func grpcNativeCallErrorItem(requestID uint32, responseError *protocol.ResponseError, _ []byte) *dshackle.NativeCallReplyItem {
-	grpcStatus := protocol.GrpcStatusOf(responseError)
+	grpcStatus, fromStatusProto := protocol.GrpcStatusOf(responseError)
 	replyItem := &dshackle.NativeCallReplyItem{
 		Id:            requestID,
 		Succeed:       false,
 		ErrorMessage:  grpcStatus.Message(),
 		ItemErrorCode: int32(grpcStatus.Code()),
 	}
-	if upstreamStatus, ok := protocol.GrpcStatusFromError(responseError); ok && len(upstreamStatus.StatusProto) > 0 {
-		replyItem.ErrorAsIs = append([]byte(nil), upstreamStatus.StatusProto...)
+	// The contract tells the client to prefer status.FromProto(error_as_is),
+	// so the status proto goes on the wire only when GrpcStatusOf actually
+	// reconstructed the status from it - corrupt bytes (never produced by our
+	// connector, purely defensive) stay off the wire.
+	if fromStatusProto {
+		if upstreamStatus, ok := protocol.GrpcStatusFromError(responseError); ok {
+			replyItem.ErrorAsIs = append([]byte(nil), upstreamStatus.StatusProto...)
+		}
 	}
 	return replyItem
 }

--- a/internal/server/emerald/native_call_adapter_jsonrpc.go
+++ b/internal/server/emerald/native_call_adapter_jsonrpc.go
@@ -1,0 +1,53 @@
+package emerald
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/signature"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/public/pkg/dshackle"
+)
+
+type jsonRpcNativeCallAdapter struct{}
+
+func (a jsonRpcNativeCallAdapter) BuildRequest(
+	chain *chains.ConfiguredChain,
+	item *dshackle.NativeCallItem,
+	requestSelector *dshackle.Selector,
+	chunkSize uint32,
+) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
+	payload := item.GetPayload()
+	if len(payload) == 0 {
+		payload = []byte("[]")
+	}
+	if !json.Valid(payload) {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("payload is not a valid JSON value")))
+	}
+
+	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
+	body := protocol.JsonRpcRequestBody{Id: []byte(requestID), Method: item.GetMethod(), Params: payload}
+	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
+	if err != nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+	}
+	if chunkSize > 0 {
+		return protocol.NewStreamUpstreamJsonRpcRequest(requestID, body, chain.MethodSpec, selectors...), nil
+	}
+	return protocol.NewUpstreamJsonRpcRequest(requestID, body, false, chain.MethodSpec, selectors...), nil
+}
+
+func (jsonRpcNativeCallAdapter) SendReply(
+	stream dshackle.Blockchain_NativeCallServer,
+	wrapper *protocol.ResponseHolderWrapper,
+	nonce uint64,
+	signer signature.ResponseSigner,
+) error {
+	return sendReply(stream, wrapper, nonce, signer, unwrapJsonRpcResultStream, nativeCallErrorItem)
+}
+
+func (jsonRpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
+	return noUpstreamErrorItem(requestID, responseError)
+}

--- a/internal/server/emerald/native_call_adapter_jsonrpc.go
+++ b/internal/server/emerald/native_call_adapter_jsonrpc.go
@@ -24,14 +24,14 @@ func (a jsonRpcNativeCallAdapter) BuildRequest(
 		payload = []byte("[]")
 	}
 	if !json.Valid(payload) {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("payload is not a valid JSON value")))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("payload is not a valid JSON value")), nil))
 	}
 
 	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
 	body := protocol.JsonRpcRequestBody{Id: []byte(requestID), Method: item.GetMethod(), Params: payload}
 	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
 	if err != nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(err), nil))
 	}
 	if chunkSize > 0 {
 		return protocol.NewStreamUpstreamJsonRpcRequest(requestID, body, chain.MethodSpec, selectors...), nil
@@ -45,9 +45,9 @@ func (jsonRpcNativeCallAdapter) SendReply(
 	nonce uint64,
 	signer signature.ResponseSigner,
 ) error {
-	return sendReply(stream, wrapper, nonce, signer, unwrapJsonRpcResultStream, nativeCallErrorItem)
+	return sendReply(stream, wrapper, nonce, signer, unwrapJsonRpcResultStream, jsonRpcNativeCallAdapter{}.ErrorItem)
 }
 
-func (jsonRpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
-	return noUpstreamErrorItem(requestID, responseError)
+func (jsonRpcNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem {
+	return nativeCallErrorItem(requestID, responseError, errorAsIs)
 }

--- a/internal/server/emerald/native_call_adapter_rest.go
+++ b/internal/server/emerald/native_call_adapter_rest.go
@@ -21,11 +21,11 @@ func (a restNativeCallAdapter) BuildRequest(
 ) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
 	restData := item.GetRestData()
 	if restData == nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("rest_data is missing")))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("rest_data is missing")), nil))
 	}
 
 	if err := validateRestMethodTemplate(item.GetMethod()); err != nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(err), nil))
 	}
 
 	// gRPC clients already deliver path/headers/query params pre-structured,
@@ -42,7 +42,7 @@ func (a restNativeCallAdapter) BuildRequest(
 	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
 	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
 	if err != nil {
-		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+		return nil, withNoUpstreamId(a.ErrorItem(item.GetId(), protocol.ClientError(err), nil))
 	}
 	if chunkSize > 0 {
 		return protocol.NewStreamUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
@@ -56,11 +56,11 @@ func (restNativeCallAdapter) SendReply(
 	nonce uint64,
 	signer signature.ResponseSigner,
 ) error {
-	return sendReply(stream, wrapper, nonce, signer, passThroughStream, nativeCallErrorItem)
+	return sendReply(stream, wrapper, nonce, signer, passThroughStream, restNativeCallAdapter{}.ErrorItem)
 }
 
-func (restNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
-	return noUpstreamErrorItem(requestID, responseError)
+func (restNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError, errorAsIs []byte) *dshackle.NativeCallReplyItem {
+	return nativeCallErrorItem(requestID, responseError, errorAsIs)
 }
 
 // validateRestMethodTemplate checks that a gRPC-supplied method string is

--- a/internal/server/emerald/native_call_adapter_rest.go
+++ b/internal/server/emerald/native_call_adapter_rest.go
@@ -1,0 +1,75 @@
+package emerald
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/signature"
+	"github.com/drpcorg/nodecore/pkg/chains"
+	"github.com/drpcorg/public/pkg/dshackle"
+)
+
+type restNativeCallAdapter struct{}
+
+func (a restNativeCallAdapter) BuildRequest(
+	chain *chains.ConfiguredChain,
+	item *dshackle.NativeCallItem,
+	requestSelector *dshackle.Selector,
+	chunkSize uint32,
+) (protocol.RequestHolder, *dshackle.NativeCallReplyItem) {
+	restData := item.GetRestData()
+	if restData == nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(fmt.Errorf("rest_data is missing")))
+	}
+
+	if err := validateRestMethodTemplate(item.GetMethod()); err != nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+	}
+
+	// gRPC clients already deliver path/headers/query params pre-structured,
+	// so we plumb them straight into RequestParams instead of recomputing
+	// anything. item.GetMethod() is taken as authoritative for the canonical
+	// method template; the HTTP connector will expand it at send time using
+	// PathParams to fill in any "*" wildcards.
+	requestParams := &protocol.RequestParams{
+		PathParams:  append([]string(nil), restData.GetPathParams()...),
+		Headers:     keyValueListToMap(restData.GetHeaders()),
+		QueryParams: keyValueListToMap(restData.GetQueryParams()),
+	}
+
+	requestID := strconv.FormatUint(uint64(item.GetId()), 10)
+	selectors, err := mapNativeCallSelectors(requestSelector, item.GetSelectors())
+	if err != nil {
+		return nil, a.ErrorItem(item.GetId(), protocol.ClientError(err))
+	}
+	if chunkSize > 0 {
+		return protocol.NewStreamUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
+	}
+	return protocol.NewUpstreamRestRequest(requestID, item.GetMethod(), requestParams, restData.GetPayload(), chain.MethodSpec, selectors...), nil
+}
+
+func (restNativeCallAdapter) SendReply(
+	stream dshackle.Blockchain_NativeCallServer,
+	wrapper *protocol.ResponseHolderWrapper,
+	nonce uint64,
+	signer signature.ResponseSigner,
+) error {
+	return sendReply(stream, wrapper, nonce, signer, passThroughStream, nativeCallErrorItem)
+}
+
+func (restNativeCallAdapter) ErrorItem(requestID uint32, responseError *protocol.ResponseError) *dshackle.NativeCallReplyItem {
+	return noUpstreamErrorItem(requestID, responseError)
+}
+
+// validateRestMethodTemplate checks that a gRPC-supplied method string is
+// well-formed: "VERB#/path", both halves non-empty. The actual verb/path
+// split happens inside the HTTP connector when the request is sent.
+func validateRestMethodTemplate(method string) error {
+	parts := strings.SplitN(method, protocol.MethodSeparator, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("rest method must be in form VERB%spath, got %q", protocol.MethodSeparator, method)
+	}
+	return nil
+}

--- a/internal/server/grpc_ingress/chain_ingress.go
+++ b/internal/server/grpc_ingress/chain_ingress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strings"
 	"time"
 
@@ -157,8 +158,12 @@ func (h *grpcRequestHandler) RequestDecode(_ context.Context) (*server_ctx.Reque
 	}
 
 	specName := chains.GetMethodSpecNameByChainName(chainName)
+	// The grpc connector requirement makes the "only gRPC methods are served
+	// here" invariant local: today it also follows from the :path shape
+	// (grpc-go only accepts /Service/Method and no JSON-RPC or REST method is
+	// named that way), but that is a naming convention, not a guarantee.
 	specMethod := specs.GetSpecMethod(specName, h.method)
-	if specMethod == nil {
+	if specMethod == nil || !slices.Contains(specMethod.GetApiConnectorTypes(), specs.GrpcConnector) {
 		return nil, protocol.ResponseErrorWithData(protocol.NoSupportedMethod, fmt.Sprintf("unknown method %s", h.method), nil)
 	}
 	requestFrame, err := h.receiveRequestFrame()
@@ -214,15 +219,12 @@ func (h *grpcRequestHandler) receiveRequestFrame() (*rawFrame, error) {
 // headers via SetHeader (flushed with the first message or the status),
 // trailers via SetTrailer - a gRPC client must receive trailers as trailers.
 func forwardResponseMetadata(stream grpc.ServerStream, response protocol.ResponseHolder) {
-	if headerBearer, ok := response.(protocol.HasResponseHeaders); ok {
-		if headers := headerBearer.ResponseHeaders(); len(headers) > 0 {
-			_ = stream.SetHeader(metadata.MD(headers))
-		}
+	headers, trailers := protocol.ResponseMetadata(response)
+	if len(headers) > 0 {
+		_ = stream.SetHeader(metadata.MD(headers))
 	}
-	if trailerBearer, ok := response.(protocol.HasResponseTrailers); ok {
-		if trailers := trailerBearer.ResponseTrailers(); len(trailers) > 0 {
-			stream.SetTrailer(trailers)
-		}
+	if len(trailers) > 0 {
+		stream.SetTrailer(trailers)
 	}
 }
 

--- a/internal/server/grpc_ingress/chain_ingress.go
+++ b/internal/server/grpc_ingress/chain_ingress.go
@@ -14,14 +14,12 @@ import (
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/nodecore/pkg/utils"
 	specs "github.com/drpcorg/public/pkg/methods"
-	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // xNodecoreChain selects the target chain, sent as call metadata: the chain
@@ -226,44 +224,6 @@ func forwardResponseMetadata(stream grpc.ServerStream, response protocol.Respons
 			stream.SetTrailer(trailers)
 		}
 	}
-}
-
-// grpcStatusFromResponseError turns a flow error back into a *status.Status.
-// An upstream gRPC status rides through verbatim - typed details included;
-// nodecore's own error codes are mapped onto the closed 17-code model.
-func grpcStatusFromResponseError(respError *protocol.ResponseError) *status.Status {
-	if grpcStatus, ok := protocol.GrpcStatusFromError(respError); ok {
-		if len(grpcStatus.StatusProto) > 0 {
-			var statusProto spb.Status
-			if err := proto.Unmarshal(grpcStatus.StatusProto, &statusProto); err == nil {
-				return status.FromProto(&statusProto)
-			}
-		}
-		return status.New(grpcStatus.Code, grpcStatus.Message)
-	}
-
-	var code codes.Code
-	switch respError.Code {
-	case protocol.NoAvailableUpstreams, protocol.NoApiConnectors:
-		code = codes.Unavailable
-	case protocol.AuthErrorCode:
-		code = codes.PermissionDenied
-	case protocol.ClientErrorCode, protocol.WrongChain:
-		code = codes.InvalidArgument
-	case protocol.RequestTimeout, protocol.CtxErrorCode:
-		code = codes.DeadlineExceeded
-	case protocol.RateLimitExceeded:
-		code = codes.ResourceExhausted
-	case protocol.NoSupportedMethod:
-		code = codes.Unimplemented
-	case protocol.SubscribeTotalFailure:
-		// the node ended a subscription without a status, or the client fell
-		// too far behind
-		code = codes.Unavailable
-	default:
-		code = codes.Internal
-	}
-	return status.New(code, respError.Message)
 }
 
 func firstMetadataValue(md metadata.MD, key string) string {

--- a/internal/server/grpc_ingress/chain_ingress_test.go
+++ b/internal/server/grpc_ingress/chain_ingress_test.go
@@ -698,3 +698,21 @@ func TestStatusFromMissingResponse(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Canceled, status.Code(err))
 }
+
+// A spec-known method without the grpc connector must answer "unknown method":
+// today no JSON-RPC or REST method name fits the /Service/Method path shape,
+// but the invariant must not depend on naming conventions.
+func TestGrpcRequestHandlerRejectsNonGrpcMethod(t *testing.T) {
+	require.NoError(t, specs.NewMethodSpecLoader().Load())
+	handler := &grpcRequestHandler{
+		md:     metadata.New(map[string]string{strings.ToLower(xNodecoreChain): "ethereum"}),
+		method: "eth_chainId",
+	}
+
+	_, err := handler.RequestDecode(context.Background())
+	require.Error(t, err)
+	respErr, ok := errors.AsType[*protocol.ResponseError](err)
+	require.True(t, ok)
+	assert.Equal(t, protocol.NoSupportedMethod, respErr.Code)
+	assert.Contains(t, respErr.Message, "eth_chainId")
+}

--- a/internal/server/grpc_ingress/grpc_call.go
+++ b/internal/server/grpc_ingress/grpc_call.go
@@ -54,7 +54,8 @@ func (u *unaryCall) serve(stream grpc.ServerStream, handleResp *server_ctx.Handl
 	}
 	forwardResponseMetadata(stream, wrapper.Response)
 	if wrapper.Response.HasError() {
-		return protocol.GrpcStatusOf(wrapper.Response.GetError()).Err()
+		grpcStatus, _ := protocol.GrpcStatusOf(wrapper.Response.GetError())
+		return grpcStatus.Err()
 	}
 	return stream.SendMsg(&rawFrame{data: wrapper.Response.ResponseResult()})
 }
@@ -80,7 +81,8 @@ func (s *serverStreamCall) serve(stream grpc.ServerStream, handleResp *server_ct
 			// handler returns, so a trailer seen on any frame is delivered.
 			forwardResponseMetadata(stream, response)
 			if response.HasError() {
-				return protocol.GrpcStatusOf(response.GetError()).Err()
+				grpcStatus, _ := protocol.GrpcStatusOf(response.GetError())
+				return grpcStatus.Err()
 			}
 			if eventResponse, ok := response.(protocol.SubscriptionResponseHolder); ok && !eventResponse.IsEventFrame() {
 				continue

--- a/internal/server/grpc_ingress/grpc_call.go
+++ b/internal/server/grpc_ingress/grpc_call.go
@@ -54,7 +54,7 @@ func (u *unaryCall) serve(stream grpc.ServerStream, handleResp *server_ctx.Handl
 	}
 	forwardResponseMetadata(stream, wrapper.Response)
 	if wrapper.Response.HasError() {
-		return grpcStatusFromResponseError(wrapper.Response.GetError()).Err()
+		return protocol.GrpcStatusOf(wrapper.Response.GetError()).Err()
 	}
 	return stream.SendMsg(&rawFrame{data: wrapper.Response.ResponseResult()})
 }
@@ -80,7 +80,7 @@ func (s *serverStreamCall) serve(stream grpc.ServerStream, handleResp *server_ct
 			// handler returns, so a trailer seen on any frame is delivered.
 			forwardResponseMetadata(stream, response)
 			if response.HasError() {
-				return grpcStatusFromResponseError(response.GetError()).Err()
+				return protocol.GrpcStatusOf(response.GetError()).Err()
 			}
 			if eventResponse, ok := response.(protocol.SubscriptionResponseHolder); ok && !eventResponse.IsEventFrame() {
 				continue

--- a/internal/upstreams/flow/sub_framing.go
+++ b/internal/upstreams/flow/sub_framing.go
@@ -69,7 +69,7 @@ func (resultOnlyFraming) begin(protocol.RequestHolder, context.CancelFunc) (*pro
 }
 
 func (resultOnlyFraming) event(request protocol.RequestHolder, r protocol.SubResponse) protocol.ResponseHolder {
-	headers, trailers := subResponseMetadata(r)
+	headers, trailers := protocol.ResponseMetadata(r)
 	return protocol.NewSubscriptionResultEventResponse(request.Id(), r.GetMessage()).WithResponseHeaders(headers).WithResponseTrailers(trailers)
 }
 

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -3,7 +3,6 @@ package flow
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/drpcorg/nodecore/internal/config"
 	"github.com/drpcorg/nodecore/internal/protocol"
@@ -155,7 +154,7 @@ func responseUpstreamId(r protocol.SubResponse) string {
 // final response - the terminal error, or a non-event end frame for a clean
 // completion - keeping the transport metadata it carried (gRPC trailers).
 func terminalWrapper(request protocol.RequestHolder, terminal protocol.SubResponse) *protocol.ResponseHolderWrapper {
-	headers, trailers := subResponseMetadata(terminal)
+	headers, trailers := protocol.ResponseMetadata(terminal)
 	if terminal.GetError() == nil {
 		return &protocol.ResponseHolderWrapper{
 			UpstreamId: responseUpstreamId(terminal),
@@ -168,17 +167,4 @@ func terminalWrapper(request protocol.RequestHolder, terminal protocol.SubRespon
 		replyErr.WithResponseHeaders(headers).WithResponseTrailers(trailers)
 	}
 	return wrapper
-}
-
-// subResponseMetadata reads the optional transport metadata of a frame.
-func subResponseMetadata(r protocol.SubResponse) (http.Header, map[string][]string) {
-	var headers http.Header
-	var trailers map[string][]string
-	if headerBearer, ok := r.(protocol.HasResponseHeaders); ok {
-		headers = headerBearer.ResponseHeaders()
-	}
-	if trailerBearer, ok := r.(protocol.HasResponseTrailers); ok {
-		trailers = trailerBearer.ResponseTrailers()
-	}
-	return headers, trailers
 }


### PR DESCRIPTION
# NativeCall: serve native gRPC calls via `grpc_data` items

## Summary

The dshackle `Blockchain.NativeCall` stream now accepts native unary gRPC calls (Sui
`sui.rpc.v2.*`) alongside JSON-RPC and REST items. A `NativeCallItem` with the new
`grpc_data` oneof branch is routed through the same execution flow as the gRPC chain
ingress and answered with one buffered reply item carrying the response message bytes,
the upstream's headers **and trailers**, and — on failure — a canonical gRPC status.

Bytes-only throughout: request and response messages are never parsed.

Depends on `github.com/drpcorg/public` **v1.1.0** (bumped here), which added:

```proto
message NativeCallItem { oneof data { ...; GrpcData grpc_data = 9; } }
message GrpcData { bytes payload = 1; repeated KeyValue metadata = 2; }
message NativeCallReplyItem { ...; repeated KeyValue response_trailers = 16; }
```

## Contract for a gRPC item

**Request** — `method` is the full gRPC method name (`/sui.rpc.v2.LedgerService/GetObject`),
`grpc_data.payload` the serialized request message (no 5-byte wire frame prefix),
`grpc_data.metadata` the call metadata to forward. Credential metadata (`x-nodecore-key`,
`x-nodecore-token`, `authorization`) is stripped before forwarding, exactly like the ingress does.
`chunk_size` is ignored: a unary gRPC reply is always one unchunked message.

**Success** — `payload` = response message bytes verbatim, `signature` over those bytes when
a nonce is given, `response_headers` / `response_trailers` = upstream metadata.

**Error** — existing fields, gRPC vocabulary:

| field | value |
|---|---|
| `item_error_code` | canonical gRPC code (0–16) — never nodecore's internal `ResponseError.Code` |
| `error_message` | the status message |
| `error_as_is` | serialized `google.rpc.Status` when the upstream attached typed details; empty otherwise |
| `error_data` | always empty for gRPC items |
| `response_headers` / `response_trailers` | present on error items too (e.g. `RESOURCE_EXHAUSTED` rate-limit hints ride in trailers) |

An upstream status is replayed verbatim; nodecore's own errors (no upstreams, rate limit,
unknown method, timeout, auth, …) are mapped onto the 17-code model **in nodecore**, so the
client needs no mapping table of its own: `status.FromProto(error_as_is)` when set, else
`status.New(item_error_code, error_message)`.

Rejected up front (no upstream involved): unknown method → `UNIMPLEMENTED`; a server-stream
spec method → `INVALID_ARGUMENT` pointing at `NativeSubscribe`; missing `grpc_data` →
`INVALID_ARGUMENT`.

## Changes

- **`protocol.GrpcStatusOf(*ResponseError) *status.Status`** — the nodecore-error → gRPC
  status mapping, moved out of `grpc_ingress/chain_ingress.go` (`grpcStatusFromResponseError`)
  so the ingress and the emerald server share one table. The ingress behaviour is unchanged.
- **`internal/server/emerald`**
  - `native_call_adapter.go` is split per API kind: `native_call_adapter_jsonrpc.go`,
    `native_call_adapter_rest.go`, `native_call_adapter_grpc.go` (new adapter); the shared
    file keeps the `nativeCallAdapter` interface, `adapterFor` and the reply machinery.
  - `nativeCallAdapter` gains `ErrorItem(requestID, err)`, so pre-dispatch failures (invalid
    payload, selector conflicts, signature requested without a signer) render in the item's
    own error vocabulary. The adapter is now chosen before the signing check.
  - `sendReply` takes an `errorItemRenderer` — nodecore codes + `error_data` for JSON-RPC/REST,
    canonical status for gRPC — and reads response metadata via the
    `HasResponseHeaders`/`HasResponseTrailers` capabilities instead of a
    `*GenericUpstreamResponse` type assertion, so metadata on `*ReplyError` (retryable upstream
    errors) is no longer dropped. Trailers are stamped on success, error and first stream chunk.
  - New `replyMeta` (request id, upstream id/version, finalization, headers, trailers) built
    once per response and `stamp`ed onto items; `streamNativeCallBody` goes from 11 positional
    params to `(stream, reader, mode, hint, meta)`.
- **`go.mod`** — `github.com/drpcorg/public v1.0.0 → v1.1.0`.

JSON-RPC and REST items are unaffected apart from the (previously empty) trailers field and
the `*ReplyError` headers that now ride along.

## Out of scope (follow-ups)

- `NativeSubscribe` for gRPC server-stream methods (still JSON-RPC only).
- Quorum for gRPC items — quorum parameters are currently read only from the HTTP query
  string, so quorum is unreachable via `NativeCall` for any item kind today.

## Testing

- `internal/protocol/grpc_status_of_test.go` — verbatim replay with/without details, every
  nodecore code mapping, nil input.
- `internal/server/emerald/grpc_blockchain_test.go` — gRPC item build (method, body, sanitized
  metadata, `chunk_size` ignored), unknown / server-stream / missing-data / signing-unavailable
  items, success item with headers + trailers, upstream status with details round-tripping
  through `error_as_is`, status without details, nodecore error → `UNAVAILABLE`, trailers on
  `*ReplyError`, JSON-RPC regression (nodecore codes kept, trailers empty).
- `go test -race ./...` green, `golangci-lint` clean.
