### PR TITLE
Sub responses refactoring

### DIFF
--- a/internal/protocol/data.go
+++ b/internal/protocol/data.go
@@ -194,9 +194,13 @@ type ResponseHolder interface {
 	Id() string
 }
 
+// SubscriptionResponseHolder is a client-facing frame of a subscription or
+// stream: an event carrying a payload, or the clean end of a bounded stream.
 type SubscriptionResponseHolder interface {
 	ResponseHolder
-	IsEventFrame() bool
+	// IsEnd reports the final frame of a stream that completed cleanly. It
+	// carries no payload, only the trailers the upstream closed with.
+	IsEnd() bool
 }
 
 type RequestBlockTag int

--- a/internal/protocol/grpc_sub_response_test.go
+++ b/internal/protocol/grpc_sub_response_test.go
@@ -40,15 +40,15 @@ func TestGrpcUpstreamSubscriptionResponse(t *testing.T) {
 	assert.Equal(t, messages, response.ResponseChan())
 }
 
-func TestSubscriptionResultResponseCarriesMetadata(t *testing.T) {
+func TestSubscriptionEventResponseCarriesMetadata(t *testing.T) {
 	headers := http.Header{"x-up-meta": {"h"}}
 	trailers := map[string][]string{"x-up-trailer": {"t"}}
-	response := protocol.NewSubscriptionResultEventResponse("1", []byte("r")).
+	response := protocol.NewSubscriptionEventResponse("1", []byte("r")).
 		WithResponseHeaders(headers).
 		WithResponseTrailers(trailers)
 
 	assert.Equal(t, headers, response.ResponseHeaders())
 	assert.Equal(t, trailers, response.ResponseTrailers())
 	assert.Equal(t, []byte("r"), response.ResponseResult())
-	assert.True(t, response.IsEventFrame())
+	assert.False(t, response.IsEnd())
 }

--- a/internal/protocol/parse_response_test.go
+++ b/internal/protocol/parse_response_test.go
@@ -1,6 +1,7 @@
 package protocol_test
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -499,6 +500,7 @@ func TestEncodeSubscriptionEventResponse(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.False(t, response.HasError())
+	assert.False(t, response.IsEnd())
 	assert.Equal(t, "11", response.Id())
 	assert.Nil(t, response.GetError())
 	assert.False(t, response.HasStream())
@@ -506,37 +508,35 @@ func TestEncodeSubscriptionEventResponse(t *testing.T) {
 	assert.Equal(t, result, respBytes)
 }
 
-func TestEncodeSubscriptionWithRealIdEventResponse(t *testing.T) {
-	result := []byte("event")
-	response := protocol.NewSubscriptionMessageEventResponse("11", result)
+func TestEncodeJsonRpcSubscriptionEventResponse(t *testing.T) {
+	result := []byte(`{"number":"0x1"}`)
+	response := protocol.NewJsonRpcSubscriptionEventResponse("11", "eth_subscription", result, json.RawMessage(`"0xabc"`))
 
 	respReader := response.EncodeResponse([]byte("32"))
 	respBytes, err := io.ReadAll(respReader)
 
 	assert.Nil(t, err)
 	assert.False(t, response.HasError())
+	assert.False(t, response.IsEnd())
 	assert.Equal(t, "11", response.Id())
-	assert.Nil(t, response.GetError())
-	assert.False(t, response.HasStream())
 	assert.Equal(t, result, response.ResponseResult())
-	assert.Equal(t, []byte(`{"id":32,"jsonrpc":"2.0","result":event}`), respBytes)
+	assert.JSONEq(t, `{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"number":"0x1"},"subscription":"0xabc"}}`, string(respBytes))
 }
 
-func TestEncodeSubscriptionResultEventResponse(t *testing.T) {
-	result := []byte(`{"foo":"bar"}`)
-	response := protocol.NewSubscriptionResultEventResponse("11", result)
+func TestEncodeSubscriptionEndResponse(t *testing.T) {
+	response := protocol.NewSubscriptionEndResponse("11")
 
 	respReader := response.EncodeResponse([]byte("32"))
 	respBytes, err := io.ReadAll(respReader)
 
 	assert.Nil(t, err)
+	assert.True(t, response.IsEnd())
 	assert.False(t, response.HasError())
 	assert.Equal(t, "11", response.Id())
 	assert.Nil(t, response.GetError())
 	assert.False(t, response.HasStream())
-	assert.True(t, response.IsEventFrame())
-	assert.Equal(t, result, response.ResponseResult())
-	assert.Equal(t, result, respBytes)
+	assert.Nil(t, response.ResponseResult())
+	assert.Empty(t, respBytes)
 }
 
 func TestRestResponseSuccessLeavesErrorNil(t *testing.T) {

--- a/internal/protocol/subscription_response.go
+++ b/internal/protocol/subscription_response.go
@@ -13,29 +13,102 @@ import (
 // Client-facing frames of a subscription/stream. They are produced by the
 // SubscriptionRequestProcessor and consumed by the WS server, the emerald
 // server and the gRPC chain ingress:
-//   - SubscriptionMessageResponse: the JSON-RPC subscribe ack carrying the
-//     client subscription id (not an event frame);
-//   - SubscriptionMethodResultResponse: a JSON-RPC notification envelope;
-//   - SubscriptionResultResponse / SubscriptionEventResponse: bare event
-//     payloads (result-only consumers);
-//   - SubscriptionEndResponse: the clean end of a bounded stream (not an event
-//     frame; carries the upstream trailers).
+//   - SubscriptionEventResponse: one event, delivered either as the bare
+//     payload (result-only consumers) or wrapped in a JSON-RPC notification
+//     envelope (the WS server);
+//   - SubscriptionEndResponse: the clean end of a bounded stream (carries the
+//     upstream trailers, no payload).
+//
+// The JSON-RPC subscribe ack is a plain WsJsonRpcResponse, not a subscription
+// frame.
 
+// SubscriptionEventResponse is one event of a subscription/stream as the
+// client receives it. The encoder decides the presentation; the transport
+// metadata (gRPC headers/trailers) rides along for the gRPC ingress.
 type SubscriptionEventResponse struct {
 	noStreamHint
-	id    string
-	event []byte
+	id               string
+	payload          []byte
+	encoder          subEventEncoder
+	responseHeaders  http.Header
+	responseTrailers map[string][]string
 }
 
-type SubscriptionMessageResponse struct {
-	noStreamHint
-	id      string
-	message []byte
+// NewSubscriptionEventResponse is the bare-payload event (result-only
+// consumers: the gRPC ingress, the emerald server).
+func NewSubscriptionEventResponse(id string, payload []byte) *SubscriptionEventResponse {
+	return &SubscriptionEventResponse{id: id, payload: payload, encoder: rawEventEncoder{}}
 }
 
-// SubscriptionEndResponse is the final, non-event frame of a stream that
-// completed cleanly (a bounded gRPC stream). It carries no payload - only the
-// upstream trailers the ingress must deliver with the OK status.
+// NewJsonRpcSubscriptionEventResponse is the event wrapped in a JSON-RPC
+// notification envelope referencing the client subscription id (the WS server).
+func NewJsonRpcSubscriptionEventResponse(id, method string, payload []byte, subId json.RawMessage) *SubscriptionEventResponse {
+	return &SubscriptionEventResponse{
+		id:      id,
+		payload: payload,
+		encoder: jsonRpcEventEncoder{method: method, subId: subId},
+	}
+}
+
+func (s *SubscriptionEventResponse) ResponseResult() []byte {
+	return s.payload
+}
+
+func (s *SubscriptionEventResponse) ResponseResultString() (string, error) {
+	return "", nil
+}
+
+func (s *SubscriptionEventResponse) ResponseCode() int {
+	return 0
+}
+
+func (s *SubscriptionEventResponse) GetError() *ResponseError {
+	return nil
+}
+
+// EncodeResponse ignores realId: an event references the subscription id, not
+// the request id.
+func (s *SubscriptionEventResponse) EncodeResponse(_ []byte) io.Reader {
+	return s.encoder.Encode(s.payload)
+}
+
+func (s *SubscriptionEventResponse) HasError() bool {
+	return false
+}
+
+func (s *SubscriptionEventResponse) HasStream() bool {
+	return false
+}
+
+func (s *SubscriptionEventResponse) Id() string {
+	return s.id
+}
+
+func (s *SubscriptionEventResponse) IsEnd() bool {
+	return false
+}
+
+func (s *SubscriptionEventResponse) ResponseHeaders() http.Header {
+	return s.responseHeaders
+}
+
+func (s *SubscriptionEventResponse) WithResponseHeaders(headers http.Header) *SubscriptionEventResponse {
+	s.responseHeaders = headers
+	return s
+}
+
+func (s *SubscriptionEventResponse) ResponseTrailers() map[string][]string {
+	return s.responseTrailers
+}
+
+func (s *SubscriptionEventResponse) WithResponseTrailers(trailers map[string][]string) *SubscriptionEventResponse {
+	s.responseTrailers = trailers
+	return s
+}
+
+// SubscriptionEndResponse is the final frame of a stream that completed
+// cleanly (a bounded gRPC stream). It carries no payload - only the upstream
+// trailers the ingress must deliver with the OK status.
 type SubscriptionEndResponse struct {
 	noStreamHint
 	id               string
@@ -79,8 +152,8 @@ func (s *SubscriptionEndResponse) Id() string {
 	return s.id
 }
 
-func (s *SubscriptionEndResponse) IsEventFrame() bool {
-	return false
+func (s *SubscriptionEndResponse) IsEnd() bool {
+	return true
 }
 
 func (s *SubscriptionEndResponse) ResponseHeaders() http.Header {
@@ -101,65 +174,23 @@ func (s *SubscriptionEndResponse) WithResponseTrailers(trailers map[string][]str
 	return s
 }
 
-var _ SubscriptionResponseHolder = (*SubscriptionEndResponse)(nil)
-
-type SubscriptionResultResponse struct {
-	noStreamHint
-	id               string
-	result           []byte
-	responseHeaders  http.Header
-	responseTrailers map[string][]string
+// subEventEncoder turns an event payload into the bytes the client receives.
+type subEventEncoder interface {
+	Encode(payload []byte) io.Reader
 }
 
-func (s *SubscriptionResultResponse) ResponseHeaders() http.Header {
-	return s.responseHeaders
+// rawEventEncoder delivers the payload as is.
+type rawEventEncoder struct{}
+
+func (rawEventEncoder) Encode(payload []byte) io.Reader {
+	return bytes.NewReader(payload)
 }
 
-func (s *SubscriptionResultResponse) WithResponseHeaders(headers http.Header) *SubscriptionResultResponse {
-	s.responseHeaders = headers
-	return s
-}
-
-func (s *SubscriptionResultResponse) ResponseTrailers() map[string][]string {
-	return s.responseTrailers
-}
-
-func (s *SubscriptionResultResponse) WithResponseTrailers(trailers map[string][]string) *SubscriptionResultResponse {
-	s.responseTrailers = trailers
-	return s
-}
-
-type SubscriptionMethodResultResponse struct {
-	noStreamHint
-	id     string
+// jsonRpcEventEncoder wraps the payload in a JSON-RPC notification envelope:
+// {"jsonrpc":"2.0","method":<method>,"params":{"result":<payload>,"subscription":<subId>}}.
+type jsonRpcEventEncoder struct {
 	method string
-	result []byte
 	subId  json.RawMessage
-}
-
-func NewSubscriptionMethodResultResponse(id, method string, result []byte, subId json.RawMessage) *SubscriptionMethodResultResponse {
-	return &SubscriptionMethodResultResponse{
-		id:     id,
-		method: method,
-		result: result,
-		subId:  subId,
-	}
-}
-
-func (s *SubscriptionMethodResultResponse) ResponseResult() []byte {
-	return s.result
-}
-
-func (s *SubscriptionMethodResultResponse) ResponseResultString() (string, error) {
-	return "", nil
-}
-
-func (s *SubscriptionMethodResultResponse) ResponseCode() int {
-	return 0
-}
-
-func (s *SubscriptionMethodResultResponse) GetError() *ResponseError {
-	return nil
 }
 
 type jsonRpcWsSubResponse struct {
@@ -168,13 +199,13 @@ type jsonRpcWsSubResponse struct {
 	Params  jsonRpcWsParams `json:"params"`
 }
 
-func (s *SubscriptionMethodResultResponse) EncodeResponse(_ []byte) io.Reader {
+func (e jsonRpcEventEncoder) Encode(payload []byte) io.Reader {
 	resp := jsonRpcWsSubResponse{
 		JsonRpc: "2.0",
-		Method:  s.method,
+		Method:  e.method,
 		Params: jsonRpcWsParams{
-			Result:       s.result,
-			Subscription: s.subId,
+			Result:       payload,
+			Subscription: e.subId,
 		},
 	}
 	respBytes, err := sonic.Marshal(resp)
@@ -184,143 +215,7 @@ func (s *SubscriptionMethodResultResponse) EncodeResponse(_ []byte) io.Reader {
 	return bytes.NewReader(respBytes)
 }
 
-func (s *SubscriptionMethodResultResponse) HasError() bool {
-	return false
-}
-
-func (s *SubscriptionMethodResultResponse) HasStream() bool {
-	return false
-}
-
-func (s *SubscriptionMethodResultResponse) Id() string {
-	return s.id
-}
-
-func (s *SubscriptionMethodResultResponse) IsEventFrame() bool {
-	return true
-}
-
-func (s *SubscriptionEventResponse) ResponseResultString() (string, error) {
-	return "", nil
-}
-
-func (s *SubscriptionMessageResponse) ResponseResultString() (string, error) {
-	return "", nil
-}
-
-func (s *SubscriptionResultResponse) ResponseResultString() (string, error) {
-	return "", nil
-}
-
-func NewSubscriptionMessageEventResponse(id string, message []byte) *SubscriptionMessageResponse {
-	return &SubscriptionMessageResponse{message: message, id: id}
-}
-
-func NewSubscriptionEventResponse(id string, event []byte) *SubscriptionEventResponse {
-	return &SubscriptionEventResponse{event: event, id: id}
-}
-
-func NewSubscriptionResultEventResponse(id string, result []byte) *SubscriptionResultResponse {
-	return &SubscriptionResultResponse{result: result, id: id}
-}
-
-func (s *SubscriptionEventResponse) IsEventFrame() bool {
-	return true
-}
-
-func (s *SubscriptionMessageResponse) IsEventFrame() bool {
-	return false
-}
-
-func (s *SubscriptionResultResponse) IsEventFrame() bool {
-	return true
-}
-
-func (s *SubscriptionEventResponse) ResponseResult() []byte {
-	return s.event
-}
-
-func (s *SubscriptionMessageResponse) ResponseResult() []byte {
-	return s.message
-}
-
-func (s *SubscriptionResultResponse) ResponseResult() []byte {
-	return s.result
-}
-
-func (s *SubscriptionEventResponse) GetError() *ResponseError {
-	return nil
-}
-
-func (s *SubscriptionMessageResponse) GetError() *ResponseError {
-	return nil
-}
-
-func (s *SubscriptionResultResponse) GetError() *ResponseError {
-	return nil
-}
-
-func (s *SubscriptionEventResponse) EncodeResponse(realId []byte) io.Reader {
-	return bytes.NewReader(s.event)
-}
-
-func (s *SubscriptionMessageResponse) EncodeResponse(realId []byte) io.Reader {
-	return jsonRpcResponseReader(realId, "result", s.message)
-}
-
-func (s *SubscriptionResultResponse) EncodeResponse(realId []byte) io.Reader {
-	return bytes.NewReader(s.result)
-}
-
-func (s *SubscriptionEventResponse) HasError() bool {
-	return false
-}
-
-func (s *SubscriptionMessageResponse) HasError() bool {
-	return false
-}
-
-func (s *SubscriptionResultResponse) HasError() bool {
-	return false
-}
-
-func (s *SubscriptionEventResponse) HasStream() bool {
-	return false
-}
-
-func (s *SubscriptionMessageResponse) HasStream() bool {
-	return false
-}
-
-func (s *SubscriptionResultResponse) HasStream() bool {
-	return false
-}
-
-func (s *SubscriptionEventResponse) Id() string {
-	return s.id
-}
-
-func (s *SubscriptionMessageResponse) Id() string {
-	return s.id
-}
-
-func (s *SubscriptionResultResponse) Id() string {
-	return s.id
-}
-
-func (s *SubscriptionEventResponse) ResponseCode() int {
-	return 0
-}
-
-func (s *SubscriptionMessageResponse) ResponseCode() int {
-	return 0
-}
-
-func (s *SubscriptionResultResponse) ResponseCode() int {
-	return 0
-}
-
 var _ SubscriptionResponseHolder = (*SubscriptionEventResponse)(nil)
-var _ SubscriptionResponseHolder = (*SubscriptionMessageResponse)(nil)
-var _ SubscriptionResponseHolder = (*SubscriptionResultResponse)(nil)
-var _ SubscriptionResponseHolder = (*SubscriptionMethodResultResponse)(nil)
+var _ SubscriptionResponseHolder = (*SubscriptionEndResponse)(nil)
+var _ subEventEncoder = rawEventEncoder{}
+var _ subEventEncoder = jsonRpcEventEncoder{}

--- a/internal/server/emerald/grpc_blockchain.go
+++ b/internal/server/emerald/grpc_blockchain.go
@@ -216,8 +216,8 @@ func (s *GrpcBlockchainService) NativeSubscribe(request *dshackle.NativeSubscrib
 			if !ok {
 				return status.Error(codes.Internal, "unexpected subscription response type")
 			}
-			if !subscriptionResponse.IsEventFrame() {
-				continue
+			if subscriptionResponse.IsEnd() {
+				return nil
 			}
 
 			replyItem, err := nativeSubscribeReplyItem(wrapper, subscriptionResponse.ResponseResult(), nonce, s.signer)

--- a/internal/server/grpc_ingress/grpc_call.go
+++ b/internal/server/grpc_ingress/grpc_call.go
@@ -84,8 +84,10 @@ func (s *serverStreamCall) serve(stream grpc.ServerStream, handleResp *server_ct
 				grpcStatus, _ := protocol.GrpcStatusOf(response.GetError())
 				return grpcStatus.Err()
 			}
-			if eventResponse, ok := response.(protocol.SubscriptionResponseHolder); ok && !eventResponse.IsEventFrame() {
-				continue
+			// the end frame carries only the trailers set above; returning nil
+			// delivers them with the OK status
+			if subResponse, ok := response.(protocol.SubscriptionResponseHolder); ok && subResponse.IsEnd() {
+				return nil
 			}
 			if err := stream.SendMsg(&rawFrame{data: response.ResponseResult()}); err != nil {
 				return err

--- a/internal/upstreams/flow/sub_framing.go
+++ b/internal/upstreams/flow/sub_framing.go
@@ -50,12 +50,12 @@ func (f *jsonRpcFraming) begin(request protocol.RequestHolder, cancel context.Ca
 	return &protocol.ResponseHolderWrapper{
 		UpstreamId: NoUpstream,
 		RequestId:  request.Id(),
-		Response:   protocol.NewSubscriptionMessageEventResponse(request.Id(), subId),
+		Response:   protocol.NewWsJsonRpcResponse(request.Id(), subId, nil),
 	}, nil
 }
 
 func (f *jsonRpcFraming) event(request protocol.RequestHolder, r protocol.SubResponse) protocol.ResponseHolder {
-	return protocol.NewSubscriptionMethodResultResponse(request.Id(), request.SpecMethod().Subscription.Method, r.GetMessage(), f.subId)
+	return protocol.NewJsonRpcSubscriptionEventResponse(request.Id(), request.SpecMethod().Subscription.Method, r.GetMessage(), f.subId)
 }
 
 // resultOnlyFraming is the presentation for consumers that carry their own
@@ -70,7 +70,7 @@ func (resultOnlyFraming) begin(protocol.RequestHolder, context.CancelFunc) (*pro
 
 func (resultOnlyFraming) event(request protocol.RequestHolder, r protocol.SubResponse) protocol.ResponseHolder {
 	headers, trailers := protocol.ResponseMetadata(r)
-	return protocol.NewSubscriptionResultEventResponse(request.Id(), r.GetMessage()).WithResponseHeaders(headers).WithResponseTrailers(trailers)
+	return protocol.NewSubscriptionEventResponse(request.Id(), r.GetMessage()).WithResponseHeaders(headers).WithResponseTrailers(trailers)
 }
 
 func isSolana(chain chains.Chain) bool {

--- a/internal/upstreams/flow/sub_processor.go
+++ b/internal/upstreams/flow/sub_processor.go
@@ -151,7 +151,7 @@ func responseUpstreamId(r protocol.SubResponse) string {
 }
 
 // terminalWrapper turns the frame that ended a subscription into the client's
-// final response - the terminal error, or a non-event end frame for a clean
+// final response - the terminal error, or an end frame for a clean
 // completion - keeping the transport metadata it carried (gRPC trailers).
 func terminalWrapper(request protocol.RequestHolder, terminal protocol.SubResponse) *protocol.ResponseHolderWrapper {
 	headers, trailers := protocol.ResponseMetadata(terminal)

--- a/internal/upstreams/flow/sub_processor_test.go
+++ b/internal/upstreams/flow/sub_processor_test.go
@@ -124,7 +124,7 @@ func TestSubscriptionRequestProcessorEmitsSubIdAck(t *testing.T) {
 	subRespWrappers := response.(*flow.SubscriptionResponse).ResponseWrappers
 	ackWrapper := <-subRespWrappers
 
-	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ackWrapper.Response)
+	assert.IsType(t, &protocol.WsJsonRpcResponse{}, ackWrapper.Response)
 	assert.False(t, ackWrapper.Response.HasError())
 	assert.Equal(t, "223", ackWrapper.RequestId)
 	assert.Equal(t, flow.NoUpstream, ackWrapper.UpstreamId)
@@ -190,7 +190,7 @@ func TestSubscriptionRequestProcessorAndSubscribeThenReceiveEvent(t *testing.T) 
 	strategy.AssertExpectations(t)
 	upSupervisor.AssertExpectations(t)
 
-	assert.IsType(t, &protocol.SubscriptionMethodResultResponse{}, responseWrapper.Response)
+	assert.IsType(t, &protocol.SubscriptionEventResponse{}, responseWrapper.Response)
 	assert.Equal(t, event, responseWrapper.Response.ResponseResult())
 	assert.False(t, responseWrapper.Response.HasError())
 	assert.False(t, responseWrapper.Response.HasStream())
@@ -234,8 +234,8 @@ func TestSubscriptionRequestProcessorTwoSubscribersShareOneUpstreamSub(t *testin
 	resp2 := p2.ProcessRequest(ctx, strategy, req2).(*flow.SubscriptionResponse).ResponseWrappers
 	ack2 := <-resp2
 
-	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ack1.Response)
-	assert.IsType(t, &protocol.SubscriptionMessageResponse{}, ack2.Response)
+	assert.IsType(t, &protocol.WsJsonRpcResponse{}, ack1.Response)
+	assert.IsType(t, &protocol.WsJsonRpcResponse{}, ack2.Response)
 	subId1 := ack1.Response.ResponseResult()
 	subId2 := ack2.Response.ResponseResult()
 	assert.NotEmpty(t, subId1)
@@ -315,7 +315,7 @@ func TestSubscriptionRequestProcessorAndSubscribeThenReceiveResultOnlyEvent(t *t
 
 	subscriptionResponse, ok := responseWrapper.Response.(protocol.SubscriptionResponseHolder)
 	assert.True(t, ok)
-	assert.True(t, subscriptionResponse.IsEventFrame())
+	assert.False(t, subscriptionResponse.IsEnd())
 	assert.Equal(t, result, subscriptionResponse.ResponseResult())
 	assert.False(t, subscriptionResponse.HasError())
 	assert.False(t, subscriptionResponse.HasStream())
@@ -372,7 +372,7 @@ func TestSubscriptionRequestProcessorGrpcFiniteStreamCompletesCleanly(t *testing
 	wrappers := processor.ProcessRequest(context.Background(), strategy, request).(*flow.SubscriptionResponse).ResponseWrappers
 
 	first := <-wrappers
-	firstResponse := first.Response.(*protocol.SubscriptionResultResponse)
+	firstResponse := first.Response.(*protocol.SubscriptionEventResponse)
 	assert.Equal(t, []byte("f1"), firstResponse.ResponseResult())
 	assert.Equal(t, []string{"h"}, map[string][]string(firstResponse.ResponseHeaders())["x-up-meta"])
 	assert.Equal(t, "id", first.UpstreamId)
@@ -383,7 +383,7 @@ func TestSubscriptionRequestProcessorGrpcFiniteStreamCompletesCleanly(t *testing
 
 	end := <-wrappers
 	endResponse := end.Response.(*protocol.SubscriptionEndResponse)
-	assert.False(t, endResponse.IsEventFrame(), "the end frame is not an event")
+	assert.True(t, endResponse.IsEnd())
 	assert.False(t, endResponse.HasError())
 	assert.Equal(t, []string{"t"}, endResponse.ResponseTrailers()["x-up-trailer"])
 	assert.Equal(t, "id", end.UpstreamId)


### PR DESCRIPTION
# Collapse the client-facing subscription frames to two types

## Summary

`SubscriptionResponseHolder` had five implementations, and it was hard to tell which one was
used where and why. Three of them were the same shape (`id` + `[]byte`) differing only in how
`EncodeResponse` wrapped the bytes; one was never constructed outside tests; and the
discriminator, `IsEventFrame() bool`, squashed a three-way state (ack / event / end) into a
bool that consumers could only use as "skip this one".

| before | what it was | after |
|---|---|---|
| `SubscriptionMessageResponse` | JSON-RPC subscribe ack `{id, result: subId}` | plain `WsJsonRpcResponse` - not a subscription frame at all |
| `SubscriptionMethodResultResponse` | event in a JSON-RPC notification envelope (WS server) | `SubscriptionEventResponse` with `jsonRpcEventEncoder` |
| `SubscriptionResultResponse` | bare event payload + gRPC headers/trailers (gRPC ingress, emerald) | `SubscriptionEventResponse` with `rawEventEncoder` |
| `SubscriptionEventResponse` | bare event payload, no metadata - tests only | removed (name reused above) |
| `SubscriptionEndResponse` | clean end of a bounded stream, trailers only | unchanged |

## The event type

One struct carries `id`, `payload`, the optional gRPC headers/trailers, and an unexported
`subEventEncoder` that owns the only thing that ever differed between the event variants:

```go
type subEventEncoder interface {
	Encode(payload []byte) io.Reader
}
```

`rawEventEncoder` returns the payload as is; `jsonRpcEventEncoder` wraps it in
`{"jsonrpc":"2.0","method":..,"params":{"result":..,"subscription":..}}`. `EncodeResponse` is
one line. The two public constructors, `NewSubscriptionEventResponse` and
`NewJsonRpcSubscriptionEventResponse`, are the only way to build one, so the encoder is never
nil and the JSON-RPC envelope fields are always set together. A third presentation later is a
new encoder, not a new holder type.

## `IsEnd` replaces `IsEventFrame`

The upstream side already names this concept `SubResponse.IsEnd()`. The client side now says
the same thing: `SubscriptionResponseHolder` is `ResponseHolder` + `IsEnd() bool`. Event
answers false, end answers true.

The two consumers read differently as a result. The gRPC ingress used to `continue` past a
non-event frame and rely on the flow closing the channel to actually return; it now returns
`nil` on the end frame directly, right after `forwardResponseMetadata` has set the trailers,
which is what delivers them with the OK status. The emerald server does the same. Nothing can
follow an end frame - `sub.Terminal()` is only read once the events channel is closed - so the
early return encodes the contract rather than defending against a state the flow cannot
produce.

## The ack is a normal response

`jsonRpcFraming.begin` now returns `NewWsJsonRpcResponse(request.Id(), subId, nil)`. Its
encoding is byte-identical to what `SubscriptionMessageResponse` produced; it only lived in the
subscription family so it could answer `IsEventFrame() == false`, and neither result-only
consumer ever received it (their framing produces no ack).

## Behaviour

No wire change. Every frame encodes exactly as before; the finite-stream OK + trailers path in
the gRPC ingress and the emerald `NativeSubscribe` path are covered by existing tests that
still pass. `internal/protocol/subscription_response.go` goes from 330 to 221 lines.

## Tests

- New `TestEncodeJsonRpcSubscriptionEventResponse` pins the notification envelope bytes
  (there was no encode test for it before).
- `TestEncodeSubscriptionEndResponse` replaces the old result-event encode test: empty body,
  `IsEnd() == true`.
- Type assertions in `sub_processor_test` and `grpc_sub_response_test` moved to the two
  remaining types; the emerald signature tests are untouched because the constructor
  signature they use survived.
