### PR TITLE
Syncing guard

### DIFF
--- a/internal/upstreams/blocks/head.go
+++ b/internal/upstreams/blocks/head.go
@@ -89,7 +89,7 @@ func (r *RpcHead) Start() {
 	r.lifecycle.Start(func(ctx context.Context) error {
 		go func() {
 			for {
-				r.poll()
+				r.poll(ctx)
 				select {
 				case <-ctx.Done():
 					return
@@ -113,7 +113,11 @@ func (r *RpcHead) HeadsChan() chan protocol.Block {
 func (r *RpcHead) OnNoHeadUpdates() {
 }
 
-func (r *RpcHead) poll() {
+// poll fetches the latest block and hands it to the processor. The send waits for the
+// reader only while this run of the head is alive: once it is stopped nobody drains the
+// channel, and a poll parked in the send would hold the poll slot and deliver a stale block
+// on the next start.
+func (r *RpcHead) poll(runCtx context.Context) {
 	if !r.pollInProgress.Load() {
 		r.pollInProgress.Store(true)
 		defer r.pollInProgress.Store(false)
@@ -126,7 +130,10 @@ func (r *RpcHead) poll() {
 			log.Error().Err(err).Msgf("couldn't get the latest block of upstream %s", r.upstreamId)
 		} else {
 			r.block.Store(block)
-			r.headsChan <- block
+			select {
+			case r.headsChan <- block:
+			case <-runCtx.Done():
+			}
 		}
 	}
 }
@@ -180,7 +187,7 @@ func (w *SubscriptionHead) Start() {
 		}
 		w.subOpId.Store(subResponse.OpId())
 		go func() {
-			w.getLatestBlock()
+			w.getLatestBlock(ctx)
 			for {
 				select {
 				case message, ok := <-subResponse.ResponseChan():
@@ -201,7 +208,13 @@ func (w *SubscriptionHead) Start() {
 						return
 					}
 					w.block.Store(block)
-					w.headsChan <- block
+					// the reader is gone once this run is stopped; a send parked here
+					// would deliver this block on the next start as if it were fresh
+					select {
+					case w.headsChan <- block:
+					case <-ctx.Done():
+						return
+					}
 				case <-ctx.Done():
 					return
 				}
@@ -221,7 +234,7 @@ func (w *SubscriptionHead) OnNoHeadUpdates() {
 	w.Start()
 }
 
-func (w *SubscriptionHead) getLatestBlock() {
+func (w *SubscriptionHead) getLatestBlock(runCtx context.Context) {
 	ctx, cancel := context.WithTimeout(w.lifecycle.GetParentContext(), w.internalTimeout)
 	defer cancel()
 	block, err := w.chainSpecific.GetLatestBlock(ctx)
@@ -230,7 +243,10 @@ func (w *SubscriptionHead) getLatestBlock() {
 		return
 	}
 	w.block.Store(block)
-	w.headsChan <- block
+	select {
+	case w.headsChan <- block:
+	case <-runCtx.Done():
+	}
 }
 
 func NewSubHead(

--- a/internal/upstreams/blocks/head_internal_test.go
+++ b/internal/upstreams/blocks/head_internal_test.go
@@ -1,0 +1,94 @@
+package blocks
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingSpecific hands out increasing heights: GetLatestBlock for the polling head,
+// ParseSubscriptionBlock for the subscription head. The other calls are never reached.
+type countingSpecific struct {
+	stubSpecific
+	height     atomic.Uint64
+	failLatest bool
+}
+
+func (c *countingSpecific) GetLatestBlock(context.Context) (protocol.Block, error) {
+	if c.failLatest {
+		return protocol.ZeroBlock{}, errors.New("no latest block")
+	}
+	return protocol.NewBlockWithHeight(c.height.Add(1)), nil
+}
+
+func (c *countingSpecific) ParseSubscriptionBlock([]byte) (protocol.Block, error) {
+	return protocol.NewBlockWithHeight(c.height.Add(1)), nil
+}
+
+// subStubConnector serves one subscription response, shared across Subscribe calls, so a
+// restarted head keeps reading from the same message channel.
+type subStubConnector struct {
+	stubConnector
+	response protocol.UpstreamSubscriptionResponse
+}
+
+func (s *subStubConnector) Subscribe(context.Context, protocol.RequestHolder) (protocol.UpstreamSubscriptionResponse, error) {
+	return s.response, nil
+}
+
+func nextBlock(t *testing.T, heads <-chan protocol.Block) protocol.Block {
+	t.Helper()
+	select {
+	case block := <-heads:
+		return block
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for a head block")
+		return protocol.ZeroBlock{}
+	}
+}
+
+func TestRpcHeadStopReleasesPollParkedOnSend(t *testing.T) {
+	specific := &countingSpecific{}
+	head := NewRpcHead(context.Background(), "up", time.Second, time.Hour, specific)
+
+	// nobody reads the heads: the first poll parks in its send
+	head.Start()
+	require.Eventually(t, func() bool { return specific.height.Load() == 1 }, time.Second, time.Millisecond)
+
+	// a stop must release it and hand back the poll slot
+	head.Stop()
+	require.Eventually(t, func() bool { return !head.pollInProgress.Load() }, time.Second, time.Millisecond,
+		"the parked poll was not released by Stop")
+
+	// the restarted head delivers a fresh poll, not the block captured before the stop
+	head.Start()
+	defer head.Stop()
+	assert.Equal(t, uint64(2), nextBlock(t, head.HeadsChan()).Height)
+}
+
+func TestSubscriptionHeadStopReleasesProducerParkedOnSend(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":{"number":"0x1"},"subscription":"0x1"}}`)
+	messages := make(chan protocol.SubResponse, 2)
+	messages <- protocol.ParseJsonRpcWsMessage(body)
+	messages <- protocol.ParseJsonRpcWsMessage(body)
+	connector := &subStubConnector{response: protocol.NewJsonRpcWsUpstreamResponse(messages, "op-1")}
+	specific := &countingSpecific{failLatest: true} // only the subscription produces heads
+	head := NewSubHead(context.Background(), "up", time.Second, connector, specific)
+
+	// nobody reads the heads: the producer parks in its send with the first block
+	head.Start()
+	require.Eventually(t, func() bool { return specific.height.Load() == 1 }, time.Second, time.Millisecond)
+
+	head.Stop()
+
+	// the restarted head delivers the next message, not the block captured before the stop
+	head.Start()
+	defer head.Stop()
+	assert.Equal(t, uint64(2), nextBlock(t, head.HeadsChan()).Height)
+}

--- a/internal/upstreams/blocks/head_processor.go
+++ b/internal/upstreams/blocks/head_processor.go
@@ -59,6 +59,9 @@ type GenericHeadProcessor struct {
 	headNoUpdatesTimeout time.Duration
 	subManager           *utils.SubscriptionManager[HeadEvent]
 	manualHeadChan       chan protocol.Block
+	// drainDone is closed when the current run's drain goroutine exits. Stop waits on it so
+	// that HeadStateEvent{Running: false} is published after the last block of the run.
+	drainDone chan struct{}
 }
 
 func NewGenericHeadProcessor(
@@ -116,7 +119,10 @@ func (h *GenericHeadProcessor) Start() {
 		h.lastUpdate.Store(time.Now())
 		h.subManager.Publish(HeadStateEvent{Running: true})
 
+		drainDone := make(chan struct{})
+		h.drainDone = drainDone
 		go func() {
+			defer close(drainDone)
 			timeout := time.NewTimer(h.headNoUpdatesTimeout)
 			for {
 				select {
@@ -147,8 +153,14 @@ func (h *GenericHeadProcessor) Start() {
 	})
 }
 
+// Stop cancels the drain goroutine and waits for it before publishing the stop, so nothing
+// of this run is published after HeadStateEvent{Running: false}: a late subscriber's replay
+// then reports a paused head exactly when the head is paused.
 func (h *GenericHeadProcessor) Stop() {
 	h.lifecycle.Stop()
+	if h.drainDone != nil {
+		<-h.drainDone
+	}
 	h.head.Stop()
 	h.subManager.Publish(HeadStateEvent{Running: false})
 }

--- a/internal/upstreams/blocks/head_processor.go
+++ b/internal/upstreams/blocks/head_processor.go
@@ -24,9 +24,27 @@ type HeadProcessor interface {
 	Subscribe(name string) *utils.Subscription[HeadEvent]
 }
 
-type HeadEvent struct {
+// HeadEvent is what a head processor publishes to its subscribers: head blocks interleaved
+// with lifecycle changes, in the order they happened. One stream keeps them ordered, so a
+// consumer can tell a block that arrived before a stop from one that arrived after a start.
+type HeadEvent interface {
+	headEvent()
+}
+
+// HeadBlockEvent carries a new head of the upstream.
+type HeadBlockEvent struct {
 	HeadData protocol.Block
 }
+
+// HeadStateEvent reports that the head processor started or stopped observing the node.
+// Silence after Running == false is not a stall: nothing is being observed.
+type HeadStateEvent struct {
+	Running bool
+}
+
+func (HeadBlockEvent) headEvent() {}
+
+func (HeadStateEvent) headEvent() {}
 
 type GenericHeadProcessor struct {
 	upstreamId           string
@@ -87,6 +105,7 @@ func (h *GenericHeadProcessor) Start() {
 	h.lifecycle.Start(func(ctx context.Context) error {
 		h.head.Start()
 		h.lastUpdate.Store(time.Now())
+		h.subManager.Publish(HeadStateEvent{Running: true})
 
 		go func() {
 			timeout := time.NewTimer(h.headNoUpdatesTimeout)
@@ -102,14 +121,14 @@ func (h *GenericHeadProcessor) Start() {
 					if ok {
 						log.Debug().Msgf("got a new head of upstream %s - %d", h.upstreamId, block.Height)
 						h.lastUpdate.Store(time.Now())
-						h.subManager.Publish(HeadEvent{HeadData: block})
+						h.subManager.Publish(HeadBlockEvent{HeadData: block})
 					}
 				case manualBlock := <-h.manualHeadChan:
 					if manualBlock.Height > h.head.GetCurrentBlock().Height {
 						log.Debug().Msgf("got a new manual head of upstream %s - %d", h.upstreamId, manualBlock.Height)
 						h.lastUpdate.Store(time.Now())
 						h.head.UpdateHead(manualBlock)
-						h.subManager.Publish(HeadEvent{HeadData: manualBlock})
+						h.subManager.Publish(HeadBlockEvent{HeadData: manualBlock})
 					}
 				}
 				timeout.Reset(h.headNoUpdatesTimeout)
@@ -122,10 +141,16 @@ func (h *GenericHeadProcessor) Start() {
 func (h *GenericHeadProcessor) Stop() {
 	h.lifecycle.Stop()
 	h.head.Stop()
+	h.subManager.Publish(HeadStateEvent{Running: false})
 }
 
 func (h *GenericHeadProcessor) UpdateHead(height, slot uint64) {
-	h.manualHeadChan <- protocol.NewBlockWithHeights(height, slot)
+	select {
+	case h.manualHeadChan <- protocol.NewBlockWithHeights(height, slot):
+	default:
+		// nobody drains the channel while the head is paused; a dropped manual head
+		// costs nothing, the next real head supersedes it
+	}
 }
 
 func createHead(

--- a/internal/upstreams/blocks/head_processor.go
+++ b/internal/upstreams/blocks/head_processor.go
@@ -22,6 +22,11 @@ type HeadProcessor interface {
 	UpdateHead(height, slot uint64)
 
 	Subscribe(name string) *utils.Subscription[HeadEvent]
+	// SubscribeWithReplay also delivers the last published event first. On this stream that
+	// event is HeadStateEvent{Running: false} exactly when the head is stopped - Stop
+	// publishes it last and nothing else is published until Start - so a late subscriber
+	// learns whether the head is currently paused.
+	SubscribeWithReplay(name string) *utils.Subscription[HeadEvent]
 }
 
 // HeadEvent is what a head processor publishes to its subscribers: head blocks interleaved
@@ -95,6 +100,10 @@ func (h *GenericHeadProcessor) GetCurrentBlock() protocol.Block {
 
 func (h *GenericHeadProcessor) Subscribe(name string) *utils.Subscription[HeadEvent] {
 	return h.subManager.Subscribe(name)
+}
+
+func (h *GenericHeadProcessor) SubscribeWithReplay(name string) *utils.Subscription[HeadEvent] {
+	return h.subManager.SubscribeWithReplay(name)
 }
 
 func (h *GenericHeadProcessor) Running() bool {

--- a/internal/upstreams/blocks/head_processor.go
+++ b/internal/upstreams/blocks/head_processor.go
@@ -156,12 +156,16 @@ func (h *GenericHeadProcessor) Start() {
 // Stop cancels the drain goroutine and waits for it before publishing the stop, so nothing
 // of this run is published after HeadStateEvent{Running: false}: a late subscriber's replay
 // then reports a paused head exactly when the head is paused.
+//
+// The head is stopped before the wait: the drain goroutine may be parked inside
+// OnNoHeadUpdates, in a resubscribe whose request honours the head's lifecycle context, and
+// head.Stop() cancelling that context is what lets the goroutine return and exit.
 func (h *GenericHeadProcessor) Stop() {
 	h.lifecycle.Stop()
+	h.head.Stop()
 	if h.drainDone != nil {
 		<-h.drainDone
 	}
-	h.head.Stop()
 	h.subManager.Publish(HeadStateEvent{Running: false})
 }
 

--- a/internal/upstreams/blocks/head_processor_internal_test.go
+++ b/internal/upstreams/blocks/head_processor_internal_test.go
@@ -125,3 +125,64 @@ func TestGenericHeadProcessorUpdateHeadDoesNotBlockWhenStopped(t *testing.T) {
 		t.Fatal("UpdateHead blocked on a full manual head channel")
 	}
 }
+
+// stubHead is a Head that does nothing; the processor tests only exercise the
+// lifecycle around it.
+type stubHead struct {
+	heads chan protocol.Block
+}
+
+func (s *stubHead) Start() {}
+
+func (s *stubHead) Stop() {}
+
+func (s *stubHead) Running() bool {
+	return true
+}
+
+func (s *stubHead) HeadsChan() chan protocol.Block {
+	return s.heads
+}
+
+func (s *stubHead) OnNoHeadUpdates() {}
+
+func (s *stubHead) GetCurrentBlock() protocol.Block {
+	return protocol.ZeroBlock{}
+}
+
+func (s *stubHead) UpdateHead(protocol.Block) {}
+
+func TestGenericHeadProcessorPublishesStateAroundBlocks(t *testing.T) {
+	head := &stubHead{heads: make(chan protocol.Block)}
+	processor := &GenericHeadProcessor{
+		upstreamId:           "up",
+		head:                 head,
+		manualHeadChan:       make(chan protocol.Block, 100),
+		lifecycle:            utils.NewGenericLifecycle("up_head_processor", context.Background()),
+		headNoUpdatesTimeout: time.Minute,
+		lastUpdate:           utils.NewAtomic[time.Time](),
+		subManager:           utils.NewSubscriptionManager[HeadEvent]("up_head_processor"),
+	}
+	sub := processor.Subscribe("test")
+	defer sub.Unsubscribe()
+
+	processor.Start()
+	assert.Equal(t, HeadStateEvent{Running: true}, nextHeadEvent(t, sub.Events))
+
+	head.heads <- protocol.NewBlockWithHeight(10)
+	assert.Equal(t, HeadBlockEvent{HeadData: protocol.NewBlockWithHeight(10)}, nextHeadEvent(t, sub.Events))
+
+	processor.Stop()
+	assert.Equal(t, HeadStateEvent{Running: false}, nextHeadEvent(t, sub.Events))
+}
+
+func nextHeadEvent(t *testing.T, events <-chan HeadEvent) HeadEvent {
+	t.Helper()
+	select {
+	case event := <-events:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for a head event")
+		return nil
+	}
+}

--- a/internal/upstreams/blocks/head_processor_internal_test.go
+++ b/internal/upstreams/blocks/head_processor_internal_test.go
@@ -3,6 +3,7 @@ package blocks
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/drpcorg/nodecore/pkg/utils"
 	specs "github.com/drpcorg/public/pkg/methods"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubConnector only reports its type; createHead never calls anything else
@@ -174,6 +176,42 @@ func TestGenericHeadProcessorPublishesStateAroundBlocks(t *testing.T) {
 
 	processor.Stop()
 	assert.Equal(t, HeadStateEvent{Running: false}, nextHeadEvent(t, sub.Events))
+}
+
+func TestGenericHeadProcessorStopPublishesStateAfterTheLastBlock(t *testing.T) {
+	// a syncing node floods heads, so a producer is always parked in its send when Stop runs
+	head := &stubHead{heads: make(chan protocol.Block)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for height := uint64(1); ; height++ {
+			select {
+			case head.heads <- protocol.NewBlockWithHeight(height):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	processor := &GenericHeadProcessor{
+		upstreamId:           "up",
+		head:                 head,
+		manualHeadChan:       make(chan protocol.Block, 100),
+		lifecycle:            utils.NewGenericLifecycle("up_head_processor", context.Background()),
+		headNoUpdatesTimeout: time.Minute,
+		lastUpdate:           utils.NewAtomic[time.Time](),
+		subManager:           utils.NewSubscriptionManager[HeadEvent]("up_head_processor"),
+	}
+
+	for i := range 200 {
+		processor.Start()
+		processor.Stop()
+
+		// a liveness consumer that subscribes during the pause must learn it is paused
+		sub := processor.SubscribeWithReplay(fmt.Sprintf("late_%d", i))
+		require.Equal(t, HeadStateEvent{Running: false}, nextHeadEvent(t, sub.Events), "iteration %d", i)
+		sub.Unsubscribe()
+	}
 }
 
 func nextHeadEvent(t *testing.T, events <-chan HeadEvent) HeadEvent {

--- a/internal/upstreams/blocks/head_processor_internal_test.go
+++ b/internal/upstreams/blocks/head_processor_internal_test.go
@@ -214,6 +214,65 @@ func TestGenericHeadProcessorStopPublishesStateAfterTheLastBlock(t *testing.T) {
 	}
 }
 
+// resubscribingHead models a websocket head whose OnNoHeadUpdates is parked in a subscribe
+// that only returns once the head's own Stop cancels it.
+type resubscribingHead struct {
+	stubHead
+	entered  chan struct{}
+	released chan struct{}
+}
+
+func (h *resubscribingHead) OnNoHeadUpdates() {
+	close(h.entered)
+	<-h.released
+}
+
+func (h *resubscribingHead) Stop() {
+	close(h.released)
+}
+
+func TestGenericHeadProcessorStopReleasesDrainParkedInResubscribe(t *testing.T) {
+	head := &resubscribingHead{
+		stubHead: stubHead{heads: make(chan protocol.Block)},
+		entered:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+	processor := &GenericHeadProcessor{
+		upstreamId:           "up",
+		head:                 head,
+		manualHeadChan:       make(chan protocol.Block, 100),
+		lifecycle:            utils.NewGenericLifecycle("up_head_processor", context.Background()),
+		headNoUpdatesTimeout: 10 * time.Millisecond,
+		lastUpdate:           utils.NewAtomic[time.Time](),
+		subManager:           utils.NewSubscriptionManager[HeadEvent]("up_head_processor"),
+	}
+
+	processor.Start()
+	select {
+	case <-head.entered:
+	case <-time.After(time.Second):
+		t.Fatal("the silence timer never fired")
+	}
+
+	// the drain goroutine is inside the resubscribe; Stop must not wait for a subscribe
+	// that only its own head.Stop() can end
+	stopped := make(chan struct{})
+	go func() {
+		processor.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop is parked behind a resubscribe the head could have cancelled")
+	}
+
+	// and the ordering guarantee still holds
+	sub := processor.SubscribeWithReplay("late")
+	defer sub.Unsubscribe()
+	assert.Equal(t, HeadStateEvent{Running: false}, nextHeadEvent(t, sub.Events))
+}
+
 func nextHeadEvent(t *testing.T, events <-chan HeadEvent) HeadEvent {
 	t.Helper()
 	select {

--- a/internal/upstreams/blocks/head_processor_internal_test.go
+++ b/internal/upstreams/blocks/head_processor_internal_test.go
@@ -105,3 +105,23 @@ func TestCreateHead(t *testing.T) {
 		})
 	}
 }
+
+func TestGenericHeadProcessorUpdateHeadDoesNotBlockWhenStopped(t *testing.T) {
+	// a paused head processor has nobody draining manualHeadChan; the integrity
+	// processor must never hang on it
+	processor := &GenericHeadProcessor{manualHeadChan: make(chan protocol.Block, 100)}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 150 {
+			processor.UpdateHead(uint64(i), 0)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("UpdateHead blocked on a full manual head channel")
+	}
+}

--- a/internal/upstreams/blocks/head_test.go
+++ b/internal/upstreams/blocks/head_test.go
@@ -43,7 +43,7 @@ func TestRpcHead(t *testing.T) {
 	sub := headProcessor.Subscribe("test")
 	go headProcessor.Start()
 
-	event, ok := <-sub.Events
+	head := nextHeadBlock(t, sub.Events)
 	expected := protocol.Block{
 		Height:     uint64(69195275),
 		Hash:       blockchain.NewHashIdFromString("0xdeeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d18"),
@@ -51,19 +51,17 @@ func TestRpcHead(t *testing.T) {
 	}
 
 	connector.AssertExpectations(t)
-	assert.True(t, ok)
-	assert.Equal(t, expected, event.HeadData)
+	assert.Equal(t, expected, head)
 	assert.Equal(t, expected, headProcessor.GetCurrentBlock())
 
 	headProcessor.UpdateHead(79195275, 0)
 
-	event, ok = <-sub.Events
+	head = nextHeadBlock(t, sub.Events)
 	expected = protocol.Block{
 		Height: uint64(79195275),
 	}
 
-	assert.True(t, ok)
-	assert.Equal(t, expected, event.HeadData)
+	assert.Equal(t, expected, head)
 	assert.Equal(t, expected, headProcessor.GetCurrentBlock())
 
 	headProcessor.UpdateHead(5555, 0)
@@ -72,7 +70,7 @@ func TestRpcHead(t *testing.T) {
 		sub.Unsubscribe()
 	}()
 
-	_, ok = <-sub.Events
+	_, ok := <-sub.Events
 
 	assert.False(t, ok)
 }
@@ -126,7 +124,7 @@ func TestSubHeadSubscribe(t *testing.T) {
 	sub := headProcessor.Subscribe("test")
 	go headProcessor.Start()
 
-	event, ok := <-sub.Events
+	head := nextHeadBlock(t, sub.Events)
 	expected := protocol.Block{
 		Height:     uint64(69195275),
 		Hash:       blockchain.NewHashIdFromString("0xdeeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d18"),
@@ -135,8 +133,7 @@ func TestSubHeadSubscribe(t *testing.T) {
 		RawData: protocol.ParseJsonRpcWsMessage(body).Message,
 	}
 
-	assert.True(t, ok)
-	assert.Equal(t, expected, event.HeadData)
+	assert.Equal(t, expected, head)
 	assert.Equal(t, expected, headProcessor.GetCurrentBlock())
 
 	connector.AssertExpectations(t)
@@ -167,13 +164,12 @@ func TestSubHeadManualUpdate(t *testing.T) {
 
 	headProcessor.UpdateHead(79195275, 0)
 
-	event, ok := <-sub.Events
+	head := nextHeadBlock(t, sub.Events)
 	expected := protocol.Block{
 		Height: uint64(79195275),
 	}
 
-	assert.True(t, ok)
-	assert.Equal(t, expected, event.HeadData)
+	assert.Equal(t, expected, head)
 	assert.Equal(t, expected, headProcessor.GetCurrentBlock())
 }
 
@@ -211,16 +207,34 @@ func TestSubHeadGetLastBlock(t *testing.T) {
 
 	headProcessor.Start()
 
-	event, ok := <-sub.Events
+	head := nextHeadBlock(t, sub.Events)
 	expected := protocol.Block{
 		Height:     uint64(69195274),
 		Hash:       blockchain.NewHashIdFromString("0x2eeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d12"),
 		ParentHash: blockchain.NewHashIdFromString("0x3eeaae5f33e2a990aab15d48c26118fd8875f1a2aaac376047268d80f2486d13"),
 	}
-	assert.True(t, ok)
-	assert.Equal(t, expected, event.HeadData)
+	assert.Equal(t, expected, head)
 	assert.Equal(t, expected, headProcessor.GetCurrentBlock())
 
 	reqConnector.AssertExpectations(t)
 	connector.AssertExpectations(t)
+}
+
+// nextHeadBlock returns the next head block published to the subscription, skipping the
+// lifecycle events the processor interleaves with them.
+func nextHeadBlock(t *testing.T, events <-chan blocks.HeadEvent) protocol.Block {
+	t.Helper()
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("head subscription closed before a block arrived")
+			}
+			if head, isBlock := event.(blocks.HeadBlockEvent); isBlock {
+				return head.HeadData
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for a head block")
+		}
+	}
 }

--- a/internal/upstreams/caps/ws_head_liveness_detector.go
+++ b/internal/upstreams/caps/ws_head_liveness_detector.go
@@ -121,6 +121,19 @@ func (h *headLivenessTracker) onTimeout() bool {
 	return h.live
 }
 
+// suspend records that observation stopped: the head is paused or the socket is down.
+// Liveness is retracted and the next observe becomes a new baseline that starts a fresh run,
+// so the height jump accumulated while not looking is not mistaken for a forward gap and no
+// cooldown is imposed. measuredBlockTime is untouched: nothing was learned about the chain,
+// and the gap is ours, not the node's. Returns the (now false) verdict.
+func (h *headLivenessTracker) suspend() bool {
+	h.live = false
+	h.count = 0
+	h.haveLast = false
+	h.haveLastBlockTime = false
+	return h.live
+}
+
 // timeout is the stall window: how long the detector waits for head progress before calling onTimeout.
 func (h *headLivenessTracker) timeout() time.Duration {
 	return h.measuredBlockTime * checkedBlocksUntilLive * timeoutMultiplier
@@ -132,6 +145,12 @@ func (h *headLivenessTracker) timeout() time.Duration {
 // upstream out of subscription serving without affecting regular RPC routing. If the connector
 // isn't a websocket (SubscribeStates returns nil) or there is no head source, the cap is never
 // asserted.
+//
+// Stall detection only runs while the detector is actually observing the node: the socket is
+// connected and the head processor is running. A disconnect or a head pause retracts the cap
+// at once, stops the stall timer, and makes the head re-prove itself with a fresh consecutive
+// run once observation resumes - without the timeout backoff, which would otherwise inflate the
+// block-time estimate for the rest of the process lifetime.
 type WsHeadLivenessCapDetector struct {
 	upstreamId        string
 	name              string
@@ -183,6 +202,10 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 			measuredBlockTime: d.expectedBlockTime,
 		}
 		var wsConnected, headLive bool
+		// The head processor is started before the cap processor (Resume order), and a
+		// later pause arrives on the head stream, so "running" is the right initial guess.
+		headRunning := true
+		observing := func() bool { return wsConnected && headRunning }
 
 		emit := func() bool {
 			caps := mapset.NewThreadUnsafeSet[protocol.Cap]()
@@ -198,7 +221,8 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 		}
 
 		// The timer fires when the head produces no progress within tracker.timeout(); it is
-		// re-armed with the current window at the bottom of every iteration.
+		// re-armed with the current window at the bottom of every iteration while observing,
+		// and held stopped otherwise.
 		timer := time.NewTimer(tracker.timeout())
 		defer timer.Stop()
 
@@ -211,6 +235,9 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 					return
 				}
 				wsConnected = state == protocol.WsConnected
+				if !wsConnected {
+					headLive = tracker.suspend()
+				}
 				if !emit() {
 					return
 				}
@@ -218,7 +245,15 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 				if !ok {
 					return
 				}
-				headLive = tracker.observe(event.HeadData.Height)
+				switch event := event.(type) {
+				case blocks.HeadBlockEvent:
+					headLive = tracker.observe(event.HeadData.Height)
+				case blocks.HeadStateEvent:
+					headRunning = event.Running
+					if !headRunning {
+						headLive = tracker.suspend()
+					}
+				}
 				if !emit() {
 					return
 				}
@@ -228,7 +263,11 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 					return
 				}
 			}
-			timer.Reset(tracker.timeout())
+			if observing() {
+				timer.Reset(tracker.timeout())
+			} else {
+				timer.Stop()
+			}
 		}
 	}()
 

--- a/internal/upstreams/caps/ws_head_liveness_detector.go
+++ b/internal/upstreams/caps/ws_head_liveness_detector.go
@@ -30,10 +30,11 @@ const (
 	defaultBlockTime = 12 * time.Second
 )
 
-// HeadSource is the subset of blocks.HeadProcessor the detector consumes: a stream of new
-// heads. blocks.HeadProcessor satisfies it.
+// HeadSource is the subset of blocks.HeadProcessor the detector consumes: the stream of new
+// heads and head lifecycle changes, with the last event replayed so a detector that starts
+// while the head is already paused learns it. blocks.HeadProcessor satisfies it.
 type HeadSource interface {
-	Subscribe(name string) *utils.Subscription[blocks.HeadEvent]
+	SubscribeWithReplay(name string) *utils.Subscription[blocks.HeadEvent]
 }
 
 // headLivenessTracker reduces a stream of head heights into a "live" verdict The head goes live once it has produced
@@ -189,7 +190,7 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 		close(out)
 		return out
 	}
-	headSub := d.head.Subscribe(fmt.Sprintf("%s_head", d.name))
+	headSub := d.head.SubscribeWithReplay(fmt.Sprintf("%s_head", d.name))
 
 	go func() {
 		defer close(out)
@@ -202,8 +203,8 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 			measuredBlockTime: d.expectedBlockTime,
 		}
 		var wsConnected, headLive bool
-		// The head processor is started before the cap processor (Resume order), and a
-		// later pause arrives on the head stream, so "running" is the right initial guess.
+		// A head that is already paused announces itself through the replayed
+		// HeadStateEvent{Running: false}; anything else on the stream means it is running.
 		headRunning := true
 		observing := func() bool { return wsConnected && headRunning }
 
@@ -222,8 +223,10 @@ func (d *WsHeadLivenessCapDetector) DetectCaps(ctx context.Context) <-chan mapse
 
 		// The timer fires when the head produces no progress within tracker.timeout(); it is
 		// re-armed with the current window at the bottom of every iteration while observing,
-		// and held stopped otherwise.
+		// and held stopped otherwise. It starts stopped: nothing is observed until the socket
+		// reports connected, and a timeout before that would only back off the estimate.
 		timer := time.NewTimer(tracker.timeout())
+		timer.Stop()
 		defer timer.Stop()
 
 		for {

--- a/internal/upstreams/caps/ws_head_liveness_detector_internal_test.go
+++ b/internal/upstreams/caps/ws_head_liveness_detector_internal_test.go
@@ -134,6 +134,50 @@ func TestHeadLivenessTracker(t *testing.T) {
 		assert.Equal(t, maxBlockTime, tr.measuredBlockTime)
 	})
 
+	t.Run("suspend retracts liveness and resets the run but keeps measuredBlockTime", func(t *testing.T) {
+		tr, _ := newTracker()
+		tr.measuredBlockTime = 7 * time.Second
+		last := driveLiveByCount(tr, 100)
+		assert.True(t, tr.live)
+
+		assert.False(t, tr.suspend())
+		assert.False(t, tr.live)
+		assert.Equal(t, 0, tr.count)
+		assert.Equal(t, 7*time.Second, tr.measuredBlockTime, "a gap in observation is not a stall")
+
+		// a fresh consecutive run is required, like a cold start: baseline plus two blocks
+		assert.False(t, tr.observe(last+1)) // new baseline
+		assert.False(t, tr.observe(last+2))
+		assert.True(t, tr.observe(last+3))
+	})
+
+	t.Run("a height jump after suspend is a new baseline, not a forward gap with a cooldown", func(t *testing.T) {
+		tr, _ := newTracker()
+		driveLiveByCount(tr, 100)
+		tr.suspend()
+
+		// the node advanced thousands of blocks while we were not looking
+		assert.False(t, tr.observe(5000)) // baseline
+		assert.False(t, tr.observe(5001))
+		assert.True(t, tr.observe(5002), "no cooldown: the gap was ours, not the node's")
+		assert.True(t, tr.lastNonConsecutiveTime.IsZero())
+	})
+
+	t.Run("the first observation after suspend does not measure the gap as a block interval", func(t *testing.T) {
+		tr, clk := newTracker()
+		tr.measuredBlockTime = time.Second
+		tr.observe(100)
+
+		tr.suspend()
+		clk.advance(time.Hour) // the head was paused for an hour
+		tr.observe(101)
+		assert.Equal(t, time.Second, tr.measuredBlockTime)
+
+		clk.advance(3 * time.Second)
+		tr.observe(102) // measuring resumes from the first post-suspend head
+		assert.Equal(t, 3*time.Second, tr.measuredBlockTime)
+	})
+
 	t.Run("a single consecutive block after a timeout flips it live again (no cooldown)", func(t *testing.T) {
 		tr, _ := newTracker()
 		last := driveLiveByCount(tr, 100)

--- a/internal/upstreams/caps/ws_head_liveness_detector_test.go
+++ b/internal/upstreams/caps/ws_head_liveness_detector_test.go
@@ -33,7 +33,20 @@ func (h *headFeed) Subscribe(name string) *utils.Subscription[blocks.HeadEvent] 
 }
 
 func (h *headFeed) emit(height uint64) {
-	h.mgr.Publish(blocks.HeadEvent{HeadData: protocol.NewBlockWithHeight(height)})
+	h.mgr.Publish(blocks.HeadBlockEvent{HeadData: protocol.NewBlockWithHeight(height)})
+}
+
+func (h *headFeed) setRunning(running bool) {
+	h.mgr.Publish(blocks.HeadStateEvent{Running: running})
+}
+
+func assertNoCaps(t *testing.T, out <-chan mapset.Set[protocol.Cap], within time.Duration) {
+	t.Helper()
+	select {
+	case c := <-out:
+		t.Fatalf("expected no cap snapshot, got %v", c.ToSlice())
+	case <-time.After(within):
+	}
 }
 
 func nextCaps(t *testing.T, out <-chan mapset.Set[protocol.Cap]) mapset.Set[protocol.Cap] {
@@ -88,7 +101,7 @@ func TestWsHeadLivenessCapDetector(t *testing.T) {
 		driveToLive(t, source, out, 102) // finish the consecutive run -> live
 	})
 
-	t.Run("ws disconnect retracts the cap even while heads keep flowing", func(t *testing.T) {
+	t.Run("ws disconnect retracts the cap and the head must re-prove itself after reconnect", func(t *testing.T) {
 		conn, wsMgr := stateFeed("ws")
 		head := newHeadFeed()
 		detector := caps.NewWsHeadLivenessCapDetector("up", "ws", protocol.WsCap, conn, head, bigBlockTime)
@@ -104,11 +117,62 @@ func TestWsHeadLivenessCapDetector(t *testing.T) {
 		wsMgr.Publish(protocol.WsDisconnected)
 		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
 
-		head.emit(last + 1) // head still live, but disconnected -> no cap
+		wsMgr.Publish(protocol.WsConnected) // reconnect alone proves nothing about the head
 		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
 
-		wsMgr.Publish(protocol.WsConnected) // reconnect -> live again
-		assert.True(t, nextCaps(t, out).Contains(protocol.WsCap))
+		driveToLive(t, head, out, last+1) // a fresh consecutive run brings the cap back
+	})
+
+	t.Run("ws disconnect pauses stall detection instead of backing off", func(t *testing.T) {
+		conn, wsMgr := stateFeed("ws")
+		head := newHeadFeed()
+		// timeout window ~= 100ms * 3 * 2 = 600ms
+		detector := caps.NewWsHeadLivenessCapDetector("up", "ws", protocol.WsCap, conn, head, 100*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		wsMgr.Publish(protocol.WsConnected)
+		nextCaps(t, out)
+		driveToLive(t, head, out, 100)
+
+		wsMgr.Publish(protocol.WsDisconnected)
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
+
+		// well past the stall window: no timeout fires while the socket is down
+		assertNoCaps(t, out, time.Second)
+	})
+
+	t.Run("a stopped head retracts the cap and pauses stall detection until it starts again", func(t *testing.T) {
+		conn, wsMgr := stateFeed("ws")
+		head := newHeadFeed()
+		// timeout window ~= 100ms * 3 * 2 = 600ms
+		detector := caps.NewWsHeadLivenessCapDetector("up", "ws", protocol.WsCap, conn, head, 100*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		wsMgr.Publish(protocol.WsConnected)
+		nextCaps(t, out)
+		last := driveToLive(t, head, out, 100)
+
+		head.setRunning(false)
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap), "a paused head is not live")
+
+		// well past the stall window: no timeout fires while the head is paused
+		assertNoCaps(t, out, time.Second)
+
+		head.setRunning(true)
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap), "starting alone proves nothing")
+		// the node advanced a lot while paused: a fresh run from the new height goes live
+		// without the forward-gap cooldown
+		driveToLive(t, head, out, last+10_000)
+
+		// stall detection is armed again with the original window, so a real stall is
+		// still caught within the test budget instead of a backed-off multi-second window
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap), "expected the cap to drop after a stall")
 	})
 
 	t.Run("a forward gap while connected retracts the cap", func(t *testing.T) {

--- a/internal/upstreams/caps/ws_head_liveness_detector_test.go
+++ b/internal/upstreams/caps/ws_head_liveness_detector_test.go
@@ -28,8 +28,8 @@ func newHeadFeed() *headFeed {
 	return &headFeed{mgr: utils.NewSubscriptionManager[blocks.HeadEvent]("test_heads")}
 }
 
-func (h *headFeed) Subscribe(name string) *utils.Subscription[blocks.HeadEvent] {
-	return h.mgr.Subscribe(name)
+func (h *headFeed) SubscribeWithReplay(name string) *utils.Subscription[blocks.HeadEvent] {
+	return h.mgr.SubscribeWithReplay(name)
 }
 
 func (h *headFeed) emit(height uint64) {
@@ -173,6 +173,46 @@ func TestWsHeadLivenessCapDetector(t *testing.T) {
 		// stall detection is armed again with the original window, so a real stall is
 		// still caught within the test budget instead of a backed-off multi-second window
 		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap), "expected the cap to drop after a stall")
+	})
+
+	t.Run("no stall timeout fires before the socket is connected", func(t *testing.T) {
+		conn, _ := stateFeed("ws")
+		head := newHeadFeed()
+		// timeout window ~= 100ms * 3 * 2 = 600ms
+		detector := caps.NewWsHeadLivenessCapDetector("up", "ws", protocol.WsCap, conn, head, 100*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		// not observing yet: nothing to time out on, and no backoff of the block-time estimate
+		assertNoCaps(t, out, time.Second)
+	})
+
+	t.Run("a head stopped before the detector subscribed is learned through replay", func(t *testing.T) {
+		conn, wsMgr := stateFeed("ws")
+		head := newHeadFeed()
+		// the health probe paused the head before the cap processor started
+		head.setRunning(false)
+		// timeout window ~= 100ms * 3 * 2 = 600ms
+		detector := caps.NewWsHeadLivenessCapDetector("up", "ws", protocol.WsCap, conn, head, 100*time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		out := detector.DetectCaps(ctx)
+
+		// the replayed stop is the first thing the detector sees, before any ws state
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
+
+		wsMgr.Publish(protocol.WsConnected)
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
+
+		// connected, but the head is known to be paused: no stall timeout fires
+		assertNoCaps(t, out, time.Second)
+
+		head.setRunning(true)
+		assert.False(t, nextCaps(t, out).Contains(protocol.WsCap))
+		driveToLive(t, head, out, 100)
 	})
 
 	t.Run("a forward gap while connected retracts the cap", func(t *testing.T) {

--- a/internal/upstreams/chains_specific/algorand_specific/algorand_chain_specific.go
+++ b/internal/upstreams/chains_specific/algorand_specific/algorand_chain_specific.go
@@ -258,3 +258,7 @@ var _ chains_specific.ChainSpecific = (*AlgorandChainSpecificObject)(nil)
 func (a *AlgorandChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (a *AlgorandChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/aptos_specific/aptos_chain_specific.go
+++ b/internal/upstreams/chains_specific/aptos_specific/aptos_chain_specific.go
@@ -165,3 +165,7 @@ var _ chains_specific.ChainSpecific = (*AptosChainSpecificObject)(nil)
 func (a *AptosChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (a *AptosChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/aztec_specific/aztec_chain_specific.go
+++ b/internal/upstreams/chains_specific/aztec_specific/aztec_chain_specific.go
@@ -200,3 +200,7 @@ var _ chains_specific.ChainSpecific = (*AztecChainSpecificObject)(nil)
 func (a *AztecChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (a *AztecChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/beacon_specific/beacon_chain_specific.go
+++ b/internal/upstreams/chains_specific/beacon_specific/beacon_chain_specific.go
@@ -220,3 +220,7 @@ var _ chains_specific.ChainSpecific = (*BeaconChainSpecificObject)(nil)
 func (b *BeaconChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (b *BeaconChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
+++ b/internal/upstreams/chains_specific/bitcoin_specific/bitcoin_chain_specific.go
@@ -197,3 +197,7 @@ var _ chains_specific.ChainSpecific = (*BitcoinChainSpecificObject)(nil)
 func (b *BitcoinChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (b *BitcoinChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/celestia_specific/celestia_chain_specific.go
+++ b/internal/upstreams/chains_specific/celestia_specific/celestia_chain_specific.go
@@ -78,6 +78,10 @@ func (c *CelestiaChainSpecificObject) MethodsProcessor() methods.MethodsProcesso
 	return nil
 }
 
+func (c *CelestiaChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}
+
 // node.Info requires an admin token, so client labels can't be detected.
 func (c *CelestiaChainSpecificObject) LabelsProcessor() labels.LabelsProcessor {
 	return nil

--- a/internal/upstreams/chains_specific/chain_specific.go
+++ b/internal/upstreams/chains_specific/chain_specific.go
@@ -37,4 +37,10 @@ type ChainSpecific interface {
 	// chain has no way to introspect a node. Detection only ever subtracts, so nil means
 	// the upstream keeps the full method set its spec declares.
 	MethodsProcessor() methods.MethodsProcessor
+
+	// PauseHeadWhileSyncing reports whether the head processor must be stopped while the
+	// health probes say the node is syncing. Some node families push heads at full replay
+	// speed during a sync, which is wasted work: fork choice drops the heads of a
+	// non-available upstream anyway.
+	PauseHeadWhileSyncing() bool
 }

--- a/internal/upstreams/chains_specific/cosmos_specific/cosmos_grpc_specific.go
+++ b/internal/upstreams/chains_specific/cosmos_specific/cosmos_grpc_specific.go
@@ -168,4 +168,8 @@ func (c *CosmosGrpcSpecific) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
 
+func (c *CosmosGrpcSpecific) PauseHeadWhileSyncing() bool {
+	return false
+}
+
 var _ chains_specific.ChainSpecific = (*CosmosGrpcSpecific)(nil)

--- a/internal/upstreams/chains_specific/cosmos_specific/cosmos_rest_specific.go
+++ b/internal/upstreams/chains_specific/cosmos_specific/cosmos_rest_specific.go
@@ -163,3 +163,7 @@ var _ chains_specific.ChainSpecific = (*CosmosRestSpecific)(nil)
 func (c *CosmosRestSpecific) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (c *CosmosRestSpecific) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
+++ b/internal/upstreams/chains_specific/evm_specific/evm_chain_specific.go
@@ -107,6 +107,12 @@ func (e *EvmChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return methods.NewGenericMethodsProcessor(e.ctx, e.upstreamId, detectors, methods.DetectionInterval)
 }
 
+// PauseHeadWhileSyncing is true for EVM nodes: a syncing execution client streams
+// newHeads at replay speed, and nothing downstream consumes those heads.
+func (e *EvmChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return true
+}
+
 // detectableMethods is the set of spec methods the detectors above may form an opinion
 // about - the chain spec's methods restricted to the connectors that speak JSON-RPC.
 func (e *EvmChainSpecificObject) detectableMethods() mapset.Set[string] {

--- a/internal/upstreams/chains_specific/near_specific/near_chain_specific.go
+++ b/internal/upstreams/chains_specific/near_specific/near_chain_specific.go
@@ -213,3 +213,7 @@ var _ chains_specific.ChainSpecific = (*NearChainSpecificObject)(nil)
 func (n *NearChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (n *NearChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/polkadot_specific/polkadot_chain_specific.go
+++ b/internal/upstreams/chains_specific/polkadot_specific/polkadot_chain_specific.go
@@ -193,3 +193,7 @@ var _ chains_specific.ChainSpecific = (*PolkadotChainSpecificObject)(nil)
 func (p *PolkadotChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (p *PolkadotChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/solana_specific/solana_chain_specific.go
+++ b/internal/upstreams/chains_specific/solana_specific/solana_chain_specific.go
@@ -191,3 +191,7 @@ var _ chains_specific.ChainSpecific = (*SolanaChainSpecificObject)(nil)
 func (s *SolanaChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (s *SolanaChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/starknet_specific/starknet_chain_specific.go
+++ b/internal/upstreams/chains_specific/starknet_specific/starknet_chain_specific.go
@@ -201,3 +201,7 @@ var _ chains_specific.ChainSpecific = (*StarknetChainSpecificObject)(nil)
 func (s *StarknetChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (s *StarknetChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/stellar_specific/stellar_chain_specific.go
+++ b/internal/upstreams/chains_specific/stellar_specific/stellar_chain_specific.go
@@ -88,6 +88,10 @@ func (s *stellarBaseChainSpecificObject) MethodsProcessor() methods.MethodsProce
 	return nil
 }
 
+func (s *stellarBaseChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}
+
 func (s *stellarBaseChainSpecificObject) ParseSubscriptionBlock(_ []byte) (protocol.Block, error) {
 	return protocol.ZeroBlock{}, blocks.ErrUnsupportedHeadSubscriptions
 }

--- a/internal/upstreams/chains_specific/sui_specific/sui_chain_specific.go
+++ b/internal/upstreams/chains_specific/sui_specific/sui_chain_specific.go
@@ -186,6 +186,10 @@ func (s *SuiChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
 
+func (s *SuiChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}
+
 func newSuiBlock(serviceInfo *sui.GetServiceInfoResponse, rawData []byte) (protocol.Block, error) {
 	return newSuiBlockFromHeight(serviceInfo.GetCheckpointHeight(), rawData)
 }

--- a/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific.go
+++ b/internal/upstreams/chains_specific/tendermint_specific/tendermint_chain_specific.go
@@ -190,3 +190,7 @@ var _ chains_specific.ChainSpecific = (*TendermintChainSpecific)(nil)
 func (t *TendermintChainSpecific) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (t *TendermintChainSpecific) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/ton_specific/ton_chain_specific.go
+++ b/internal/upstreams/chains_specific/ton_specific/ton_chain_specific.go
@@ -145,3 +145,7 @@ func tonBlockFromIdExt(last tonBlockIdExt) protocol.Block {
 func (t *tonBaseChainSpecificObject) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (t *tonBaseChainSpecificObject) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
+++ b/internal/upstreams/chains_specific/tron_specific/tron_rest_specific.go
@@ -224,3 +224,7 @@ var _ chains_specific.ChainSpecific = (*TronRestSpecific)(nil)
 func (t *TronRestSpecific) MethodsProcessor() methods.MethodsProcessor {
 	return nil
 }
+
+func (t *TronRestSpecific) PauseHeadWhileSyncing() bool {
+	return false
+}

--- a/internal/upstreams/event_processors/block_event_processor.go
+++ b/internal/upstreams/event_processors/block_event_processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	"github.com/drpcorg/nodecore/pkg/utils"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
@@ -95,7 +96,9 @@ func (h *HeadEventProcessor) Start() {
 	h.lifecycle.Start(func(ctx context.Context) error {
 		h.headProcessor.Start()
 
-		headSub := h.headProcessor.Subscribe(fmt.Sprintf("%s_head_updates", h.upstreamId))
+		// unique per start: the previous run releases its subscription asynchronously, and
+		// a pause followed by an immediate resume must not clash with it
+		headSub := h.headProcessor.Subscribe(fmt.Sprintf("%s_head_updates_%s", h.upstreamId, uuid.NewString()))
 
 		go func() {
 			defer headSub.Unsubscribe()
@@ -106,7 +109,7 @@ func (h *HeadEventProcessor) Start() {
 					return
 				case event, ok := <-headSub.Events:
 					if !ok {
-						continue
+						return
 					}
 					// lifecycle changes of the head are for liveness consumers; the upstream
 					// state only ever learns about blocks

--- a/internal/upstreams/event_processors/block_event_processor.go
+++ b/internal/upstreams/event_processors/block_event_processor.go
@@ -104,8 +104,13 @@ func (h *HeadEventProcessor) Start() {
 				case <-ctx.Done():
 					log.Info().Msgf("stopping head events of upstream '%s'", h.upstreamId)
 					return
-				case head, ok := <-headSub.Events:
-					if ok {
+				case event, ok := <-headSub.Events:
+					if !ok {
+						continue
+					}
+					// lifecycle changes of the head are for liveness consumers; the upstream
+					// state only ever learns about blocks
+					if head, isBlock := event.(blocks.HeadBlockEvent); isBlock {
 						h.emitter(&protocol.HeadUpstreamStateEvent{HeadData: head.HeadData})
 						headsMetric.WithLabelValues(h.chain.String(), h.upstreamId).Set(float64(head.HeadData.Height))
 					}

--- a/internal/upstreams/event_processors/block_event_processor_test.go
+++ b/internal/upstreams/event_processors/block_event_processor_test.go
@@ -160,7 +160,7 @@ func TestHeadEventProcessorStartEmitsEvents(t *testing.T) {
 	headData := protocol.NewBlockWithHeight(202)
 
 	require.Eventually(t, func() bool {
-		headProcessor.Publish(blocks.HeadEvent{HeadData: headData})
+		headProcessor.Publish(blocks.HeadBlockEvent{HeadData: headData})
 
 		select {
 		case event := <-events:
@@ -224,4 +224,39 @@ func TestHeadEventProcessorStopStopsUnderlyingProcessor(t *testing.T) {
 
 	assert.False(t, processor.Running())
 	headProcessor.AssertExpectations(t)
+}
+
+func TestHeadEventProcessorIgnoresStateEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	headProcessor := mocks.NewHeadProcessorMock()
+	processor := event_processors.NewHeadEventProcessor(ctx, "upstream-1", chains.ETHEREUM, headProcessor)
+	events := make(chan protocol.AbstractUpstreamStateEvent, 10)
+
+	headProcessor.On("Start").Return()
+	headProcessor.On("Subscribe", "upstream-1_head_updates")
+	headProcessor.On("Stop").Return()
+
+	processor.SetEmitter(func(event protocol.AbstractUpstreamStateEvent) {
+		events <- event
+	})
+	processor.Start()
+	defer processor.Stop()
+
+	headData := protocol.NewBlockWithHeight(202)
+	require.Eventually(t, func() bool {
+		// state changes carry no head data and must not reach the upstream state pipeline
+		headProcessor.Publish(blocks.HeadStateEvent{Running: false})
+		headProcessor.Publish(blocks.HeadBlockEvent{HeadData: headData})
+
+		select {
+		case event := <-events:
+			headEvent, ok := event.(*protocol.HeadUpstreamStateEvent)
+			require.True(t, ok, "only head blocks are emitted, got %T", event)
+			return headEvent.HeadData.Equals(headData)
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/upstreams/event_processors/block_event_processor_test.go
+++ b/internal/upstreams/event_processors/block_event_processor_test.go
@@ -2,6 +2,7 @@ package event_processors_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -148,7 +149,7 @@ func TestHeadEventProcessorStartEmitsEvents(t *testing.T) {
 	events := make(chan protocol.AbstractUpstreamStateEvent, 1)
 
 	headProcessor.On("Start").Return()
-	headProcessor.On("Subscribe", "upstream-1_head_updates")
+	headProcessor.On("Subscribe", headUpdatesSubscription())
 	headProcessor.On("Stop").Return()
 
 	processor.SetEmitter(func(event protocol.AbstractUpstreamStateEvent) {
@@ -210,7 +211,7 @@ func TestHeadEventProcessorStopStopsUnderlyingProcessor(t *testing.T) {
 	processor := event_processors.NewHeadEventProcessor(ctx, "upstream-1", chains.ETHEREUM, headProcessor)
 
 	headProcessor.On("Start").Return()
-	headProcessor.On("Subscribe", "upstream-1_head_updates")
+	headProcessor.On("Subscribe", headUpdatesSubscription())
 	headProcessor.On("Stop").Return()
 
 	processor.SetEmitter(func(protocol.AbstractUpstreamStateEvent) {})
@@ -235,7 +236,7 @@ func TestHeadEventProcessorIgnoresStateEvents(t *testing.T) {
 	events := make(chan protocol.AbstractUpstreamStateEvent, 10)
 
 	headProcessor.On("Start").Return()
-	headProcessor.On("Subscribe", "upstream-1_head_updates")
+	headProcessor.On("Subscribe", headUpdatesSubscription())
 	headProcessor.On("Stop").Return()
 
 	processor.SetEmitter(func(event protocol.AbstractUpstreamStateEvent) {
@@ -255,6 +256,52 @@ func TestHeadEventProcessorIgnoresStateEvents(t *testing.T) {
 			headEvent, ok := event.(*protocol.HeadUpstreamStateEvent)
 			require.True(t, ok, "only head blocks are emitted, got %T", event)
 			return headEvent.HeadData.Equals(headData)
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+// headUpdatesSubscription matches the head event processor's subscription name, which is
+// unique per start so that a restart never clashes with a subscription whose asynchronous
+// release has not run yet.
+func headUpdatesSubscription() any {
+	return mock.MatchedBy(func(name string) bool {
+		return strings.HasPrefix(name, "upstream-1_head_updates")
+	})
+}
+
+func TestHeadEventProcessorRestartsBackToBack(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	headProcessor := mocks.NewHeadProcessorMock()
+	processor := event_processors.NewHeadEventProcessor(ctx, "upstream-1", chains.ETHEREUM, headProcessor)
+	events := make(chan protocol.AbstractUpstreamStateEvent, 10)
+
+	headProcessor.On("Start").Return()
+	headProcessor.On("Subscribe", headUpdatesSubscription())
+	headProcessor.On("Stop").Return()
+
+	processor.SetEmitter(func(event protocol.AbstractUpstreamStateEvent) {
+		events <- event
+	})
+
+	// a pause followed by an immediate resume: the previous run's subscription is
+	// released asynchronously, so the second start must not reuse its name
+	processor.Start()
+	processor.Stop()
+	processor.Start()
+	defer processor.Stop()
+
+	headData := protocol.NewBlockWithHeight(303)
+	require.Eventually(t, func() bool {
+		headProcessor.Publish(blocks.HeadBlockEvent{HeadData: headData})
+
+		select {
+		case event := <-events:
+			headEvent, ok := event.(*protocol.HeadUpstreamStateEvent)
+			return ok && headEvent.HeadData.Equals(headData)
 		default:
 			return false
 		}

--- a/internal/upstreams/event_processors/event_processor.go
+++ b/internal/upstreams/event_processors/event_processor.go
@@ -1,6 +1,8 @@
 package event_processors
 
 import (
+	"sync"
+
 	"github.com/drpcorg/nodecore/internal/protocol"
 	"github.com/drpcorg/nodecore/internal/upstreams/validations"
 	"github.com/drpcorg/nodecore/pkg/utils"
@@ -30,6 +32,11 @@ type Emitter func(event protocol.AbstractUpstreamStateEvent)
 
 type UpstreamProcessorAggregator struct {
 	eventProcessors map[EventProcessorType]UpstreamStateEventProcessor
+	// mu serializes StartProcessor and StopProcessor. Two goroutines drive them: the
+	// supervisor (Resume, PartialStop) and the upstream state loop (head pause while
+	// syncing). A processor's start or stop is a compound operation (its own lifecycle
+	// plus the nested processor it owns), so the whole call must be one critical section.
+	mu sync.Mutex
 }
 
 func (u *UpstreamProcessorAggregator) SetEmitter(emitter Emitter) {
@@ -78,12 +85,16 @@ func (u *UpstreamProcessorAggregator) ValidateSettings() (validations.Validation
 }
 
 func (u *UpstreamProcessorAggregator) StartProcessor(processorType EventProcessorType) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	if processor, ok := u.eventProcessors[processorType]; ok {
 		processor.Start()
 	}
 }
 
 func (u *UpstreamProcessorAggregator) StopProcessor(processorType EventProcessorType) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	if processor, ok := u.eventProcessors[processorType]; ok {
 		processor.Stop()
 	}

--- a/internal/upstreams/event_processors/event_processor_aggregator_test.go
+++ b/internal/upstreams/event_processors/event_processor_aggregator_test.go
@@ -2,10 +2,12 @@ package event_processors_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/blocks"
 	"github.com/drpcorg/nodecore/internal/upstreams/event_processors"
 	"github.com/drpcorg/nodecore/internal/upstreams/validations"
 	"github.com/drpcorg/nodecore/pkg/chains"
@@ -152,5 +154,53 @@ func aggregatorTestUpstreamOptions() *chains.Options {
 		DisableChainValidation:      new(false),
 		DisableHealthValidation:     new(false),
 		DisableLowerBoundsDetection: new(false),
+	}
+}
+
+func TestUpstreamProcessorAggregatorSerializesConcurrentStartStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	headProcessor := mocks.NewHeadProcessorMock()
+	headProcessor.On("Start").Return()
+	headProcessor.On("Stop").Return()
+	headProcessor.On("Subscribe", mock.Anything)
+
+	processor := event_processors.NewHeadEventProcessor(ctx, "upstream-1", chains.ETHEREUM, headProcessor)
+	aggregator := event_processors.NewUpstreamProcessorAggregator([]event_processors.UpstreamStateEventProcessor{processor})
+	events := make(chan protocol.AbstractUpstreamStateEvent, 100)
+	aggregator.SetEmitter(func(event protocol.AbstractUpstreamStateEvent) {
+		events <- event
+	})
+
+	// the supervisor (Resume/PartialStop) and the upstream state loop (pause on syncing)
+	// drive the same processor from different goroutines
+	const iterations = 3000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			aggregator.StartProcessor(event_processors.HeadEventProcessorType)
+			aggregator.StopProcessor(event_processors.HeadEventProcessorType)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			aggregator.StopProcessor(event_processors.HeadEventProcessorType)
+			aggregator.StartProcessor(event_processors.HeadEventProcessorType)
+		}
+	}()
+	wg.Wait()
+	aggregator.StopProcessor(event_processors.HeadEventProcessorType)
+
+	// everything is stopped: a head published now must reach no forwarder. A run that
+	// escaped the lifecycle (started behind a concurrent stop) would still forward it.
+	headProcessor.Publish(blocks.HeadBlockEvent{HeadData: protocol.NewBlockWithHeight(1)})
+	select {
+	case event := <-events:
+		t.Fatalf("an orphan forwarder is still alive: got %T after the final stop", event)
+	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/upstreams/flow/method_translation_test.go
+++ b/internal/upstreams/flow/method_translation_test.go
@@ -156,6 +156,7 @@ func bitcoinTestUpstream(connector connectors.ApiConnector, headHeight uint64) *
 		nil,
 		nil,
 		nil,
+		false,
 	)
 }
 

--- a/internal/upstreams/flow/pending_tx_source_internal_test.go
+++ b/internal/upstreams/flow/pending_tx_source_internal_test.go
@@ -402,6 +402,7 @@ func pendingDrpcUpstream(id string, wsCh chan protocol.SubResponse, opId string,
 		nil,
 		nil,
 		nil,
+		false,
 	)
 }
 
@@ -515,6 +516,7 @@ func TestDrpcPendingTxSourceEnrichesConcurrently(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		false,
 	)
 
 	upSup := mocks.NewUpstreamSupervisorMock()

--- a/internal/upstreams/upstream.go
+++ b/internal/upstreams/upstream.go
@@ -49,6 +49,9 @@ type GenericUpstream struct {
 	headLag atomic.Int64
 
 	processorAggregator *event_processors.UpstreamProcessorAggregator
+	// pauseHeadWhileSyncing is the chain family's answer to ChainSpecific.PauseHeadWhileSyncing,
+	// captured at construction so the state pipeline does not need the chain-specific itself
+	pauseHeadWhileSyncing bool
 }
 
 // groupLabelsFromConfig builds the immutable set of config-defined group-labels
@@ -112,6 +115,7 @@ func NewGenericUpstream(
 	if err != nil {
 		return nil, err
 	}
+	upstream.pauseHeadWhileSyncing = chainSpecific.PauseHeadWhileSyncing()
 	headProcessor := CreateHeadProcessor(ctx, conf, creationData.upstreamConnectorsInfo.headConnector, chainSpecific)
 	processorAggregator := event_processors.NewUpstreamProcessorAggregator(
 		[]event_processors.UpstreamStateEventProcessor{
@@ -141,6 +145,7 @@ func NewGenericUpstreamWithParams(
 	processorAggregator *event_processors.UpstreamProcessorAggregator,
 	stateChan *chan protocol.AbstractUpstreamStateEvent,
 	emitter *event_processors.Emitter,
+	pauseHeadWhileSyncing bool,
 ) *GenericUpstream {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -160,18 +165,19 @@ func NewGenericUpstreamWithParams(
 
 	mainLifecycle := utils.NewGenericLifecycle(fmt.Sprintf("%s_main_upstream", id), ctx)
 	return &GenericUpstream{
-		id:                  id,
-		configuredChain:     chains.GetChain(chain.String()),
-		upstreamCtx:         newUpstreamCtx(cancel, mainLifecycle),
-		upstreamState:       upState,
-		apiConnectors:       apiConnectors,
-		subManager:          utils.NewSubscriptionManager[protocol.UpstreamEvent](fmt.Sprintf("%s_upstream", id)),
-		upstreamIndexHex:    index,
-		upConfig:            upConfig,
-		groupLabels:         groupLabelsFromConfig(upConfig),
-		processorAggregator: processorAggregator,
-		stateChan:           *stateChan,
-		emitter:             *emitter,
+		id:                    id,
+		configuredChain:       chains.GetChain(chain.String()),
+		upstreamCtx:           newUpstreamCtx(cancel, mainLifecycle),
+		upstreamState:         upState,
+		apiConnectors:         apiConnectors,
+		subManager:            utils.NewSubscriptionManager[protocol.UpstreamEvent](fmt.Sprintf("%s_upstream", id)),
+		upstreamIndexHex:      index,
+		upConfig:              upConfig,
+		groupLabels:           groupLabelsFromConfig(upConfig),
+		processorAggregator:   processorAggregator,
+		stateChan:             *stateChan,
+		emitter:               *emitter,
+		pauseHeadWhileSyncing: pauseHeadWhileSyncing,
 	}
 }
 

--- a/internal/upstreams/upstream_events.go
+++ b/internal/upstreams/upstream_events.go
@@ -6,6 +6,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/drpcorg/nodecore/internal/protocol"
+	"github.com/drpcorg/nodecore/internal/upstreams/event_processors"
 	"github.com/drpcorg/nodecore/internal/upstreams/methods"
 	"github.com/drpcorg/nodecore/pkg/chains"
 	specs "github.com/drpcorg/public/pkg/methods"
@@ -30,6 +31,8 @@ func (u *GenericUpstream) processStateEvents(ctx context.Context, initialValid b
 	// with the upstream's current head lag (u.headLag) to derive the effective
 	// availability published on UpstreamState.Status.
 	baseAvail := u.upstreamState.Load().Status
+	// headPaused tracks whether toggleHeadOnSyncing has stopped the head processor
+	headPaused := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -47,6 +50,9 @@ func (u *GenericUpstream) processStateEvents(ctx context.Context, initialValid b
 				log.Warn().Msgf("upstream '%s' settings are invalid, it will be stopped", u.id)
 				eventType = &protocol.RemoveUpstreamEvent{}
 				validUpstream = false
+				// PartialStop takes the head down with everything else and Resume brings it
+				// back outside this loop, so the pause bookkeeping starts over
+				headPaused = false
 				u.publishUpstreamEvent(state, eventType)
 			case *protocol.ValidUpstreamStateEvent:
 				if validUpstream {
@@ -96,6 +102,7 @@ func (u *GenericUpstream) processStateEvents(ctx context.Context, initialValid b
 				}
 				if stateEvent.Lag == nil {
 					baseAvail = stateEvent.Status
+					headPaused = u.toggleHeadOnSyncing(baseAvail, headPaused)
 				}
 				newAvail := protocol.StatusByLag(u.headLag.Load(), baseAvail, u.configuredChain.Settings.Lags.Syncing)
 				if newAvail != state.Status {
@@ -118,6 +125,26 @@ func (u *GenericUpstream) processStateEvents(ctx context.Context, initialValid b
 			}
 		}
 	}
+}
+
+// toggleHeadOnSyncing stops the head processor when the health probes report Syncing
+// and starts it again on the first non-Syncing verdict. Only probe results reach here:
+// lag-observer events carry a Lag and never change baseAvail, so a node that merely
+// fell behind keeps its head. Returns the new paused state.
+func (u *GenericUpstream) toggleHeadOnSyncing(probeAvail protocol.AvailabilityStatus, paused bool) bool {
+	if !u.pauseHeadWhileSyncing {
+		return false
+	}
+	syncing := probeAvail == protocol.Syncing
+	switch {
+	case syncing && !paused:
+		log.Warn().Msgf("upstream '%s' reports syncing, pausing its head", u.id)
+		u.processorAggregator.StopProcessor(event_processors.HeadEventProcessorType)
+	case !syncing && paused:
+		log.Warn().Msgf("upstream '%s' is synced again, resuming its head", u.id)
+		u.processorAggregator.StartProcessor(event_processors.HeadEventProcessorType)
+	}
+	return syncing
 }
 
 func (u *GenericUpstream) createUpstreamEvent(eventType protocol.UpstreamEventType) protocol.UpstreamEvent {

--- a/internal/upstreams/upstream_test.go
+++ b/internal/upstreams/upstream_test.go
@@ -22,6 +22,7 @@ import (
 	specs "github.com/drpcorg/public/pkg/methods"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -695,11 +696,126 @@ func TestGenericUpstreamProcessStateEvents_HeadLagDoesNotUpgradeUnavailable(t *t
 	assert.Equal(t, protocol.Unavailable, upstream.GetUpstreamState().Status)
 }
 
+func TestGenericUpstreamProcessStateEvents_ProbeSyncingPausesHead(t *testing.T) {
+	headProcessor := newHeadEventProcessorMock()
+	aggregator := event_processors.NewUpstreamProcessorAggregator([]event_processors.UpstreamStateEventProcessor{headProcessor})
+	upstream, emit, sub := newTestGenericUpstreamWithHeadPause(t, nil, nil, aggregator, true)
+	t.Cleanup(upstream.Stop)
+	startUpstream(t, upstream, sub)
+	// Resume on Start brings the head up once
+	headProcessor.AssertNumberOfCalls(t, "Start", 1)
+
+	// the probe says syncing: the head is stopped before the status is published
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Stop", 1)
+
+	// a repeated syncing verdict changes nothing
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	assertNoUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Stop", 1)
+
+	// synced again: the head is started
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Available})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Start", 2)
+
+	// any non-syncing verdict resumes, Immature included
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Stop", 2)
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Immature})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Start", 3)
+}
+
+func TestGenericUpstreamProcessStateEvents_LagSyncingDoesNotPauseHead(t *testing.T) {
+	headProcessor := newHeadEventProcessorMock()
+	aggregator := event_processors.NewUpstreamProcessorAggregator([]event_processors.UpstreamStateEventProcessor{headProcessor})
+	upstream, _, sub := newTestGenericUpstreamWithHeadPause(t, nil, nil, aggregator, true)
+	t.Cleanup(upstream.Stop)
+	startUpstream(t, upstream, sub)
+
+	// the lag observer downgrades the status to Syncing, but that is not the probe's verdict
+	upstream.UpdateHeadLag(100)
+	event := nextUpstreamEvent(t, sub)
+	stateEvent, ok := event.EventType.(*protocol.StateUpstreamEvent)
+	require.True(t, ok)
+	require.Equal(t, protocol.Syncing, stateEvent.State.Status)
+
+	headProcessor.AssertNumberOfCalls(t, "Stop", 0)
+}
+
+func TestGenericUpstreamProcessStateEvents_ProbeSyncingKeepsHeadWithoutPauseFlag(t *testing.T) {
+	headProcessor := newHeadEventProcessorMock()
+	aggregator := event_processors.NewUpstreamProcessorAggregator([]event_processors.UpstreamStateEventProcessor{headProcessor})
+	upstream, emit, sub := newTestGenericUpstreamWithHeadPause(t, nil, nil, aggregator, false)
+	t.Cleanup(upstream.Stop)
+	startUpstream(t, upstream, sub)
+
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	_ = nextUpstreamEvent(t, sub)
+	require.Equal(t, protocol.Syncing, upstream.GetUpstreamState().Status)
+
+	headProcessor.AssertNumberOfCalls(t, "Stop", 0)
+}
+
+func TestGenericUpstreamProcessStateEvents_HeadPauseResetsAfterFatalError(t *testing.T) {
+	headProcessor := newHeadEventProcessorMock()
+	aggregator := event_processors.NewUpstreamProcessorAggregator([]event_processors.UpstreamStateEventProcessor{headProcessor})
+	upstream, emit, sub := newTestGenericUpstreamWithHeadPause(t, nil, nil, aggregator, true)
+	t.Cleanup(upstream.Stop)
+	startUpstream(t, upstream, sub)
+
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Stop", 1)
+
+	// the supervisor takes the whole upstream down on a fatal error and brings
+	// everything back on Valid, so the pause bookkeeping must start over
+	emit(&protocol.FatalErrorUpstreamStateEvent{})
+	event := nextUpstreamEvent(t, sub)
+	_, ok := event.EventType.(*protocol.RemoveUpstreamEvent)
+	require.True(t, ok)
+	emit(&protocol.ValidUpstreamStateEvent{})
+	event = nextUpstreamEvent(t, sub)
+	_, ok = event.EventType.(*protocol.ValidUpstreamEvent)
+	require.True(t, ok)
+
+	// the head is considered running again: a synced verdict does not start it...
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Available})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Start", 1)
+	// ...and a syncing verdict stops it once more
+	emit(&protocol.StatusUpstreamStateEvent{Status: protocol.Syncing})
+	_ = nextUpstreamEvent(t, sub)
+	headProcessor.AssertNumberOfCalls(t, "Stop", 2)
+}
+
+func newHeadEventProcessorMock() *mocks.UpstreamStateEventProcessorMock {
+	headProcessor := mocks.NewUpstreamStateEventProcessorMock(event_processors.HeadEventProcessorType)
+	headProcessor.On("SetEmitter", mock.Anything)
+	headProcessor.On("Start")
+	headProcessor.On("Stop")
+	return headProcessor
+}
+
 func newTestGenericUpstream(
 	t *testing.T,
 	upConfig *config.Upstream,
 	connectorMocks []*mocks.ConnectorMock,
 	aggregator *event_processors.UpstreamProcessorAggregator,
+) (*upstreams.GenericUpstream, func(protocol.AbstractUpstreamStateEvent), *utils.Subscription[protocol.UpstreamEvent]) {
+	t.Helper()
+	return newTestGenericUpstreamWithHeadPause(t, upConfig, connectorMocks, aggregator, false)
+}
+
+func newTestGenericUpstreamWithHeadPause(
+	t *testing.T,
+	upConfig *config.Upstream,
+	connectorMocks []*mocks.ConnectorMock,
+	aggregator *event_processors.UpstreamProcessorAggregator,
+	pauseHeadWhileSyncing bool,
 ) (*upstreams.GenericUpstream, func(protocol.AbstractUpstreamStateEvent), *utils.Subscription[protocol.UpstreamEvent]) {
 	t.Helper()
 	loadMethodSpecs(t)
@@ -741,6 +857,7 @@ func newTestGenericUpstream(
 		aggregator,
 		&stateChan,
 		&stateEmitter,
+		pauseHeadWhileSyncing,
 	)
 
 	sub := upstream.Subscribe(t.Name())

--- a/internal/upstreams/validations/eth_validations/eth_health_validator.go
+++ b/internal/upstreams/validations/eth_validations/eth_health_validator.go
@@ -123,6 +123,11 @@ func (e *EthSyncingValidator) Validate() protocol.AvailabilityStatus {
 		root.Get("syncTargetMsgCount").Exists() {
 		return protocol.Syncing
 	}
+	// newer Arbitrum Nitro releases report sync progress with these fields instead
+	if root.Get("executionSyncTarget").Exists() &&
+		root.Get("messageOfLastBlock").Exists() {
+		return protocol.Syncing
+	}
 	return protocol.Available
 }
 

--- a/internal/upstreams/validations/eth_validations/eth_health_validator_test.go
+++ b/internal/upstreams/validations/eth_validations/eth_health_validator_test.go
@@ -205,6 +205,18 @@ func TestEthSyncingValidatorReturnsSyncingForOpNodeStylePayload(t *testing.T) {
 	connector.AssertExpectations(t)
 }
 
+func TestEthSyncingValidatorReturnsSyncingForNitroExecutionSyncTargetPayload(t *testing.T) {
+	connector := newEthHealthConnectorMock(t, "eth_syncing",
+		protocol.NewSimpleHttpUpstreamResponse("1", []byte(`{"blockNum":43327714,"consensusMaxMessageCount":92338320,"executionSyncTarget":92338319,"messageOfLastBlock":43327714}`), protocol.JsonRpc),
+	)
+	validator := eth_validations.NewEthSyncingValidator("upstream-1", testConfiguredChain(5), connector, time.Second)
+
+	status := validator.Validate()
+
+	assert.Equal(t, protocol.Syncing, status)
+	connector.AssertExpectations(t)
+}
+
 func TestEthSyncingValidatorReturnsAvailableWhenStructuredPayloadHasNoKnownSyncFields(t *testing.T) {
 	connector := newEthHealthConnectorMock(t, "eth_syncing",
 		protocol.NewSimpleHttpUpstreamResponse("1", []byte(`{"status":"ok"}`), protocol.JsonRpc),

--- a/pkg/test_utils/mocks/blocks.go
+++ b/pkg/test_utils/mocks/blocks.go
@@ -87,6 +87,11 @@ func (m *HeadProcessorMock) Subscribe(name string) *utils.Subscription[blocks.He
 	return m.subManager.Subscribe(name)
 }
 
+func (m *HeadProcessorMock) SubscribeWithReplay(name string) *utils.Subscription[blocks.HeadEvent] {
+	m.Called(name)
+	return m.subManager.SubscribeWithReplay(name)
+}
+
 func (m *HeadProcessorMock) Publish(event blocks.HeadEvent) {
 	m.subManager.Publish(event)
 }

--- a/pkg/test_utils/test_helpers.go
+++ b/pkg/test_utils/test_helpers.go
@@ -231,6 +231,7 @@ func TestEvmUpstream(
 		processorAggregator,
 		nil,
 		nil,
+		false,
 	)
 }
 


### PR DESCRIPTION
# Pause EVM heads while the node is syncing

## Summary

A syncing EVM node does two things that hurt us. Newer Arbitrum Nitro releases answer
`eth_syncing` with an object we did not recognise, so the health probe reported the node as
`Available` while it was replaying history. And a syncing node with a websocket head streams
`newHeads` at replay speed: fork choice already drops the heads of a non-available upstream,
so every one of those events was parsed and discarded for nothing.

This PR fixes the probe, stops the head processor of an EVM upstream for as long as the
`eth_syncing` probe says the node is syncing, and teaches the websocket head-liveness
detector that a paused head is not a stalled one. dshackle does the same thing on its head
level (`GenericWsHead.onSyncingNode`); here the guard lives in the upstream state pipeline,
which already separates the probe verdict from the lag-derived one.

## Changes

### `eth_syncing` probe recognises the new Nitro shape

`EthSyncingValidator` returns `Syncing` when the result object carries `executionSyncTarget`
and `messageOfLastBlock`, the fields newer Nitro emits while the execution layer is behind
its target:

```json
{
  "blockNum": 43327714,
  "consensusMaxMessageCount": 92338320,
  "executionSyncTarget": 92338319,
  "messageOfLastBlock": 43327714
}
```

The existing fallback for unknown structured payloads (`Available`) is unchanged.

### Head pause driven by the probe, not by lag

`GenericUpstream.processStateEvents` already keeps `baseAvail`, the availability reported by
health probes, separately from the effective status that the chain supervisor's lag observer
can downgrade to `Syncing`. Only probe events (those without a `Lag`) update `baseAvail`, so
that is where the guard sits:

- when `baseAvail` transitions into `Syncing`, the head event processor is stopped, which
  unsubscribes the head and stops its no-updates timer;
- when it transitions to anything else (`Available` or `Immature`), the head event processor
  is started again, which refetches the latest block and resubscribes.

A node that merely fell behind by lag keeps its head. The fatal-error branch resets the pause
bookkeeping because `PartialStop` and `Resume` restart the head outside the loop.

The guard is opt-in per chain family through a new `ChainSpecific.PauseHeadWhileSyncing()`.
The EVM specific returns true; every other specific, Tron included, returns false. The upstream
captures the answer as a bool at construction, so it does not need the chain-specific itself.

`GenericHeadProcessor.UpdateHead` (manual heads from the integrity processor) is now a
non-blocking send: with a paused head nobody drains that channel, and the previous blocking
send could hang a request once the buffer filled.

### Head-liveness detector: a gap in observation is not a stall

`WsHeadLivenessCapDetector` gates `WsCap` on the head advancing. Its tracker learns the block
time as the largest interval seen (it never shrinks) and doubles it on every stall timeout. A
paused head, or a dropped socket, used to poison that estimate twice: the timer kept firing
during the pause (backoff up to the 10-minute cap, a 60-minute stall window), and the first
head after resume was measured against the pre-pause timestamp. After one long sync the
detector was effectively blind for the rest of the process lifetime.

Now:

- `blocks.HeadEvent` is a sealed interface. The former struct is `HeadBlockEvent`; the new
  `HeadStateEvent{Running bool}` is published by the head processor on `Start` and `Stop`.
  One ordered stream keeps blocks and lifecycle changes in the order they happened, so the
  detector can tell a block that arrived before a stop from one that arrived after a start.
  The head event processor forwards only blocks to the state pipeline.
- The tracker gets `suspend()`: liveness is retracted, the consecutive run and the last
  height/timestamp are forgotten, `measuredBlockTime` and the forward-gap cooldown are left
  alone. The detector calls it on websocket disconnect and on head stop.
- The stall timer is armed only while observing (socket connected and head running) and held
  stopped otherwise. On resume it is re-armed with the unchanged window.
- The first head after a suspend is a new baseline, so the height jump accumulated while not
  looking is not mistaken for a forward gap and no cooldown is imposed. A fresh run of three
  heads brings the cap back.

**Behaviour change:** after a websocket reconnect the cap no longer returns on its own; the
head must produce a fresh consecutive run first. The test that asserted the old behaviour now
asserts this one.

## Tests

- `eth_health_validator_test.go`: the Nitro payload above yields `Syncing`.
- `upstream_test.go`: probe `Syncing` pauses the head, a repeated verdict is a no-op,
  `Available` and `Immature` both resume; lag-driven `Syncing` does not pause; without the flag
  nothing is paused; the pause bookkeeping resets across a fatal error.
- `head_processor_internal_test.go`: `Start`, a block and `Stop` publish in order on one
  subscription; `UpdateHead` does not block on a full channel with no reader.
- `block_event_processor_test.go`: state events are not forwarded to the state pipeline.
- `ws_head_liveness_detector_internal_test.go`: `suspend` keeps the block time and requires a
  fresh run without a cooldown; the first observation after a suspend does not measure the gap;
  a height jump after a suspend is a baseline, not a forward gap.
- `ws_head_liveness_detector_test.go`: a stopped head retracts the cap, no timeout fires during
  the pause, and after restart the cap returns on a fresh run at a much higher height while a
  real stall is still caught with the original window; the same for a websocket disconnect;
  reconnect alone does not restore the cap.
